### PR TITLE
feat(active-cwd): show the active working directory of Claude

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,6 @@
   ],
   "patchedDependencies": {
     "ink@6.2.0": "patches/ink@6.2.0.patch"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/types/RenderContext.ts
+++ b/src/types/RenderContext.ts
@@ -12,4 +12,5 @@ export interface RenderContext {
     isPreview?: boolean;
     lineIndex?: number;  // Index of the current line being rendered (for theme cycling)
     globalSeparatorIndex?: number;  // Global separator index that continues across lines
+    cwd?: string | null; // Current working directory of the last command
 }

--- a/src/types/TokenMetrics.ts
+++ b/src/types/TokenMetrics.ts
@@ -9,6 +9,7 @@ export interface TranscriptLine {
     message?: { usage?: TokenUsage };
     isSidechain?: boolean;
     timestamp?: string;
+    cwd?: string;
 }
 
 export interface TokenMetrics {

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -347,3 +347,34 @@ function floorToHour(timestamp: Date): Date {
     floored.setUTCMinutes(0, 0, 0);
     return floored;
 }
+
+/**
+ * Gets the latest cwd from the transcript
+ */
+export async function getLatestCwd(transcriptPath: string): Promise<string | null> {
+    try {
+        // Use Node.js-compatible file reading
+        if (!fs.existsSync(transcriptPath)) {
+            return null;
+        }
+
+        const content = await readFile(transcriptPath, 'utf-8');
+        const lines = content.trim().split('\n');
+
+        for (const line of lines) {
+            try {
+                const data = JSON.parse(line) as TranscriptLine;
+
+                if (data.cwd) {
+                    return data.cwd;
+                }
+            } catch {
+                // Skip invalid JSON lines
+            }
+        }
+
+        return null;
+    } catch {
+        return null;
+    }
+}

--- a/src/utils/widgets.ts
+++ b/src/utils/widgets.ts
@@ -13,6 +13,7 @@ const widgetRegistry = new Map<WidgetItemType, Widget>([
     ['git-changes', new widgets.GitChangesWidget()],
     ['git-worktree', new widgets.GitWorktreeWidget()],
     ['current-working-dir', new widgets.CurrentWorkingDirWidget()],
+    ['current-active-working-dir', new widgets.CurrentActiveWorkingDirWidget()],
     ['tokens-input', new widgets.TokensInputWidget()],
     ['tokens-output', new widgets.TokensOutputWidget()],
     ['tokens-cached', new widgets.TokensCachedWidget()],

--- a/src/widgets/CurrentActiveWorkingDir.tsx
+++ b/src/widgets/CurrentActiveWorkingDir.tsx
@@ -1,0 +1,76 @@
+import * as path from 'path';
+
+import type { RenderContext } from '../types/RenderContext';
+import type {
+    CustomKeybind,
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+
+export class CurrentActiveWorkingDirWidget implements Widget {
+    getDefaultColor(): string { return 'magenta'; }
+    getDescription(): string { return 'Shows the current active working directory'; }
+    getDisplayName(): string { return 'Current Active Working Dir'; }
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
+        const showAbsolute = item.metadata?.showAbsolute === 'true';
+        const modifiers: string[] = [];
+
+        if (showAbsolute) {
+            modifiers.push('absolute');
+        } else {
+            modifiers.push('relative');
+        }
+
+        return {
+            displayText: this.getDisplayName(),
+            modifierText: modifiers.length > 0 ? `(${modifiers.join(', ')})` : undefined
+        };
+    }
+
+    handleEditorAction(action: string, item: WidgetItem): WidgetItem | null {
+        if (action === 'toggle-absolute') {
+            const currentState = item.metadata?.showAbsolute === 'true';
+
+            return {
+                ...item,
+                metadata: {
+                    ...item.metadata,
+                    showAbsolute: (!currentState).toString()
+                }
+            };
+        }
+        return null;
+    }
+
+    render(item: WidgetItem, context: RenderContext): string | null {
+        const showAbsolute = item.metadata?.showAbsolute === 'true';
+
+        if (context.isPreview) {
+            const value = showAbsolute ? '/Users/example/project/folder' : './folder';
+            return item.rawValue ? value : `dir: ${value}`;
+        }
+
+        // return "TODO";
+
+        const cwd = context.data?.cwd;
+        const activeWorkingDir = context.cwd ?? cwd;
+
+        if (activeWorkingDir)  {
+            const value = showAbsolute || !cwd ? activeWorkingDir : path.relative(cwd, activeWorkingDir);
+
+            return item.rawValue ? value : `dir: ${value}`;
+        }
+
+        return null;
+    }
+
+    getCustomKeybinds(): CustomKeybind[] {
+        return [
+            { key: 't', label: '(t)oggle absolute path', action: 'toggle-absolute' }
+        ];
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -18,3 +18,4 @@ export { CustomTextWidget } from './CustomText';
 export { CustomCommandWidget } from './CustomCommand';
 export { BlockTimerWidget } from './BlockTimer';
 export { CurrentWorkingDirWidget } from './CurrentWorkingDir';
+export { CurrentActiveWorkingDirWidget } from './CurrentActiveWorkingDir';


### PR DESCRIPTION
## Changes

- Add `CurrentActiveWorkingDir` widget, which displays the latest directory that Claude is in
    - Useful if Claude has moved around a lot and gets confused about where it is