### PR TITLE
Add a related projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 - GitHub: [@sirmalloc](https://github.com/sirmalloc)
 
+## 🔗 Related Projects
+
+- [tweakcc](https://github.com/Piebald-AI/tweakcc) - Customize Claude Code themes, thinking verbs, and more.
+
 ## 🙏 Acknowledgments
 
 - Built for use with [Claude Code CLI](https://claude.ai/code) by Anthropic


### PR DESCRIPTION
Hi!  ccstatusline is quite a convenient little tool!  I thought I'd add a link to our own tool, [tweakcc](https://github.com/Piebald-AI/tweakcc), which has a related, although different, purpose.  I've [linked](https://github.com/Piebald-AI/tweakcc?tab=readme-ov-file#related-projects) ccstatusline in tweakcc's README too.

You should also submit ccstatusline to [Awesome Claude Code](https://github.com/hesreallyhim/awesome-claude-code)&mdash;you'll get accepted easily and it will get you more visibility.