### PR TITLE
feat: use context_window data from Claude Code input for context widgets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,11 @@ bun install
 # Run in interactive TUI mode
 bun run start
 
-# Test with piped input (use [1m] suffix for 1M context models)
-echo '{"model":{"id":"claude-sonnet-4-5-20250929[1m]"},"transcript_path":"test.jsonl"}' | bun run src/ccstatusline.ts
-
-# Or use example payload
+# Test with example payload
 bun run example
+
+# Test with session start payload
+bun run example:start
 
 # Build for npm distribution
 bun run build   # Creates dist/ccstatusline.js with Node.js 14+ compatibility
@@ -73,6 +73,13 @@ The project has dual runtime compatibility - works with both Bun and Node.js:
   - Sonnet 4.5 WITH [1m] suffix: 1M tokens (800k usable at 80%) - requires long context beta access
   - Sonnet 4.5 WITHOUT [1m] suffix: 200k tokens (160k usable at 80%)
   - Legacy models: 200k tokens (160k usable at 80%)
+- **input-parsers.ts**: Parses token metrics from status JSON input
+  - `extractTokenMetricsFromContextWindow()`: Extracts token metrics from the `context_window` object
+  - `formatDurationMs()`: Formats duration in milliseconds to human-readable string
+- **jsonl.ts**: JSONL transcript parsing for token metrics (fallback)
+  - `getTokenMetrics()`: Gets token metrics from JSONL transcript files
+  - `getSessionDuration()`: Gets session duration from JSONL transcript files
+  - `getBlockMetrics()`: Gets 5-hour block metrics from JSONL files
 
 ### Widgets (src/widgets/)
 Custom widgets implementing the Widget interface defined in src/types/Widget.ts:
@@ -107,7 +114,7 @@ All widgets must implement:
 ## Key Implementation Details
 
 - **Cross-platform stdin reading**: Detects Bun vs Node.js environment and uses appropriate stdin API
-- **Token metrics**: Parses Claude Code transcript files (JSONL format) to calculate token usage
+- **Token metrics**: Extracted from `context_window` object in the status JSON input, with JSONL transcript parsing as fallback
 - **Git integration**: Uses child_process.execSync to get current branch and changes
 - **Terminal width management**: Three modes for handling width (full, full-minus-40, full-until-compact)
 - **Flex separators**: Special separator type that expands to fill available space
@@ -138,10 +145,11 @@ Default to using Bun instead of Node.js:
 - **Dependencies**: All runtime dependencies are bundled using `--packages=external` for npm package
 - **Type checking and linting**: Only run via `bun run lint` command, never using `npx eslint` or `eslint` directly. Never run `tsx`, `bun tsc` or any other variation
 - **Lint rules**: Never disable a lint rule via a comment, no matter how benign the lint warning or error may seem
-- **Testing**: Uses Vitest (via Bun) with 6 test files and ~40 test cases covering:
-  - Model context detection and token calculation (src/utils/__tests__/model-context.test.ts)
+- **Testing**: Uses Vitest (via Bun) with test files covering:
+  - Model context detection (src/utils/__tests__/model-context.test.ts)
+  - Input parsing and token metrics extraction (src/utils/__tests__/input-parsers.test.ts)
   - Context percentage calculations (src/utils/__tests__/context-percentage.test.ts)
-  - JSONL transcript parsing (src/utils/__tests__/jsonl.test.ts)
+  - JSONL block metrics parsing (src/utils/__tests__/jsonl.test.ts)
   - Widget rendering (src/widgets/__tests__/*.test.ts)
   - Run tests with `bun test` or `bun test --watch` for watch mode
   - Test configuration: vitest.config.ts

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "rm -rf dist/* ; bun build src/ccstatusline.ts --target=node --outfile=dist/ccstatusline.js --target-version=14",
     "postbuild": "bun run scripts/replace-version.ts",
     "example": "cat scripts/payload.example.json | bun start",
+    "example:start": "cat scripts/payload.example-start.json | bun start",
     "prepublishOnly": "bun run build",
     "lint": "bun tsc --noEmit; eslint . --config eslint.config.js --max-warnings=999999 --fix",
     "test": "bun vitest",

--- a/scripts/payload.example-start.json
+++ b/scripts/payload.example-start.json
@@ -1,0 +1,28 @@
+{
+  "session_id": "abc123...",
+  "transcript_path": "/path/to/transcript.jsonl",
+  "cwd": "/current/working/directory",
+  "model": { "id": "claude-opus-4-5-20251101", "display_name": "Opus 4.5" },
+  "workspace": {
+    "current_dir": "/current/working/directory",
+    "project_dir": "/current/working/directory"
+  },
+  "version": "2.1.19",
+  "output_style": { "name": "default" },
+  "cost": {
+    "total_cost_usd": 0,
+    "total_duration_ms": 2472,
+    "total_api_duration_ms": 0,
+    "total_lines_added": 0,
+    "total_lines_removed": 0
+  },
+  "context_window": {
+    "total_input_tokens": 0,
+    "total_output_tokens": 0,
+    "context_window_size": 200000,
+    "current_usage": null,
+    "used_percentage": null,
+    "remaining_percentage": null
+  },
+  "exceeds_200k_tokens": false
+}

--- a/scripts/payload.example.json
+++ b/scripts/payload.example.json
@@ -21,5 +21,18 @@
     "total_api_duration_ms": 2300,
     "total_lines_added": 156,
     "total_lines_removed": 23
+  },
+  "context_window": {
+    "total_input_tokens": 15234,
+    "total_output_tokens": 4521,
+    "context_window_size": 200000,
+    "used_percentage": 42.5,
+    "remaining_percentage": 57.5,
+    "current_usage": {
+      "input_tokens": 8500,
+      "output_tokens": 1200,
+      "cache_creation_input_tokens": 5000,
+      "cache_read_input_tokens": 2000
+    }
   }
 }

--- a/src/types/StatusJSON.ts
+++ b/src/types/StatusJSON.ts
@@ -1,30 +1,56 @@
 import { z } from 'zod';
 
+const modelSchema = z.union([
+    z.string(),
+    z.object({
+        id: z.string().optional(),
+        display_name: z.string().optional()
+    })
+]);
+
+const workspaceSchema = z.object({
+    current_dir: z.string().optional(),
+    project_dir: z.string().optional()
+});
+
+const outputStyleSchema = z.object({ name: z.string().optional() });
+
+const costSchema = z.object({
+    total_cost_usd: z.number().optional(),
+    total_duration_ms: z.number().optional(),
+    total_api_duration_ms: z.number().optional(),
+    total_lines_added: z.number().optional(),
+    total_lines_removed: z.number().optional()
+});
+
+const currentUsageSchema = z.object({
+    input_tokens: z.number().optional(),
+    output_tokens: z.number().optional(),
+    cache_creation_input_tokens: z.number().optional(),
+    cache_read_input_tokens: z.number().optional()
+});
+
+const contextWindowSchema = z.object({
+    total_input_tokens: z.number().optional(),
+    total_output_tokens: z.number().optional(),
+    context_window_size: z.number().optional(),
+    current_usage: currentUsageSchema.nullish(),
+    used_percentage: z.number().nullish(),
+    remaining_percentage: z.number().nullish()
+});
+
 export const StatusJSONSchema = z.looseObject({
     hook_event_name: z.string().optional(),
     session_id: z.string().optional(),
     transcript_path: z.string().optional(),
     cwd: z.string().optional(),
-    model: z.union([
-        z.string(),
-        z.object({
-            id: z.string().optional(),
-            display_name: z.string().optional()
-        })
-    ]).optional(),
-    workspace: z.object({
-        current_dir: z.string().optional(),
-        project_dir: z.string().optional()
-    }).optional(),
+    model: modelSchema.optional(),
+    workspace: workspaceSchema.optional(),
     version: z.string().optional(),
-    output_style: z.object({ name: z.string().optional() }).optional(),
-    cost: z.object({
-        total_cost_usd: z.number().optional(),
-        total_duration_ms: z.number().optional(),
-        total_api_duration_ms: z.number().optional(),
-        total_lines_added: z.number().optional(),
-        total_lines_removed: z.number().optional()
-    }).optional()
+    output_style: outputStyleSchema.optional(),
+    cost: costSchema.optional(),
+    context_window: contextWindowSchema.optional()
 });
 
 export type StatusJSON = z.infer<typeof StatusJSONSchema>;
+export type ContextWindow = z.infer<typeof contextWindowSchema>;

--- a/src/types/TokenMetrics.ts
+++ b/src/types/TokenMetrics.ts
@@ -18,4 +18,7 @@ export interface TokenMetrics {
     cachedTokens: number;
     totalTokens: number;
     contextLength: number;
+    contextWindowSize: number;
+    usedPercentage: number;
+    remainingPercentage: number;
 }

--- a/src/utils/__tests__/context-percentage.test.ts
+++ b/src/utils/__tests__/context-percentage.test.ts
@@ -6,19 +6,29 @@ import {
 
 import type { RenderContext } from '../../types';
 import { calculateContextPercentage } from '../context-percentage';
+import { getContextConfig } from '../model-context';
+
+function createTokenMetrics(contextLength: number, modelId?: string) {
+    const contextWindowSize = getContextConfig(modelId);
+    const usedPercentage = Math.min(100, (contextLength / contextWindowSize) * 100);
+    return {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedTokens: 0,
+        totalTokens: 0,
+        contextLength,
+        contextWindowSize,
+        usedPercentage,
+        remainingPercentage: 100 - usedPercentage
+    };
+}
 
 describe('calculateContextPercentage', () => {
     describe('Sonnet 4.5 with 1M context window', () => {
         it('should calculate percentage using 1M denominator with [1m] suffix', () => {
             const context: RenderContext = {
                 data: { model: { id: 'claude-sonnet-4-5-20250929[1m]' } },
-                tokenMetrics: {
-                    inputTokens: 0,
-                    outputTokens: 0,
-                    cachedTokens: 0,
-                    totalTokens: 0,
-                    contextLength: 42000
-                }
+                tokenMetrics: createTokenMetrics(42000, 'claude-sonnet-4-5-20250929[1m]')
             };
 
             const percentage = calculateContextPercentage(context);
@@ -28,13 +38,7 @@ describe('calculateContextPercentage', () => {
         it('should cap at 100% with [1m] suffix', () => {
             const context: RenderContext = {
                 data: { model: { id: 'claude-sonnet-4-5-20250929[1m]' } },
-                tokenMetrics: {
-                    inputTokens: 0,
-                    outputTokens: 0,
-                    cachedTokens: 0,
-                    totalTokens: 0,
-                    contextLength: 2000000
-                }
+                tokenMetrics: createTokenMetrics(2000000, 'claude-sonnet-4-5-20250929[1m]')
             };
 
             const percentage = calculateContextPercentage(context);
@@ -46,13 +50,7 @@ describe('calculateContextPercentage', () => {
         it('should calculate percentage using 200k denominator', () => {
             const context: RenderContext = {
                 data: { model: { id: 'claude-3-5-sonnet-20241022' } },
-                tokenMetrics: {
-                    inputTokens: 0,
-                    outputTokens: 0,
-                    cachedTokens: 0,
-                    totalTokens: 0,
-                    contextLength: 42000
-                }
+                tokenMetrics: createTokenMetrics(42000, 'claude-3-5-sonnet-20241022')
             };
 
             const percentage = calculateContextPercentage(context);
@@ -67,15 +65,7 @@ describe('calculateContextPercentage', () => {
         });
 
         it('should use default 200k context when model ID is undefined', () => {
-            const context: RenderContext = {
-                tokenMetrics: {
-                    inputTokens: 0,
-                    outputTokens: 0,
-                    cachedTokens: 0,
-                    totalTokens: 0,
-                    contextLength: 42000
-                }
-            };
+            const context: RenderContext = { tokenMetrics: createTokenMetrics(42000, undefined) };
 
             const percentage = calculateContextPercentage(context);
             expect(percentage).toBe(21.0);

--- a/src/utils/__tests__/input-parsers.test.ts
+++ b/src/utils/__tests__/input-parsers.test.ts
@@ -1,0 +1,180 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import {
+    extractTokenMetricsFromContextWindow,
+    formatDurationMs
+} from '../input-parsers';
+
+describe('extractTokenMetricsFromContextWindow', () => {
+    it('should return null for undefined input', () => {
+        const result = extractTokenMetricsFromContextWindow(undefined, undefined);
+        expect(result).toBeNull();
+    });
+
+    it('should extract token metrics from complete context_window', () => {
+        const contextWindow = {
+            total_input_tokens: 15234,
+            total_output_tokens: 4521,
+            context_window_size: 200000,
+            used_percentage: 12.5,
+            remaining_percentage: 87.5,
+            current_usage: {
+                input_tokens: 8500,
+                output_tokens: 1200,
+                cache_creation_input_tokens: 5000,
+                cache_read_input_tokens: 2000
+            }
+        };
+
+        const result = extractTokenMetricsFromContextWindow(contextWindow, undefined);
+
+        expect(result).not.toBeNull();
+        expect(result?.inputTokens).toBe(15234);
+        expect(result?.outputTokens).toBe(4521);
+        expect(result?.cachedTokens).toBe(7000); // 5000 + 2000
+        expect(result?.totalTokens).toBe(26755); // 15234 + 4521 + 7000
+        expect(result?.contextLength).toBe(15500); // 8500 + 5000 + 2000
+        expect(result?.usedPercentage).toBe(12.5);
+        expect(result?.remainingPercentage).toBe(87.5);
+    });
+
+    it('should handle missing optional fields with defaults', () => {
+        const contextWindow = {};
+
+        const result = extractTokenMetricsFromContextWindow(contextWindow, undefined);
+
+        expect(result).not.toBeNull();
+        expect(result?.inputTokens).toBe(0);
+        expect(result?.outputTokens).toBe(0);
+        expect(result?.cachedTokens).toBe(0);
+        expect(result?.totalTokens).toBe(0);
+        expect(result?.contextLength).toBe(0);
+        expect(result?.usedPercentage).toBe(0);
+        expect(result?.remainingPercentage).toBe(100);
+    });
+
+    it('should handle partial current_usage', () => {
+        const contextWindow = {
+            total_input_tokens: 1000,
+            total_output_tokens: 500,
+            current_usage: {
+                input_tokens: 800,
+                cache_read_input_tokens: 200
+            }
+        };
+
+        const result = extractTokenMetricsFromContextWindow(contextWindow, undefined);
+
+        expect(result).not.toBeNull();
+        expect(result?.inputTokens).toBe(1000);
+        expect(result?.outputTokens).toBe(500);
+        expect(result?.cachedTokens).toBe(200); // only cache_read, no cache_creation
+        expect(result?.totalTokens).toBe(1700); // 1000 + 500 + 200
+        expect(result?.contextLength).toBe(1000); // 800 + 0 + 200
+    });
+
+    it('should handle missing current_usage', () => {
+        const contextWindow = {
+            total_input_tokens: 5000,
+            total_output_tokens: 2000
+        };
+
+        const result = extractTokenMetricsFromContextWindow(contextWindow, undefined);
+
+        expect(result).not.toBeNull();
+        expect(result?.inputTokens).toBe(5000);
+        expect(result?.outputTokens).toBe(2000);
+        expect(result?.cachedTokens).toBe(0);
+        expect(result?.totalTokens).toBe(7000);
+        expect(result?.contextLength).toBe(0);
+    });
+
+    it('should use getContextConfig fallback when context_window_size is missing', () => {
+        const contextWindow = {
+            total_input_tokens: 1000,
+            total_output_tokens: 500,
+            current_usage: { input_tokens: 1000 }
+        };
+
+        // With 1M model, should use 1000000 as context window size
+        const result1M = extractTokenMetricsFromContextWindow(
+            contextWindow,
+            'claude-sonnet-4-5-20250929[1m]'
+        );
+        expect(result1M?.contextWindowSize).toBe(1000000);
+
+        // With regular model, should use 200000 as context window size
+        const resultDefault = extractTokenMetricsFromContextWindow(
+            contextWindow,
+            'claude-sonnet-4-5-20250929'
+        );
+        expect(resultDefault?.contextWindowSize).toBe(200000);
+    });
+
+    it('should calculate percentages when not provided', () => {
+        const contextWindow = {
+            total_input_tokens: 1000,
+            total_output_tokens: 500,
+            context_window_size: 10000,
+            current_usage: {
+                input_tokens: 2000,
+                cache_creation_input_tokens: 500,
+                cache_read_input_tokens: 500
+            }
+        };
+
+        const result = extractTokenMetricsFromContextWindow(contextWindow, undefined);
+
+        // contextLength = 2000 + 500 + 500 = 3000
+        // usedPercentage = 3000 / 10000 * 100 = 30%
+        expect(result?.contextLength).toBe(3000);
+        expect(result?.usedPercentage).toBe(30);
+        expect(result?.remainingPercentage).toBe(70);
+    });
+
+    it('should cap usedPercentage at 100 and remainingPercentage at 0', () => {
+        const contextWindow = {
+            context_window_size: 1000,
+            // More than context window
+            current_usage: { input_tokens: 2000 }
+        };
+
+        const result = extractTokenMetricsFromContextWindow(contextWindow, undefined);
+
+        // contextLength = 2000, which exceeds context_window_size of 1000
+        // usedPercentage should be capped at 100
+        expect(result?.usedPercentage).toBe(100);
+        expect(result?.remainingPercentage).toBe(0);
+    });
+});
+
+describe('formatDurationMs', () => {
+    it('should return "<1m" for durations less than 1 minute', () => {
+        expect(formatDurationMs(0)).toBe('<1m');
+        expect(formatDurationMs(30000)).toBe('<1m'); // 30 seconds
+        expect(formatDurationMs(59999)).toBe('<1m'); // Just under 1 minute
+    });
+
+    it('should return minutes only for durations under 1 hour', () => {
+        expect(formatDurationMs(60000)).toBe('1m'); // Exactly 1 minute
+        expect(formatDurationMs(300000)).toBe('5m'); // 5 minutes
+        expect(formatDurationMs(3540000)).toBe('59m'); // 59 minutes
+    });
+
+    it('should return hours only when no remaining minutes', () => {
+        expect(formatDurationMs(3600000)).toBe('1hr'); // Exactly 1 hour
+        expect(formatDurationMs(7200000)).toBe('2hr'); // 2 hours
+        expect(formatDurationMs(36000000)).toBe('10hr'); // 10 hours
+    });
+
+    it('should return hours and minutes when both are present', () => {
+        expect(formatDurationMs(3660000)).toBe('1hr 1m'); // 1 hour 1 minute
+        expect(formatDurationMs(3720000)).toBe('1hr 2m'); // 1 hour 2 minutes
+        expect(formatDurationMs(5400000)).toBe('1hr 30m'); // 1 hour 30 minutes
+        expect(formatDurationMs(9000000)).toBe('2hr 30m'); // 2 hours 30 minutes
+    });
+});

--- a/src/utils/__tests__/model-context.test.ts
+++ b/src/utils/__tests__/model-context.test.ts
@@ -9,67 +9,59 @@ import { getContextConfig } from '../model-context';
 describe('getContextConfig', () => {
     describe('Sonnet 4.5 models with [1m] suffix', () => {
         it('should return 1M context window for claude-sonnet-4-5 with [1m] suffix', () => {
-            const config = getContextConfig('claude-sonnet-4-5-20250929[1m]');
+            const maxTokens = getContextConfig('claude-sonnet-4-5-20250929[1m]');
 
-            expect(config.maxTokens).toBe(1000000);
-            expect(config.usableTokens).toBe(800000);
+            expect(maxTokens).toBe(1000000);
         });
 
         it('should return 1M context window for AWS Bedrock format with [1m] suffix', () => {
-            const config = getContextConfig(
+            const maxTokens = getContextConfig(
                 'us.anthropic.claude-sonnet-4-5-20250929-v1:0[1m]'
             );
 
-            expect(config.maxTokens).toBe(1000000);
-            expect(config.usableTokens).toBe(800000);
+            expect(maxTokens).toBe(1000000);
         });
 
         it('should return 1M context window with uppercase [1M] suffix', () => {
-            const config = getContextConfig('claude-sonnet-4-5-20250929[1M]');
+            const maxTokens = getContextConfig('claude-sonnet-4-5-20250929[1M]');
 
-            expect(config.maxTokens).toBe(1000000);
-            expect(config.usableTokens).toBe(800000);
+            expect(maxTokens).toBe(1000000);
         });
     });
 
     describe('Sonnet 4.5 models without [1m] suffix', () => {
         it('should return 200k context window for claude-sonnet-4-5 without [1m] suffix', () => {
-            const config = getContextConfig('claude-sonnet-4-5-20250929');
+            const maxTokens = getContextConfig('claude-sonnet-4-5-20250929');
 
-            expect(config.maxTokens).toBe(200000);
-            expect(config.usableTokens).toBe(160000);
+            expect(maxTokens).toBe(200000);
         });
 
         it('should return 200k context window for AWS Bedrock format without [1m] suffix', () => {
-            const config = getContextConfig(
+            const maxTokens = getContextConfig(
                 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
             );
 
-            expect(config.maxTokens).toBe(200000);
-            expect(config.usableTokens).toBe(160000);
+            expect(maxTokens).toBe(200000);
         });
     });
 
     describe('Older/default models', () => {
         it('should return 200k context window for older Sonnet 3.5 model', () => {
-            const config = getContextConfig('claude-3-5-sonnet-20241022');
+            const maxTokens = getContextConfig('claude-3-5-sonnet-20241022');
 
-            expect(config.maxTokens).toBe(200000);
-            expect(config.usableTokens).toBe(160000);
+            expect(maxTokens).toBe(200000);
         });
 
         it('should return 200k context window when model ID is undefined', () => {
-            const config = getContextConfig(undefined);
+            const maxTokens = getContextConfig(undefined);
 
-            expect(config.maxTokens).toBe(200000);
-            expect(config.usableTokens).toBe(160000);
+            expect(maxTokens).toBe(200000);
         });
 
         it('should return 200k context window for unknown model ID', () => {
-            const config = getContextConfig('claude-unknown-model');
+            const maxTokens = getContextConfig('claude-unknown-model');
 
-            expect(config.maxTokens).toBe(200000);
-            expect(config.usableTokens).toBe(160000);
+            expect(maxTokens).toBe(200000);
         });
     });
 });

--- a/src/utils/context-percentage.ts
+++ b/src/utils/context-percentage.ts
@@ -14,5 +14,5 @@ export function calculateContextPercentage(context: RenderContext): number {
     const modelId = typeof model === 'string' ? model : model?.id;
     const contextConfig = getContextConfig(modelId);
 
-    return Math.min(100, (context.tokenMetrics.contextLength / contextConfig.maxTokens) * 100);
+    return Math.min(100, (context.tokenMetrics.contextLength / contextConfig) * 100);
 }

--- a/src/utils/input-parsers.ts
+++ b/src/utils/input-parsers.ts
@@ -1,0 +1,59 @@
+import type { TokenMetrics } from '../types';
+import type { ContextWindow } from '../types/StatusJSON';
+
+import { getContextConfig } from './model-context';
+
+/**
+ * Formats a duration in milliseconds to a human-readable string
+ */
+export function formatDurationMs(durationMs: number): string {
+    const totalMinutes = Math.floor(durationMs / (1000 * 60));
+
+    if (totalMinutes < 1) {
+        return '<1m';
+    }
+
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+
+    if (hours === 0) {
+        return `${minutes}m`;
+    } else if (minutes === 0) {
+        return `${hours}hr`;
+    } else {
+        return `${hours}hr ${minutes}m`;
+    }
+}
+
+/**
+ * Extracts token metrics from the context_window object in the status JSON
+ */
+export function extractTokenMetricsFromContextWindow(
+    contextWindow: ContextWindow | undefined,
+    modelId: string | undefined
+): TokenMetrics | null {
+    if (!contextWindow)
+        return null;
+
+    const inputTokens = contextWindow.total_input_tokens ?? 0;
+    const outputTokens = contextWindow.total_output_tokens ?? 0;
+    const cacheCreation = contextWindow.current_usage?.cache_creation_input_tokens ?? 0;
+    const cacheRead = contextWindow.current_usage?.cache_read_input_tokens ?? 0;
+    const cachedTokens = cacheCreation + cacheRead;
+    const totalTokens = inputTokens + outputTokens + cachedTokens;
+    const contextLength = (contextWindow.current_usage?.input_tokens ?? 0) + cacheCreation + cacheRead;
+    const contextWindowSize = contextWindow.context_window_size ?? getContextConfig(modelId);
+    const usedPercentage = contextWindow.used_percentage ?? Math.min(100, contextLength / contextWindowSize * 100);
+    const remainingPercentage = contextWindow.remaining_percentage ?? Math.max(0, 100 - usedPercentage);
+
+    return {
+        inputTokens,
+        outputTokens,
+        cachedTokens,
+        totalTokens,
+        contextLength,
+        contextWindowSize,
+        usedPercentage,
+        remainingPercentage
+    };
+}

--- a/src/utils/model-context.ts
+++ b/src/utils/model-context.ts
@@ -1,14 +1,6 @@
-interface ModelContextConfig {
-    maxTokens: number;
-    usableTokens: number;
-}
-
-export function getContextConfig(modelId?: string): ModelContextConfig {
+export function getContextConfig(modelId?: string): number {
     // Default to 200k for older models
-    const defaultConfig = {
-        maxTokens: 200000,
-        usableTokens: 160000
-    };
+    const defaultConfig = 200000;
 
     if (!modelId)
         return defaultConfig;
@@ -18,10 +10,7 @@ export function getContextConfig(modelId?: string): ModelContextConfig {
         modelId.includes('claude-sonnet-4-5')
         && modelId.toLowerCase().includes('[1m]')
     ) {
-        return {
-            maxTokens: 1000000,
-            usableTokens: 800000 // 80% of 1M
-        };
+        return 1000000;
     }
 
     // Add future models here as needed

--- a/src/widgets/ContextPercentage.ts
+++ b/src/widgets/ContextPercentage.ts
@@ -6,7 +6,6 @@ import type {
     WidgetEditorDisplay,
     WidgetItem
 } from '../types/Widget';
-import { getContextConfig } from '../utils/model-context';
 
 export class ContextPercentageWidget implements Widget {
     getDefaultColor(): string { return 'blue'; }
@@ -40,18 +39,15 @@ export class ContextPercentageWidget implements Widget {
         return null;
     }
 
-    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
+    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
         const isInverse = item.metadata?.inverse === 'true';
 
         if (context.isPreview) {
             const previewValue = isInverse ? '90.7%' : '9.3%';
             return item.rawValue ? previewValue : `Ctx: ${previewValue}`;
         } else if (context.tokenMetrics) {
-            const model = context.data?.model;
-            const modelId = typeof model === 'string' ? model : model?.id;
-            const contextConfig = getContextConfig(modelId);
-            const usedPercentage = Math.min(100, (context.tokenMetrics.contextLength / contextConfig.maxTokens) * 100);
-            const displayPercentage = isInverse ? (100 - usedPercentage) : usedPercentage;
+            const displayPercentage = isInverse ? context.tokenMetrics.remainingPercentage : context.tokenMetrics.usedPercentage;
+
             return item.rawValue ? `${displayPercentage.toFixed(1)}%` : `Ctx: ${displayPercentage.toFixed(1)}%`;
         }
         return null;

--- a/src/widgets/ContextPercentageUsable.ts
+++ b/src/widgets/ContextPercentageUsable.ts
@@ -6,7 +6,9 @@ import type {
     WidgetEditorDisplay,
     WidgetItem
 } from '../types/Widget';
-import { getContextConfig } from '../utils/model-context';
+
+const USABLE_CONTEXT_RATIO = 0.80; // 80% of max context is usable
+const USABLE_TO_FULL_MULTIPLIER = 1 / USABLE_CONTEXT_RATIO; // 1.25
 
 export class ContextPercentageUsableWidget implements Widget {
     getDefaultColor(): string { return 'green'; }
@@ -40,17 +42,17 @@ export class ContextPercentageUsableWidget implements Widget {
         return null;
     }
 
-    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
+    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
         const isInverse = item.metadata?.inverse === 'true';
 
         if (context.isPreview) {
             const previewValue = isInverse ? '88.4%' : '11.6%';
             return item.rawValue ? previewValue : `Ctx(u): ${previewValue}`;
         } else if (context.tokenMetrics) {
-            const model = context.data?.model;
-            const modelId = typeof model === 'string' ? model : model?.id;
-            const contextConfig = getContextConfig(modelId);
-            const usedPercentage = Math.min(100, (context.tokenMetrics.contextLength / contextConfig.usableTokens) * 100);
+            // Convert from full context percentage to usable context percentage
+            // Usable is 80% of max, so multiply by 1.25 to get percentage of usable
+            const usedPercentage = Math.min(100, context.tokenMetrics.usedPercentage * USABLE_TO_FULL_MULTIPLIER);
+
             const displayPercentage = isInverse ? (100 - usedPercentage) : usedPercentage;
             return item.rawValue ? `${displayPercentage.toFixed(1)}%` : `Ctx(u): ${displayPercentage.toFixed(1)}%`;
         }

--- a/src/widgets/__tests__/ContextPercentage.test.ts
+++ b/src/widgets/__tests__/ContextPercentage.test.ts
@@ -9,19 +9,29 @@ import type {
     WidgetItem
 } from '../../types';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
+import { getContextConfig } from '../../utils/model-context';
 import { ContextPercentageWidget } from '../ContextPercentage';
+
+function createTokenMetrics(contextLength: number, modelId?: string) {
+    const contextWindowSize = getContextConfig(modelId);
+    const usedPercentage = Math.min(100, (contextLength / contextWindowSize) * 100);
+    return {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedTokens: 0,
+        totalTokens: 0,
+        contextLength,
+        contextWindowSize,
+        usedPercentage,
+        remainingPercentage: 100 - usedPercentage
+    };
+}
 
 function render(modelId: string | undefined, contextLength: number, rawValue = false, inverse = false) {
     const widget = new ContextPercentageWidget();
     const context: RenderContext = {
         data: modelId ? { model: { id: modelId } } : undefined,
-        tokenMetrics: {
-            inputTokens: 0,
-            outputTokens: 0,
-            cachedTokens: 0,
-            totalTokens: 0,
-            contextLength
-        }
+        tokenMetrics: createTokenMetrics(contextLength, modelId)
     };
     const item: WidgetItem = {
         id: 'context-percentage',

--- a/src/widgets/__tests__/ContextPercentageUsable.test.ts
+++ b/src/widgets/__tests__/ContextPercentageUsable.test.ts
@@ -9,19 +9,29 @@ import type {
     WidgetItem
 } from '../../types';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
+import { getContextConfig } from '../../utils/model-context';
 import { ContextPercentageUsableWidget } from '../ContextPercentageUsable';
+
+function createTokenMetrics(contextLength: number, modelId?: string) {
+    const contextWindowSize = getContextConfig(modelId);
+    const usedPercentage = Math.min(100, (contextLength / contextWindowSize) * 100);
+    return {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedTokens: 0,
+        totalTokens: 0,
+        contextLength,
+        contextWindowSize,
+        usedPercentage,
+        remainingPercentage: 100 - usedPercentage
+    };
+}
 
 function render(modelId: string | undefined, contextLength: number, rawValue = false, inverse = false) {
     const widget = new ContextPercentageUsableWidget();
     const context: RenderContext = {
         data: modelId ? { model: { id: modelId } } : undefined,
-        tokenMetrics: {
-            inputTokens: 0,
-            outputTokens: 0,
-            cachedTokens: 0,
-            totalTokens: 0,
-            contextLength
-        }
+        tokenMetrics: createTokenMetrics(contextLength, modelId)
     };
     const item: WidgetItem = {
         id: 'context-percentage-usable',


### PR DESCRIPTION
## Summary
- Extract token metrics from the `context_window` object provided by Claude Code v2.0.65+ instead of parsing transcript JSONL files
- Add `input-parsers.ts` utility with `extractTokenMetricsFromContextWindow()` function
- Update `ContextPercentage` and `ContextPercentageUsable` widgets to use new data source
- Fall back to JSONL parsing when `context_window` is not available for backward compatibility

## Test plan
- [x] Unit tests added for `extractTokenMetricsFromContextWindow()` in `input-parsers.test.ts`
- [x] Updated tests for `ContextPercentage` and `ContextPercentageUsable` widgets
- [x] Manual testing with `bun run example` using updated payload
- [ ] Verify backward compatibility with older Claude Code versions (no `context_window`)

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)