### PR TITLE
FEAT: Support CLAUDE_CONFIG_DIR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,10 @@ The project has dual runtime compatibility - works with both Bun and Node.js:
   - Manages flex separator expansion
 - **powerline.ts**: Powerline font detection and installation
 - **claude-settings.ts**: Integration with Claude Code settings.json
+  - Respects `CLAUDE_CONFIG_DIR` environment variable with fallback to `~/.claude`
+  - Provides installation command constants (NPM, BUNX, self-managed)
+  - Detects installation status and manages settings.json updates
+  - Validates config directory paths with proper error handling
 - **colors.ts**: Color definitions and ANSI code mapping
 
 ### Widgets (src/widgets/)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@
 - **🖥️ Interactive TUI** - Built-in configuration interface using React/Ink
 - **⚙️ Global Options** - Apply consistent formatting across all widgets (padding, separators, bold, background)
 - **🚀 Cross-platform** - Works seamlessly with both Bun and Node.js
+- **🔧 Flexible Configuration** - Supports custom Claude Code config directory via `CLAUDE_CONFIG_DIR` environment variable
 - **📏 Smart Width Detection** - Automatically adapts to terminal width with flex separators
 - **⚡ Zero Config** - Sensible defaults that work out of the box
 
@@ -154,6 +155,15 @@ The interactive configuration tool provides a terminal UI where you can:
 - Preview your status line in real-time
 
 > 💡 **Tip:** Your settings are automatically saved to `~/.config/ccstatusline/settings.json`
+
+> 🔧 **Custom Claude Config:** If your Claude Code configuration is in a non-standard location, set the `CLAUDE_CONFIG_DIR` environment variable:
+> ```bash
+> # Linux/macOS
+> export CLAUDE_CONFIG_DIR=/custom/path/to/.claude
+> 
+> # Windows PowerShell
+> $env:CLAUDE_CONFIG_DIR="C:\custom\path\.claude"
+> ```
 
 ---
 
@@ -294,7 +304,11 @@ For the best experience, configure Windows Terminal with these recommended setti
 #### Claude Code Integration
 Configure ccstatusline in your Claude Code settings:
 
-**For Bun users** (Windows: `%USERPROFILE%\.claude\settings.json`):
+**Settings Location:**
+- Default: `~/.claude/settings.json` (Windows: `%USERPROFILE%\.claude\settings.json`)
+- Custom: Set `CLAUDE_CONFIG_DIR` environment variable to use a different directory
+
+**For Bun users**:
 ```json
 {
   "statusLine": "bunx ccstatusline@latest"
@@ -307,6 +321,8 @@ Configure ccstatusline in your Claude Code settings:
   "statusLine": "npx ccstatusline@latest"
 }
 ```
+
+> 💡 **Custom Config Directory:** If you use a non-standard Claude Code configuration directory, set the `CLAUDE_CONFIG_DIR` environment variable before running ccstatusline. The tool will automatically detect and use your custom location.
 
 ### Performance on Windows
 
@@ -561,7 +577,7 @@ ccstatusline/
 │   │   ├── renderer.ts         # Core rendering logic
 │   │   ├── powerline.ts        # Powerline font utilities
 │   │   ├── colors.ts           # Color definitions
-│   │   └── claude-settings.ts  # Claude Code integration
+│   │   └── claude-settings.ts  # Claude Code integration (supports CLAUDE_CONFIG_DIR)
 │   └── types/                  # TypeScript type definitions
 │       ├── Settings.ts
 │       ├── Widget.ts

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -15,6 +15,8 @@ import React, {
 import type { Settings } from '../types/Settings';
 import type { WidgetItem } from '../types/Widget';
 import {
+    CCSTATUSLINE_COMMANDS,
+    getClaudeSettingsPath,
     getExistingStatusLine,
     installStatusLine,
     isBunxAvailable,
@@ -137,7 +139,7 @@ export const App: React.FC = () => {
         if (isClaudeInstalled) {
             // Uninstall
             setConfirmDialog({
-                message: 'This will remove ccstatusline from ~/.claude/settings.json. Continue?',
+                message: `This will remove ccstatusline from ${getClaudeSettingsPath()}. Continue?`,
                 action: async () => {
                     await uninstallStatusLine();
                     setIsClaudeInstalled(false);
@@ -378,15 +380,15 @@ export const App: React.FC = () => {
                         existingStatusLine={existingStatusLine}
                         onSelectNpx={() => {
                             void getExistingStatusLine().then((existing) => {
-                                const isAlreadyInstalled = ['npx -y ccstatusline@latest', 'bunx -y ccstatusline@latest'].includes(existing ?? '');
+                                const isAlreadyInstalled = [CCSTATUSLINE_COMMANDS.NPM, CCSTATUSLINE_COMMANDS.BUNX, CCSTATUSLINE_COMMANDS.SELF_MANAGED].includes(existing ?? '');
                                 let message: string;
 
                                 if (existing && !isAlreadyInstalled) {
-                                    message = `This will modify ~/.claude/settings.json\n\nA status line is already configured: "${existing}"\nReplace it with npx -y ccstatusline@latest?`;
+                                    message = `This will modify ${getClaudeSettingsPath()}\n\nA status line is already configured: "${existing}"\nReplace it with ${CCSTATUSLINE_COMMANDS.NPM}?`;
                                 } else if (isAlreadyInstalled) {
-                                    message = 'ccstatusline is already installed in ~/.claude/settings.json\nUpdate it with npx -y ccstatusline@latest?';
+                                    message = `ccstatusline is already installed in ${getClaudeSettingsPath()}\nUpdate it with ${CCSTATUSLINE_COMMANDS.NPM}?`;
                                 } else {
-                                    message = 'This will modify ~/.claude/settings.json to add ccstatusline with npx.\nContinue?';
+                                    message = `This will modify ${getClaudeSettingsPath()} to add ccstatusline with npx.\nContinue?`;
                                 }
 
                                 setConfirmDialog({
@@ -394,7 +396,7 @@ export const App: React.FC = () => {
                                     action: async () => {
                                         await installStatusLine(false);
                                         setIsClaudeInstalled(true);
-                                        setExistingStatusLine('npx -y ccstatusline@latest');
+                                        setExistingStatusLine(CCSTATUSLINE_COMMANDS.NPM);
                                         setScreen('main');
                                         setConfirmDialog(null);
                                     }
@@ -404,15 +406,15 @@ export const App: React.FC = () => {
                         }}
                         onSelectBunx={() => {
                             void getExistingStatusLine().then((existing) => {
-                                const isAlreadyInstalled = ['npx -y ccstatusline@latest', 'bunx -y ccstatusline@latest'].includes(existing ?? '');
+                                const isAlreadyInstalled = [CCSTATUSLINE_COMMANDS.NPM, CCSTATUSLINE_COMMANDS.BUNX, CCSTATUSLINE_COMMANDS.SELF_MANAGED].includes(existing ?? '');
                                 let message: string;
 
                                 if (existing && !isAlreadyInstalled) {
-                                    message = `This will modify ~/.claude/settings.json\n\nA status line is already configured: "${existing}"\nReplace it with bunx -y ccstatusline@latest?`;
+                                    message = `This will modify ${getClaudeSettingsPath()}\n\nA status line is already configured: "${existing}"\nReplace it with ${CCSTATUSLINE_COMMANDS.BUNX}?`;
                                 } else if (isAlreadyInstalled) {
-                                    message = 'ccstatusline is already installed in ~/.claude/settings.json\nUpdate it with bunx -y ccstatusline@latest?';
+                                    message = `ccstatusline is already installed in ${getClaudeSettingsPath()}\nUpdate it with ${CCSTATUSLINE_COMMANDS.BUNX}?`;
                                 } else {
-                                    message = 'This will modify ~/.claude/settings.json to add ccstatusline with bunx.\nContinue?';
+                                    message = `This will modify ${getClaudeSettingsPath()} to add ccstatusline with bunx.\nContinue?`;
                                 }
 
                                 setConfirmDialog({
@@ -420,7 +422,7 @@ export const App: React.FC = () => {
                                     action: async () => {
                                         await installStatusLine(true);
                                         setIsClaudeInstalled(true);
-                                        setExistingStatusLine('bunx -y ccstatusline@latest');
+                                        setExistingStatusLine(CCSTATUSLINE_COMMANDS.BUNX);
                                         setScreen('main');
                                         setConfirmDialog(null);
                                     }

--- a/src/tui/components/InstallMenu.tsx
+++ b/src/tui/components/InstallMenu.tsx
@@ -5,6 +5,8 @@ import {
 } from 'ink';
 import React, { useState } from 'react';
 
+import { getClaudeSettingsPath } from '../../utils/claude-settings';
+
 export interface InstallMenuProps {
     bunxAvailable: boolean;
     existingStatusLine: string | null;
@@ -95,7 +97,9 @@ export const InstallMenu: React.FC<InstallMenuProps> = ({
 
             <Box marginTop={2}>
                 <Text dimColor>
-                    The selected command will be written to ~/.claude/settings.json
+                    The selected command will be written to
+                    {' '}
+                    {getClaudeSettingsPath()}
                 </Text>
             </Box>
 

--- a/src/tui/components/LineSelector.tsx
+++ b/src/tui/components/LineSelector.tsx
@@ -73,10 +73,10 @@ const LineSelector: React.FC<LineSelectorProps> = ({
     const powerlineEnabled = settings ? settings.powerline.enabled : false;
     const powerlineTheme = settings ? settings.powerline.theme : undefined;
     const isThemeManaged
-    = blockIfPowerlineActive
-        && powerlineEnabled
-        && powerlineTheme
-        && powerlineTheme !== 'custom';
+        = blockIfPowerlineActive
+            && powerlineEnabled
+            && powerlineTheme
+            && powerlineTheme !== 'custom';
 
     // Handle keyboard input
     useInput((input, key) => {
@@ -153,9 +153,9 @@ const LineSelector: React.FC<LineSelectorProps> = ({
 
     if (showDeleteDialog && selectedLine) {
         const suffix
-      = selectedLine.length > 0
-          ? pluralize('widget', selectedLine.length, true)
-          : 'empty';
+            = selectedLine.length > 0
+                ? pluralize('widget', selectedLine.length, true)
+                : 'empty';
 
         return (
             <Box flexDirection='column'>

--- a/src/utils/claude-settings.ts
+++ b/src/utils/claude-settings.ts
@@ -13,32 +13,89 @@ const readFile = fs.promises.readFile;
 const writeFile = fs.promises.writeFile;
 const mkdir = fs.promises.mkdir;
 
-const CLAUDE_SETTINGS_PATH = path.join(os.homedir(), '.claude', 'settings.json');
+export const CCSTATUSLINE_COMMANDS = {
+    NPM: 'npx -y ccstatusline@latest',
+    BUNX: 'bunx -y ccstatusline@latest',
+    SELF_MANAGED: 'ccstatusline'
+};
+
+/**
+ * Determines the Claude config directory, checking CLAUDE_CONFIG_DIR environment variable first,
+ * then falling back to the default ~/.claude directory.
+ */
+export function getClaudeConfigDir(): string {
+    const envConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+    if (envConfigDir) {
+        try {
+            // Validate that the path is absolute and reasonable
+            const resolvedPath = path.resolve(envConfigDir);
+
+            // Check if directory exists or can be created
+            if (fs.existsSync(resolvedPath)) {
+                const stats = fs.statSync(resolvedPath);
+                if (stats.isDirectory()) {
+                    return resolvedPath;
+                }
+            } else {
+                // Directory doesn't exist yet, but we can try to use it
+                // (mkdir will be called later when saving)
+                return resolvedPath;
+            }
+        } catch {
+            // Fall through to default on any error
+        }
+    }
+
+    // Default fallback
+    return path.join(os.homedir(), '.claude');
+}
+
+/**
+ * Gets the full path to the Claude settings.json file.
+ */
+export function getClaudeSettingsPath(): string {
+    return path.join(getClaudeConfigDir(), 'settings.json');
+}
 
 export async function loadClaudeSettings(): Promise<ClaudeSettings> {
     try {
-        if (!fs.existsSync(CLAUDE_SETTINGS_PATH)) {
+        const settingsPath = getClaudeSettingsPath();
+        if (!fs.existsSync(settingsPath)) {
             return {};
         }
-        const content = await readFile(CLAUDE_SETTINGS_PATH, 'utf-8');
+        const content = await readFile(settingsPath, 'utf-8');
         return JSON.parse(content) as ClaudeSettings;
     } catch {
         return {};
     }
 }
 
-export async function saveClaudeSettings(settings: ClaudeSettings): Promise<void> {
-    const dir = path.dirname(CLAUDE_SETTINGS_PATH);
+export async function saveClaudeSettings(
+    settings: ClaudeSettings
+): Promise<void> {
+    const settingsPath = getClaudeSettingsPath();
+    const dir = path.dirname(settingsPath);
     await mkdir(dir, { recursive: true });
-    await writeFile(CLAUDE_SETTINGS_PATH, JSON.stringify(settings, null, 2), 'utf-8');
+    await writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
 }
 
 export async function isInstalled(): Promise<boolean> {
     const settings = await loadClaudeSettings();
     // Check if command is either npx or bunx version AND padding is 0 (or undefined for new installs)
-    const validCommands = ['npx -y ccstatusline@latest', 'bunx -y ccstatusline@latest'];
-    return validCommands.includes(settings.statusLine?.command ?? '')
-        && (settings.statusLine?.padding === 0 || settings.statusLine?.padding === undefined);
+    const validCommands = [
+        // Default autoinstalled npm command
+        CCSTATUSLINE_COMMANDS.NPM,
+        // Default autoinstalled bunx command
+        CCSTATUSLINE_COMMANDS.BUNX,
+        // Self managed installation command
+        CCSTATUSLINE_COMMANDS.SELF_MANAGED
+    ];
+    return (
+        validCommands.includes(settings.statusLine?.command ?? '')
+        && (settings.statusLine?.padding === 0
+            || settings.statusLine?.padding === undefined)
+    );
 }
 
 export function isBunxAvailable(): boolean {
@@ -58,7 +115,9 @@ export async function installStatusLine(useBunx = false): Promise<void> {
     // Update settings with our status line (confirmation already handled in TUI)
     settings.statusLine = {
         type: 'command',
-        command: useBunx ? 'bunx -y ccstatusline@latest' : 'npx -y ccstatusline@latest',
+        command: useBunx
+            ? CCSTATUSLINE_COMMANDS.BUNX
+            : CCSTATUSLINE_COMMANDS.NPM,
         padding: 0
     };
 


### PR DESCRIPTION
This pull request adds support for customizing the location of the Claude Code configuration directory using the `CLAUDE_CONFIG_DIR` environment variable. It updates both documentation and code to respect this variable, improves error handling in config path management, and refactors related UI components to reflect the new flexibility. These changes make it easier for users to specify non-standard locations for their configuration and ensure consistent handling throughout the app.

### Flexible Configuration Directory Support

* Added logic to detect and validate a custom Claude config directory via the `CLAUDE_CONFIG_DIR` environment variable, with fallback to the default `~/.claude` location. This includes error handling and path validation in `getClaudeConfigDir` and `getClaudeSettingsPath` functions (`src/utils/claude-settings.ts`).
* Updated all config read/write operations to use the dynamically determined config path, ensuring settings are saved and loaded from the correct location. 

### User Interface Improvements

* Refactored the interactive TUI install/uninstall flows to display the actual config path being modified, and to use new install command constants for clarity and maintainability (`src/tui/App.tsx`, `src/tui/components/InstallMenu.tsx`).
* Centralized install command definitions (`CCSTATUSLINE_COMMANDS`) for easier updates and future extensibility. 

### Documentation Updates

* Updated `README.md` and `CLAUDE.md` to document support for `CLAUDE_CONFIG_DIR`, including usage examples and clearer instructions for custom config locations. 

Closes https://github.com/sirmalloc/ccstatusline/issues/37