### PR TITLE
feat: add abbreviate home option to Current Working Directory widget

### DIFF
--- a/src/widgets/CurrentWorkingDir.tsx
+++ b/src/widgets/CurrentWorkingDir.tsx
@@ -114,7 +114,7 @@ export class CurrentWorkingDirWidget implements Widget {
                 previewPath = '~/D/P/my-project';
             } else if (abbreviateHome && segments && segments > 0) {
                 if (segments === 1) {
-                    previewPath = '.../my-project';
+                    previewPath = '~/.../my-project';
                 } else {
                     previewPath = '~/.../Projects/my-project';
                 }
@@ -161,7 +161,7 @@ export class CurrentWorkingDirWidget implements Widget {
                     // Take the last N segments and join with the detected separator
                     const selectedSegments = filteredParts.slice(-segments);
                     // Preserve ~ prefix when combined with segments
-                    const prefix = displayPath.startsWith('~') ? '~/' : '';
+                    const prefix = displayPath.startsWith('~') ? `~${outSep}` : '';
                     displayPath = prefix + '...' + outSep + selectedSegments.join(outSep);
                 }
             }
@@ -187,7 +187,15 @@ export class CurrentWorkingDirWidget implements Widget {
 
     private abbreviateHomeDir(path: string): string {
         const homeDir = os.homedir();
+        if (path === homeDir) {
+            return '~';
+        }
+
         if (path.startsWith(homeDir)) {
+            const boundaryChar = path[homeDir.length];
+            if (boundaryChar !== '/' && boundaryChar !== '\\') {
+                return path;
+            }
             return '~' + path.slice(homeDir.length);
         }
         return path;


### PR DESCRIPTION
Closes #125

## Summary
- Add a new 'abbreviate home' toggle (h key) to the Current Working Directory widget
- Replaces the home directory path with `~` (e.g., `/Users/matt/Projects` → `~/Projects`)
- Can be combined with segments for paths like `~/.../Projects/my-project`
- Mutually exclusive with fish-style abbreviation
- Includes tests for the new functionality

## Test plan
- [x] Run `bun test` to verify all tests pass
- [x] Launch TUI with `bun run start` and add Current Working Directory widget
- [x] Toggle abbreviate home with 'h' key and verify preview shows `~` prefix
- [x] Verify abbreviate home is disabled when fish-style is enabled
- [x] Test combination of abbreviate home + segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)