### PR TITLE
fixes/block-timer: Reuse `claude` directory calculation logic for block-timer widget 

### DIFF
--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -59,6 +59,7 @@ async function renderMultipleLines(data: StatusJSON) {
 
     // Set global chalk level based on settings
     chalk.level = settings.colorLevel;
+
     // Update color map after setting chalk level
     updateColorMap();
 
@@ -75,16 +76,19 @@ async function renderMultipleLines(data: StatusJSON) {
     const hasBlockTimer = lines.some(line => line.some(item => item.type === 'block-timer'));
 
     let tokenMetrics: TokenMetrics | null = null;
-    if (hasTokenItems && data.transcript_path)
+    if (hasTokenItems && data.transcript_path) {
         tokenMetrics = await getTokenMetrics(data.transcript_path);
+    }
 
     let sessionDuration: string | null = null;
-    if (hasSessionClock && data.transcript_path)
+    if (hasSessionClock && data.transcript_path) {
         sessionDuration = await getSessionDuration(data.transcript_path);
+    }
 
     let blockMetrics: BlockMetrics | null = null;
-    if (hasBlockTimer && data.transcript_path)
-        blockMetrics = getBlockMetrics(data.transcript_path);
+    if (hasBlockTimer) {
+        blockMetrics = getBlockMetrics();
+    }
 
     // Create render context
     const context: RenderContext = {


### PR DESCRIPTION
> [!IMPORTANT]
> Problem trying to be solved: on non "standard" claude code installations, like those leveraging the `CLAUDE_CONFIG_DIR` env var, the logic for the calculation of block metrics would wrongly assume:
> - On windows: that the projects jsonl files where located in a subdirectory of `~/.claude`
> - On other platforms: that the projects jsonl files where located in a subdirectory of a folder called `.claude` which is an ancestor of the transcript path value
> 
> This PR leverages the existing and simpler logic to determine the "claude config dir" and fetches block metrics from within it

This pull request refactors how the `.claude` configuration directory is located and used to retrieve block metrics, improving code clarity and platform consistency. The main changes include centralizing the logic for finding the `.claude` directory, updating the usage of `getBlockMetrics`, and making minor code style improvements.

**Block Metrics Handling:**
* Refactored `getBlockMetrics` in `src/utils/jsonl.ts` to remove platform-specific logic and instead use the new centralized `getClaudeConfigDir` function for locating the `.claude` directory. This simplifies the function and ensures consistent behavior across platforms.
* Updated the call to `getBlockMetrics` in `src/ccstatusline.ts` to no longer require a `transcriptPath` argument, reflecting the new function signature and logic.

**Configuration Directory Logic:**
* Imported the new `getClaudeConfigDir` helper in `src/utils/jsonl.ts` to handle locating the `.claude` configuration directory.

**Code Style and Readability:**
* Added braces to single-line `if` statements in `src/ccstatusline.ts` for improved readability and consistency.
* Ensured that the color map is updated immediately after setting the chalk color level in `src/ccstatusline.ts`.