### PR TITLE
feat: show 'no git' placeholder when not in a git repository

### DIFF
--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -434,6 +434,9 @@ export function renderStatusLine(
                     if (branch) {
                         const text = item.rawValue ? branch : `⎇ ${branch}`;
                         elements.push({ content: applyColorsWithOverride(text, item.color || 'magenta', item.backgroundColor, item.bold), type: 'git-branch', item });
+                    } else {
+                        const text = item.rawValue ? 'no git' : '⎇ no git';
+                        elements.push({ content: applyColorsWithOverride(text, item.color || 'magenta', item.backgroundColor, item.bold), type: 'git-branch', item });
                     }
                 }
                 break;
@@ -446,6 +449,9 @@ export function renderStatusLine(
                     const changes = context.gitChanges || getGitChanges();
                     if (changes !== null) {
                         const changeStr = `(+${changes.insertions},-${changes.deletions})`;
+                        elements.push({ content: applyColorsWithOverride(changeStr, item.color || 'yellow', item.backgroundColor, item.bold), type: 'git-changes', item });
+                    } else {
+                        const changeStr = '(no git)';
                         elements.push({ content: applyColorsWithOverride(changeStr, item.color || 'yellow', item.backgroundColor, item.bold), type: 'git-changes', item });
                     }
                 }


### PR DESCRIPTION
## Summary

This PR improves the user experience when using ccstatusline in directories that are not git repositories by showing meaningful placeholders instead of empty gaps in the status line.

## Changes

- **git-branch**: Now displays `⎇ no git` when not in a git repository (was: hidden/empty)
- **git-changes**: Now displays `(no git)` when not in a git repository (was: hidden/empty)

## Implementation Details

- Maintains existing color scheme (magenta for branch, yellow for changes)
- Preserves all formatting and rawValue behavior
- Minimal code changes following KISS principles
- Only affects the rendering logic when git functions return null

## Test Plan

✅ Tested in git repository - shows normal git info
✅ Tested in non-git directory - shows "no git" placeholders
✅ Built successfully with `bun run build`

🤖 Generated with [Claude Code](https://claude.ai/code)