### PR TITLE
Add Session Name widget

### DIFF
--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -17,6 +17,7 @@ import {
 import {
     getBlockMetrics,
     getSessionDuration,
+    getSessionSlug,
     getTokenMetrics
 } from './utils/jsonl';
 import {
@@ -72,6 +73,9 @@ async function renderMultipleLines(data: StatusJSON) {
     // Check if session clock is needed
     const hasSessionClock = lines.some(line => line.some(item => item.type === 'session-clock'));
 
+    // Check if session name is needed
+    const hasSessionName = lines.some(line => line.some(item => item.type === 'session-name'));
+
     // Check if block timer is needed
     const hasBlockTimer = lines.some(line => line.some(item => item.type === 'block-timer'));
 
@@ -85,6 +89,11 @@ async function renderMultipleLines(data: StatusJSON) {
         sessionDuration = await getSessionDuration(data.transcript_path);
     }
 
+    let sessionSlug: string | null = null;
+    if (hasSessionName && data.transcript_path) {
+        sessionSlug = await getSessionSlug(data.transcript_path);
+    }
+
     let blockMetrics: BlockMetrics | null = null;
     if (hasBlockTimer) {
         blockMetrics = getBlockMetrics();
@@ -95,6 +104,7 @@ async function renderMultipleLines(data: StatusJSON) {
         data,
         tokenMetrics,
         sessionDuration,
+        sessionSlug,
         blockMetrics,
         isPreview: false
     };

--- a/src/types/RenderContext.ts
+++ b/src/types/RenderContext.ts
@@ -8,6 +8,7 @@ export interface RenderContext {
     tokenMetrics?: TokenMetrics | null;
     sessionDuration?: string | null;
     blockMetrics?: BlockMetrics | null;
+    sessionSlug?: string | null;
     terminalWidth?: number | null;
     isPreview?: boolean;
     lineIndex?: number;  // Index of the current line being rendered (for theme cycling)

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -16,6 +16,32 @@ const readFile = promisify(fs.readFile);
 const readFileSync = fs.readFileSync;
 const statSync = fs.statSync;
 
+export async function getSessionSlug(transcriptPath: string): Promise<string | null> {
+    try {
+        if (!fs.existsSync(transcriptPath)) {
+            return null;
+        }
+
+        const content = await readFile(transcriptPath, 'utf-8');
+        const lines = content.trim().split('\n');
+
+        for (const line of lines) {
+            try {
+                const data = JSON.parse(line) as { slug?: string };
+                if (data.slug) {
+                    return data.slug;
+                }
+            } catch {
+                // Skip invalid lines
+            }
+        }
+
+        return null;
+    } catch {
+        return null;
+    }
+}
+
 export async function getSessionDuration(transcriptPath: string): Promise<string | null> {
     try {
         if (!fs.existsSync(transcriptPath)) {

--- a/src/utils/widgets.ts
+++ b/src/utils/widgets.ts
@@ -27,7 +27,8 @@ const widgetRegistry = new Map<WidgetItemType, Widget>([
     ['version', new widgets.VersionWidget()],
     ['custom-text', new widgets.CustomTextWidget()],
     ['custom-command', new widgets.CustomCommandWidget()],
-    ['claude-session-id', new widgets.ClaudeSessionIdWidget()]
+    ['claude-session-id', new widgets.ClaudeSessionIdWidget()],
+    ['session-name', new widgets.SessionNameWidget()]
 ]);
 
 export function getWidget(type: WidgetItemType): Widget | null {

--- a/src/widgets/SessionName.ts
+++ b/src/widgets/SessionName.ts
@@ -1,0 +1,31 @@
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+
+export class SessionNameWidget implements Widget {
+    getDefaultColor(): string { return 'cyan'; }
+    getDescription(): string { return 'Shows the current Claude Code session name (slug) from the transcript'; }
+    getDisplayName(): string { return 'Session Name'; }
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
+        return { displayText: this.getDisplayName() };
+    }
+
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
+        if (context.isPreview) {
+            return item.rawValue ? 'witty-dancing-llama' : 'Session: witty-dancing-llama';
+        }
+
+        const slug = context.sessionSlug;
+        if (!slug) {
+            return null;
+        }
+        return item.rawValue ? slug : `Session: ${slug}`;
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -19,3 +19,4 @@ export { CustomCommandWidget } from './CustomCommand';
 export { BlockTimerWidget } from './BlockTimer';
 export { CurrentWorkingDirWidget } from './CurrentWorkingDir';
 export { ClaudeSessionIdWidget } from './ClaudeSessionId';
+export { SessionNameWidget } from './SessionName';


### PR DESCRIPTION
## Summary

- Adds a native `session-name` widget that displays the Claude Code session slug (e.g., "witty-dancing-llama") parsed from the transcript JSONL
- Follows the same pattern as existing widgets like `claude-session-id` and `session-clock`
- Supports `rawValue` mode (slug only vs "Session: slug") and color customization

## Changes

- **`src/utils/jsonl.ts`**: Add `getSessionSlug()` — scans transcript JSONL for the first `slug` field
- **`src/types/RenderContext.ts`**: Add `sessionSlug` to the render context interface
- **`src/ccstatusline.ts`**: Wire slug fetching (lazy — only when `session-name` widget is configured)
- **`src/widgets/SessionName.ts`**: New widget implementing the full Widget interface
- **`src/widgets/index.ts`**: Export the new widget
- **`src/utils/widgets.ts`**: Register as `'session-name'` in the widget registry

## Configuration example

```json
{
  "type": "session-name",
  "id": "session-name-1",
  "color": "cyan",
  "rawValue": true
}
```

## Test plan

- [x] `bun test` passes (33/34 — pre-existing GitWorktree `vi.mock` failure unrelated)
- [x] `bun run lint` passes type check (pre-existing lint issue in GitWorktree.test.ts unrelated)
- [x] `bun run build` succeeds
- [x] Piped input test confirms slug renders correctly from real transcript
- [x] Preview mode returns sample slug text
- [x] Returns `null` gracefully when no transcript or no slug found