### PR TITLE
Fix context widgets showing 0% due to synthetic API error messages

### DIFF
--- a/src/types/TokenMetrics.ts
+++ b/src/types/TokenMetrics.ts
@@ -9,6 +9,7 @@ export interface TranscriptLine {
     message?: { usage?: TokenUsage };
     isSidechain?: boolean;
     timestamp?: string;
+    isApiErrorMessage?: boolean;
 }
 
 export interface TokenMetrics {

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -114,7 +114,8 @@ export async function getTokenMetrics(transcriptPath: string): Promise<TokenMetr
                     cachedTokens += data.message.usage.cache_creation_input_tokens ?? 0;
 
                     // Track the most recent entry with isSidechain: false (or undefined, which defaults to main chain)
-                    if (data.isSidechain !== true && data.timestamp) {
+                    // Also skip API error messages (synthetic messages with 0 tokens)
+                    if (data.isSidechain !== true && data.timestamp && !data.isApiErrorMessage) {
                         const entryTime = new Date(data.timestamp);
                         if (!mostRecentTimestamp || entryTime > mostRecentTimestamp) {
                             mostRecentTimestamp = entryTime;


### PR DESCRIPTION
Fix #97 

Investigation revealed that Claude Code now appends synthetic error messages to transcript files when API errors occur (rate limits, authentication failures, etc.). These synthetic messages have:
- model: "<synthetic>"
- isApiErrorMessage: true
- All token usage fields set to 0

The getTokenMetrics() function in src/utils/jsonl.ts calculates the current context length by finding the most recent main chain entry(isSidechain !== true) sorted by timestamp. When an API error occurs, the synthetic error message becomes the "most recent entry", causing contextLength to be calculated as 0.