### PR TITLE
feat: add SessionName widget

### DIFF
--- a/src/utils/widgets.ts
+++ b/src/utils/widgets.ts
@@ -22,6 +22,7 @@ const widgetRegistry = new Map<WidgetItemType, Widget>([
     ['context-percentage-usable', new widgets.ContextPercentageUsableWidget()],
     ['session-clock', new widgets.SessionClockWidget()],
     ['session-cost', new widgets.SessionCostWidget()],
+    ['session-name', new widgets.SessionNameWidget()],
     ['block-timer', new widgets.BlockTimerWidget()],
     ['terminal-width', new widgets.TerminalWidthWidget()],
     ['version', new widgets.VersionWidget()],

--- a/src/widgets/SessionName.ts
+++ b/src/widgets/SessionName.ts
@@ -1,0 +1,80 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+
+interface SessionIndexEntry {
+    sessionId: string;
+    customTitle?: string;
+    summary?: string;
+    firstPrompt?: string;
+}
+
+interface SessionsIndex {
+    version: number;
+    entries: SessionIndexEntry[];
+    originalPath: string;
+}
+
+/**
+ * Reads the sessions-index.json file from the same directory as the transcript file
+ * and finds the customTitle for the given session ID.
+ */
+function getSessionName(transcriptPath: string | undefined, sessionId: string | undefined): string | null {
+    if (!transcriptPath || !sessionId) {
+        return null;
+    }
+
+    try {
+        const transcriptDir = path.dirname(transcriptPath);
+        const indexPath = path.join(transcriptDir, 'sessions-index.json');
+
+        if (!fs.existsSync(indexPath)) {
+            return null;
+        }
+
+        const content = fs.readFileSync(indexPath, 'utf-8');
+        const index = JSON.parse(content) as SessionsIndex;
+
+        const entry = index.entries.find(e => e.sessionId === sessionId);
+        if (entry?.customTitle) {
+            return entry.customTitle;
+        }
+
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+export class SessionNameWidget implements Widget {
+    getDefaultColor(): string { return 'magenta'; }
+    getDescription(): string { return 'Shows the custom session name (set via /name command in Claude Code)'; }
+    getDisplayName(): string { return 'Session Name'; }
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
+        return { displayText: this.getDisplayName() };
+    }
+
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
+        if (context.isPreview) {
+            return item.rawValue ? 'my-session' : 'Session: my-session';
+        }
+
+        const sessionName = getSessionName(context.data?.transcript_path, context.data?.session_id);
+
+        if (!sessionName) {
+            return null;
+        }
+
+        return item.rawValue ? sessionName : `Session: ${sessionName}`;
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -19,3 +19,4 @@ export { CustomCommandWidget } from './CustomCommand';
 export { BlockTimerWidget } from './BlockTimer';
 export { CurrentWorkingDirWidget } from './CurrentWorkingDir';
 export { ClaudeSessionIdWidget } from './ClaudeSessionId';
+export { SessionNameWidget } from './SessionName';


### PR DESCRIPTION
## Summary

Add a new **SessionName** widget that displays the custom session name set via the `/rename` command in Claude Code.

## Implementation Details

- The widget reads the `sessions-index.json` file from the same directory as the transcript file
- It looks up the `customTitle` field by matching the `session_id`
- Supports raw value mode: displays just the session name or `Session: <name>`
- Returns `null` if no custom title is set (widget won't render)

## Changes

- **New file**: `src/widgets/SessionName.ts` - Widget implementation
- **Modified**: `src/widgets/index.ts` - Export the new widget
- **Modified**: `src/utils/widgets.ts` - Register `session-name` in the widget registry

## Testing

- [x] Lint passes (`bun run lint`)
- [x] TypeScript compiles without errors