### PR TITLE
Add Spotify widget with rotating phrases and emojis

### DIFF
--- a/src/utils/widgets.ts
+++ b/src/utils/widgets.ts
@@ -25,7 +25,8 @@ const widgetRegistry = new Map<WidgetItemType, Widget>([
     ['terminal-width', new widgets.TerminalWidthWidget()],
     ['version', new widgets.VersionWidget()],
     ['custom-text', new widgets.CustomTextWidget()],
-    ['custom-command', new widgets.CustomCommandWidget()]
+    ['custom-command', new widgets.CustomCommandWidget()],
+    ['spotify', new widgets.SpotifyWidget()]
 ]);
 
 export function getWidget(type: WidgetItemType): Widget {

--- a/src/widgets/SpotifyWidget.ts
+++ b/src/widgets/SpotifyWidget.ts
@@ -1,0 +1,84 @@
+import { execSync } from 'child_process';
+import * as os from 'os';
+
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+
+export class SpotifyWidget implements Widget {
+    getDefaultColor(): string { return 'green'; }
+    getDescription(): string { return 'Shows currently playing Spotify track with rotating phrases and emojis (Mac only)'; }
+    getDisplayName(): string { return 'Spotify'; }
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
+        return { displayText: this.getDisplayName() };
+    }
+
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
+        if (context.isPreview) {
+            const phrase = this.getRandomPhrase();
+            const emoji = this.getRandomEmoji();
+            return item.rawValue ? 'Song Name by Artist' : `${phrase}: Song Name by Artist ${emoji}`;
+        }
+
+        // Only works on macOS
+        if (os.platform() !== 'darwin') {
+            return null;
+        }
+
+        const spotifyInfo = this.getSpotifyInfo();
+        if (!spotifyInfo) {
+            return null;
+        }
+
+        if (item.rawValue) {
+            return spotifyInfo;
+        }
+
+        const phrase = this.getRandomPhrase();
+        const emoji = this.getRandomEmoji();
+        return `${phrase}: ${spotifyInfo} ${emoji}`;
+    }
+
+    private getSpotifyInfo(): string | null {
+        try {
+            const script = `tell application "Spotify"
+                if it is running and player state is playing then
+                    get name of current track & " by " & artist of current track
+                end if
+            end tell`;
+
+            const result = execSync(`osascript -e '${script}'`, {
+                encoding: 'utf8',
+                stdio: ['pipe', 'pipe', 'ignore'],
+                timeout: 2000
+            }).trim();
+
+            return result || null;
+        } catch {
+            return null;
+        }
+    }
+
+    private getRandomPhrase(): string {
+        const phrases = ['🎵 now playing', '🎶 grooving to', '🎧 vibing to', '🎤 jamming to', '🔥 bumping'] as const;
+        // Rotate through phrases every 10 seconds
+        const phraseIndex = Math.floor(Date.now() / 1000 / 10) % phrases.length;
+        const phrase = phrases[phraseIndex];
+        return phrase ?? phrases[0];
+    }
+
+    private getRandomEmoji(): string {
+        const emojis = ['🎼', '🎹', '🥁', '🎸', '🎺', '🎷', '🎻', '✨', '💫', '🌟'] as const;
+        // Rotate through emojis every 8 seconds
+        const emojiIndex = Math.floor(Date.now() / 1000 / 8) % emojis.length;
+        const emoji = emojis[emojiIndex];
+        return emoji ?? emojis[0];
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -17,3 +17,4 @@ export { CustomTextWidget } from './CustomText';
 export { CustomCommandWidget } from './CustomCommand';
 export { BlockTimerWidget } from './BlockTimer';
 export { CurrentWorkingDirWidget } from './CurrentWorkingDir';
+export { SpotifyWidget } from './SpotifyWidget';


### PR DESCRIPTION
## Summary
- Add new Spotify widget that displays currently playing track with engaging visual elements
- Mac-only implementation using osascript for reliable Spotify detection  
- Rotating phrases and emojis for dynamic, entertaining display
- Seamless integration with existing ccstatusline widget system

## Features
- **5 rotating phrases**: 🎵 now playing, 🎶 grooving to, 🎧 vibing to, 🎤 jamming to, 🔥 bumping
- **10 rotating emojis**: 🎼🎹🥁🎸🎺🎷🎻✨💫🌟  
- **Time-based rotation**: Phrases (10s intervals), emojis (8s intervals)
- **Display format**: `🎧 vibing to: Song Name by Artist 🎸`
- **Raw value mode**: Shows just `Song Name by Artist`
- **Graceful fallback**: Widget hidden when Spotify not playing
- **Full integration**: Colors, separators, multi-line support

## Technical Implementation
- Follows established widget patterns (similar to GitBranch, SessionClock)
- Platform detection using `os.platform() === 'darwin'`
- Uses `execSync` with osascript for Spotify communication
- Proper error handling and null returns for non-playing states
- TypeScript compliance with existing codebase standards

## Test plan
- [x] Widget registration and integration
- [x] Preview and raw value modes
- [x] Live Spotify track detection  
- [x] Rotating phrases and emojis working
- [x] Color customization
- [x] Multi-line status line support
- [x] Graceful fallback when not playing
- [x] Lint and TypeScript checks passing

🤖 Generated with ccstatusline