### PR TITLE
fix: recognize [1m] suffix on all models, not just Sonnet 4.5

### DIFF
--- a/src/utils/__tests__/model-context.test.ts
+++ b/src/utils/__tests__/model-context.test.ts
@@ -7,9 +7,16 @@ import {
 import { getContextConfig } from '../model-context';
 
 describe('getContextConfig', () => {
-    describe('Sonnet 4.5 models with [1m] suffix', () => {
+    describe('Models with [1m] suffix', () => {
         it('should return 1M context window for claude-sonnet-4-5 with [1m] suffix', () => {
             const config = getContextConfig('claude-sonnet-4-5-20250929[1m]');
+
+            expect(config.maxTokens).toBe(1000000);
+            expect(config.usableTokens).toBe(800000);
+        });
+
+        it('should return 1M context window for claude-opus-4-6 with [1m] suffix', () => {
+            const config = getContextConfig('claude-opus-4-6[1m]');
 
             expect(config.maxTokens).toBe(1000000);
             expect(config.usableTokens).toBe(800000);
@@ -32,7 +39,7 @@ describe('getContextConfig', () => {
         });
     });
 
-    describe('Sonnet 4.5 models without [1m] suffix', () => {
+    describe('Models without [1m] suffix', () => {
         it('should return 200k context window for claude-sonnet-4-5 without [1m] suffix', () => {
             const config = getContextConfig('claude-sonnet-4-5-20250929');
 

--- a/src/utils/model-context.ts
+++ b/src/utils/model-context.ts
@@ -13,11 +13,8 @@ export function getContextConfig(modelId?: string): ModelContextConfig {
     if (!modelId)
         return defaultConfig;
 
-    // Sonnet 4.5 variants with 1M context (requires [1m] suffix for long context beta)
-    if (
-        modelId.includes('claude-sonnet-4-5')
-        && modelId.toLowerCase().includes('[1m]')
-    ) {
+    // Any model with [1m] suffix has 1M context
+    if (modelId.toLowerCase().includes('[1m]')) {
         return {
             maxTokens: 1000000,
             usableTokens: 800000 // 80% of 1M


### PR DESCRIPTION
## Summary

Fixes #171

- `getContextConfig` was hardcoded to only match `claude-sonnet-4-5` models with the `[1m]` suffix
- Other models like `claude-opus-4-6[1m]` also support 1M context but were falling back to the 200k default, causing incorrect context percentage display
- The `[1m]` suffix itself is sufficient to indicate 1M context regardless of model family

## Changes

- **`src/utils/model-context.ts`**: Simplified the condition to check only for the `[1m]` suffix instead of requiring both a specific model name and the suffix
- **`src/utils/__tests__/model-context.test.ts`**: Added test case for `claude-opus-4-6[1m]` and updated test group descriptions to reflect the broader scope

## Test plan

- [x] All 41 existing tests pass
- [x] New test for `claude-opus-4-6[1m]` passes
- [x] Existing Sonnet 4.5 tests still pass (no regression)