### PR TITLE
fix: improve separator rendering logic to look backwards for content

### DIFF
--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -705,7 +705,20 @@ export function renderStatusLine(
 
         // Handle separators specially (they're not widgets)
         if (widget.type === 'separator') {
-            if (i > 0 && !preRenderedWidgets[i - 1]?.content)
+            // Check if there's any widget before this separator that actually rendered content
+            // Look backwards to find ANY widget that produced content
+            let hasContentBefore = false;
+            for (let j = i - 1; j >= 0; j--) {
+                const prevWidget = widgets[j];
+                if (prevWidget && prevWidget.type !== 'separator' && prevWidget.type !== 'flex-separator') {
+                    if (preRenderedWidgets[j]?.content) {
+                        hasContentBefore = true;
+                        break;
+                    }
+                    // Continue looking backwards even if this widget didn't render content
+                }
+            }
+            if (!hasContentBefore)
                 continue;
 
             const sepChar = widget.character ?? (settings.defaultSeparator ?? '|');


### PR DESCRIPTION
- Enhanced separator rendering to check all previous widgets for actual content
- Prevents separators from being skipped when there are widgets that don't render but others before them do
- Improves status line layout consistency by properly detecting content presence

before:
<img width="610" height="253" alt="image" src="https://github.com/user-attachments/assets/283dd1ef-b92a-48a9-80fb-71fb8a4839bf" />

after:
<img width="585" height="122" alt="image" src="https://github.com/user-attachments/assets/08fd1e2f-1cca-4420-b5db-9d32b3818a80" />
