### PR TITLE
chore(no-git): Hide separators where the previous widget returns null

### DIFF
--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -655,6 +655,10 @@ export function renderStatusLine(
 
         // Handle separators specially (they're not widgets)
         if (widget.type === 'separator') {
+            if (i > 0 && !preRenderedWidgets[i - 1]?.content) {
+                continue;
+            }
+
             const sepChar = widget.character ?? (settings.defaultSeparator ?? '|');
             const formattedSep = formatSeparator(sepChar);
 


### PR DESCRIPTION
## Changes

- Hide separator when widgets return `null` (where `no git` is hidden)