### PR TITLE
Fix bunx availability check on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "start": "bun run src/ccstatusline.ts",
-    "build": "rm -rf dist/* && bun build src/ccstatusline.ts --target=node --outfile=dist/ccstatusline.js --target-version=14",
+    "build": "rm -rf dist/* ; bun build src/ccstatusline.ts --target=node --outfile=dist/ccstatusline.js --target-version=14",
     "postbuild": "bun run scripts/replace-version.ts",
     "example": "cat scripts/payload.example.json | bun start",
     "prepublishOnly": "bun run build",

--- a/src/utils/claude-settings.ts
+++ b/src/utils/claude-settings.ts
@@ -43,7 +43,9 @@ export async function isInstalled(): Promise<boolean> {
 
 export function isBunxAvailable(): boolean {
     try {
-        execSync('which bunx', { stdio: 'ignore' });
+        // Use platform-appropriate command to check for bunx availability
+        const command = process.platform === 'win32' ? 'where bunx' : 'which bunx';
+        execSync(command, { stdio: 'ignore' });
         return true;
     } catch {
         return false;


### PR DESCRIPTION
### **Describe the Bug**  
CCStatusline (v2.0.19) incorrectly reports `bunx - Bun Package Execute (not installed)` **even when Bun is installed and functional** (as confirmed by running `bunx` in PowerShell). This prevents users from selecting `bunx` as the package manager during configuration.  

<img width="1901" height="524" alt="Image" src="https://github.com/user-attachments/assets/c0676ccb-49fd-4c97-9116-16177517fbc2" />

### **Steps to Reproduce**  
1. **Verify Bun is installed and working**:  
   - Open PowerShell (7.5.3)  
   - Run: `bun --version` → Returns valid version (e.g., `1.2.23`)  
   - Run: `bunx ccstatusline` → **Executes successfully** (screenshot confirms this works)  
2. Open CCStatusline Configuration (v2.0.19)  
3. Navigate to `Install ccstatusline to Claude Code`  
4. **Observe**:  
   - `bunx` option shows `(not installed)`  
   - Cannot select `bunx` despite it being usable in the same terminal  

### **Expected Behavior**  
- If `bunx` executes successfully in the current shell (as shown in screenshot), CCStatusline **should detect Bun as installed** and allow selecting `bunx`.  

### **Actual Behavior**  
- CCStatusline **falsely reports Bun as not installed** (`bunx - Bun Package Execute (not installed)`), blocking usage of `bunx` even though:  
  - Bun is installed  
  - `bunx` commands run successfully in the same PowerShell session  

### **Environment**  
- CCStatusline: `v2.0.19`  
- Shell: `PowerShell 7.5.3` (Windows)  
- Bun: Installed (version: **1.2.23**), confirmed working via `bunx ccstatusline`  
- OS: Windows 11 