### PR TITLE
fix: use transcript model to correct cross-session model contamination

### DIFF
--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -38,6 +38,14 @@ import {
 } from './utils/speed-window';
 import { prefetchUsageDataIfNeeded } from './utils/usage-prefetch';
 
+function formatModelDisplayName(modelId: string): string {
+    return modelId
+        .replace(/^claude-/, '')
+        .replace(/-(\d{8})$/, '')
+        .replace(/-/g, ' ')
+        .replace(/\b\w/g, c => c.toUpperCase());
+}
+
 function hasSessionDurationInStatusJson(data: StatusJSON): boolean {
     const durationMs = data.cost?.total_duration_ms;
     return typeof durationMs === 'number' && Number.isFinite(durationMs) && durationMs >= 0;
@@ -114,6 +122,18 @@ async function renderMultipleLines(data: StatusJSON) {
     let tokenMetrics: TokenMetrics | null = null;
     if (data.transcript_path) {
         tokenMetrics = await getTokenMetrics(data.transcript_path);
+
+        if (tokenMetrics.model) {
+            const stdinModelId = typeof data.model === 'string'
+                ? data.model
+                : data.model?.id;
+            if (stdinModelId !== tokenMetrics.model) {
+                data.model = {
+                    id: tokenMetrics.model,
+                    display_name: formatModelDisplayName(tokenMetrics.model)
+                };
+            }
+        }
     }
 
     let sessionDuration: string | null = null;

--- a/src/types/TokenMetrics.ts
+++ b/src/types/TokenMetrics.ts
@@ -6,7 +6,7 @@ export interface TokenUsage {
 }
 
 export interface TranscriptLine {
-    message?: { usage?: TokenUsage };
+    message?: { usage?: TokenUsage; model?: string };
     isSidechain?: boolean;
     timestamp?: string;
     isApiErrorMessage?: boolean;
@@ -19,4 +19,5 @@ export interface TokenMetrics {
     cachedTokens: number;
     totalTokens: number;
     contextLength: number;
+    model: string | null;
 }

--- a/src/utils/__tests__/context-percentage.test.ts
+++ b/src/utils/__tests__/context-percentage.test.ts
@@ -23,7 +23,8 @@ describe('calculateContextPercentage', () => {
                     outputTokens: 0,
                     cachedTokens: 0,
                     totalTokens: 0,
-                    contextLength: 100000
+                    contextLength: 100000,
+                    model: null
                 }
             };
 
@@ -61,7 +62,8 @@ describe('calculateContextPercentage', () => {
                     outputTokens: 0,
                     cachedTokens: 0,
                     totalTokens: 0,
-                    contextLength: 42000
+                    contextLength: 42000,
+                    model: null
                 }
             };
 
@@ -79,7 +81,8 @@ describe('calculateContextPercentage', () => {
                     outputTokens: 0,
                     cachedTokens: 0,
                     totalTokens: 0,
-                    contextLength: 42000
+                    contextLength: 42000,
+                    model: null
                 }
             };
 
@@ -95,7 +98,8 @@ describe('calculateContextPercentage', () => {
                     outputTokens: 0,
                     cachedTokens: 0,
                     totalTokens: 0,
-                    contextLength: 2000000
+                    contextLength: 2000000,
+                    model: null
                 }
             };
 
@@ -111,7 +115,8 @@ describe('calculateContextPercentage', () => {
                     outputTokens: 0,
                     cachedTokens: 0,
                     totalTokens: 0,
-                    contextLength: 42000
+                    contextLength: 42000,
+                    model: null
                 }
             };
 
@@ -127,7 +132,8 @@ describe('calculateContextPercentage', () => {
                     outputTokens: 0,
                     cachedTokens: 0,
                     totalTokens: 0,
-                    contextLength: 42000
+                    contextLength: 42000,
+                    model: null
                 }
             };
 
@@ -148,7 +154,8 @@ describe('calculateContextPercentage', () => {
                     outputTokens: 0,
                     cachedTokens: 0,
                     totalTokens: 0,
-                    contextLength: 42000
+                    contextLength: 42000,
+                    model: null
                 }
             };
 
@@ -166,7 +173,8 @@ describe('calculateContextPercentage', () => {
                     outputTokens: 0,
                     cachedTokens: 0,
                     totalTokens: 0,
-                    contextLength: 42000
+                    contextLength: 42000,
+                    model: null
                 }
             };
 
@@ -188,7 +196,8 @@ describe('calculateContextPercentage', () => {
                     outputTokens: 0,
                     cachedTokens: 0,
                     totalTokens: 0,
-                    contextLength: 42000
+                    contextLength: 42000,
+                    model: null
                 }
             };
 

--- a/src/utils/__tests__/jsonl-metrics.test.ts
+++ b/src/utils/__tests__/jsonl-metrics.test.ts
@@ -46,6 +46,7 @@ function makeTranscriptLine(params: {
     output?: number;
     isSidechain?: boolean;
     isApiErrorMessage?: boolean;
+    model?: string;
 }): string {
     return JSON.stringify({
         timestamp: params.timestamp,
@@ -57,7 +58,8 @@ function makeTranscriptLine(params: {
                 usage: {
                     input_tokens: params.input ?? 0,
                     output_tokens: params.output ?? 0
-                }
+                },
+                model: params.model
             }
             : undefined
     });
@@ -155,7 +157,8 @@ describe('jsonl transcript metrics', () => {
             outputTokens: 141,
             cachedTokens: 92,
             totalTokens: 2032,
-            contextLength: 250
+            contextLength: 250,
+            model: null
         });
     });
 
@@ -166,8 +169,78 @@ describe('jsonl transcript metrics', () => {
             outputTokens: 0,
             cachedTokens: 0,
             totalTokens: 0,
-            contextLength: 0
+            contextLength: 0,
+            model: null
         });
+    });
+
+    it('returns the model from the most recent assistant entry', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-jsonl-metrics-'));
+        tempRoots.push(root);
+        const transcriptPath = path.join(root, 'model.jsonl');
+        fs.writeFileSync(transcriptPath, [
+            makeTranscriptLine({
+                timestamp: '2026-01-01T10:00:00.000Z',
+                type: 'user'
+            }),
+            makeTranscriptLine({
+                timestamp: '2026-01-01T10:00:05.000Z',
+                type: 'assistant',
+                input: 100,
+                output: 50,
+                model: 'claude-sonnet-4-5-20250929'
+            })
+        ].join('\n'));
+
+        const metrics = await getTokenMetrics(transcriptPath);
+        expect(metrics.model).toBe('claude-sonnet-4-5-20250929');
+    });
+
+    it('returns null model when the last entry is a user message (API in progress)', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-jsonl-metrics-'));
+        tempRoots.push(root);
+        const transcriptPath = path.join(root, 'model-pending.jsonl');
+        fs.writeFileSync(transcriptPath, [
+            makeTranscriptLine({
+                timestamp: '2026-01-01T10:00:00.000Z',
+                type: 'user'
+            }),
+            makeTranscriptLine({
+                timestamp: '2026-01-01T10:00:05.000Z',
+                type: 'assistant',
+                input: 100,
+                output: 50,
+                model: 'claude-sonnet-4-5-20250929'
+            }),
+            makeTranscriptLine({
+                timestamp: '2026-01-01T10:01:00.000Z',
+                type: 'user'
+            })
+        ].join('\n'));
+
+        const metrics = await getTokenMetrics(transcriptPath);
+        expect(metrics.model).toBeNull();
+    });
+
+    it('returns null model when transcript has no model field', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-jsonl-metrics-'));
+        tempRoots.push(root);
+        const transcriptPath = path.join(root, 'no-model.jsonl');
+        fs.writeFileSync(transcriptPath, [
+            makeTranscriptLine({
+                timestamp: '2026-01-01T10:00:00.000Z',
+                type: 'user'
+            }),
+            makeTranscriptLine({
+                timestamp: '2026-01-01T10:00:05.000Z',
+                type: 'assistant',
+                input: 100,
+                output: 50
+            })
+        ].join('\n'));
+
+        const metrics = await getTokenMetrics(transcriptPath);
+        expect(metrics.model).toBeNull();
     });
 
     it('calculates speed metrics from user-to-assistant processing windows', async () => {

--- a/src/utils/jsonl-metrics.ts
+++ b/src/utils/jsonl-metrics.ts
@@ -152,7 +152,7 @@ export async function getTokenMetrics(transcriptPath: string): Promise<TokenMetr
     try {
         // Use Node.js-compatible file reading
         if (!fs.existsSync(transcriptPath)) {
-            return { inputTokens: 0, outputTokens: 0, cachedTokens: 0, totalTokens: 0, contextLength: 0 };
+            return { inputTokens: 0, outputTokens: 0, cachedTokens: 0, totalTokens: 0, contextLength: 0, model: null };
         }
 
         const lines = await readJsonlLines(transcriptPath);
@@ -194,11 +194,29 @@ export async function getTokenMetrics(transcriptPath: string): Promise<TokenMetr
                 + (usage.cache_creation_input_tokens ?? 0);
         }
 
+        // Check if last entry is a user message (API call may be in progress).
+        // In that case, don't report the model — it may be stale if the user
+        // just changed models. After the response, the transcript catches up.
+        let model: string | null = null;
+        if (mostRecentMainChainEntry?.message?.model) {
+            let lastEntryIsUser = false;
+            for (let i = lines.length - 1; i >= 0; i--) {
+                const last = parseJsonlLine(lines[i]!) as TranscriptLine | null;
+                if (last?.type === 'assistant' || last?.type === 'user') {
+                    lastEntryIsUser = last.type === 'user';
+                    break;
+                }
+            }
+            if (!lastEntryIsUser) {
+                model = mostRecentMainChainEntry.message.model;
+            }
+        }
+
         const totalTokens = inputTokens + outputTokens + cachedTokens;
 
-        return { inputTokens, outputTokens, cachedTokens, totalTokens, contextLength };
+        return { inputTokens, outputTokens, cachedTokens, totalTokens, contextLength, model };
     } catch {
-        return { inputTokens: 0, outputTokens: 0, cachedTokens: 0, totalTokens: 0, contextLength: 0 };
+        return { inputTokens: 0, outputTokens: 0, cachedTokens: 0, totalTokens: 0, contextLength: 0, model: null };
     }
 }
 

--- a/src/utils/jsonl-metrics.ts
+++ b/src/utils/jsonl-metrics.ts
@@ -201,7 +201,11 @@ export async function getTokenMetrics(transcriptPath: string): Promise<TokenMetr
         if (mostRecentMainChainEntry?.message?.model) {
             let lastEntryIsUser = false;
             for (let i = lines.length - 1; i >= 0; i--) {
-                const last = parseJsonlLine(lines[i]!) as TranscriptLine | null;
+                const line = lines[i];
+                if (!line) {
+                    continue;
+                }
+                const last = parseJsonlLine(line) as TranscriptLine | null;
                 if (last?.type === 'assistant' || last?.type === 'user') {
                     lastEntryIsUser = last.type === 'user';
                     break;

--- a/src/widgets/__tests__/ContextBar.test.ts
+++ b/src/widgets/__tests__/ContextBar.test.ts
@@ -49,7 +49,8 @@ describe('ContextBarWidget', () => {
                 outputTokens: 0,
                 cachedTokens: 0,
                 totalTokens: 0,
-                contextLength: 50000
+                contextLength: 50000,
+                model: null
             }
         };
         const widget = new ContextBarWidget();
@@ -65,7 +66,8 @@ describe('ContextBarWidget', () => {
                 outputTokens: 0,
                 cachedTokens: 0,
                 totalTokens: 0,
-                contextLength: 50000
+                contextLength: 50000,
+                model: null
             }
         };
         const widget = new ContextBarWidget();
@@ -81,7 +83,8 @@ describe('ContextBarWidget', () => {
                 outputTokens: 0,
                 cachedTokens: 0,
                 totalTokens: 0,
-                contextLength: 50000
+                contextLength: 50000,
+                model: null
             }
         };
         const widget = new ContextBarWidget();

--- a/src/widgets/__tests__/ContextPercentage.test.ts
+++ b/src/widgets/__tests__/ContextPercentage.test.ts
@@ -20,7 +20,8 @@ function render(modelId: string | undefined, contextLength: number, rawValue = f
             outputTokens: 0,
             cachedTokens: 0,
             totalTokens: 0,
-            contextLength
+            contextLength,
+            model: null
         }
     };
     const item: WidgetItem = {
@@ -72,7 +73,8 @@ describe('ContextPercentageWidget', () => {
                 outputTokens: 0,
                 cachedTokens: 0,
                 totalTokens: 0,
-                contextLength: 100000
+                contextLength: 100000,
+                model: null
             }
         };
 

--- a/src/widgets/__tests__/ContextPercentageUsable.test.ts
+++ b/src/widgets/__tests__/ContextPercentageUsable.test.ts
@@ -20,7 +20,8 @@ function render(modelId: string | undefined, contextLength: number, rawValue = f
             outputTokens: 0,
             cachedTokens: 0,
             totalTokens: 0,
-            contextLength
+            contextLength,
+            model: null
         }
     };
     const item: WidgetItem = {
@@ -76,7 +77,8 @@ describe('ContextPercentageUsableWidget', () => {
                 outputTokens: 0,
                 cachedTokens: 0,
                 totalTokens: 0,
-                contextLength: 200000
+                contextLength: 200000,
+                model: null
             }
         };
 
@@ -99,7 +101,8 @@ describe('ContextPercentageUsableWidget', () => {
                 outputTokens: 0,
                 cachedTokens: 0,
                 totalTokens: 0,
-                contextLength: 42000
+                contextLength: 42000,
+                model: null
             }
         };
 

--- a/src/widgets/__tests__/TokensWidgets.test.ts
+++ b/src/widgets/__tests__/TokensWidgets.test.ts
@@ -57,7 +57,8 @@ describe('Token widgets', () => {
                 outputTokens: 9999,
                 cachedTokens: 9999,
                 totalTokens: 9999,
-                contextLength: 9999
+                contextLength: 9999,
+                model: null
             }
         };
 
@@ -75,7 +76,8 @@ describe('Token widgets', () => {
                 outputTokens: 3400,
                 cachedTokens: 560,
                 totalTokens: 5160,
-                contextLength: 0
+                contextLength: 0,
+                model: null
             }
         };
 
@@ -105,7 +107,8 @@ describe('Token widgets', () => {
                 outputTokens: 3400,
                 cachedTokens: 560,
                 totalTokens: 5160,
-                contextLength: 20000
+                contextLength: 20000,
+                model: null
             }
         };
 


### PR DESCRIPTION
## Summary

Fixes the model display showing the wrong model when multiple Claude Code sessions are open and one changes models. The root cause is upstream (anthropics/claude-code#19570) — the `model` field in statusline JSON reads from global shared state instead of per-session state.

- Extracts the model from the per-session transcript (which has the correct `message.model` on each assistant entry) inside `getTokenMetrics` — no extra file read
- Overrides the stdin model in `renderMultipleLines` when the transcript model differs
- When the last transcript entry is a user message (API call in progress), returns `null` to avoid showing a stale model — self-corrects once the response arrives

### Trade-off

Brief window during API calls where cross-session contamination can still show. Acceptable vs permanently displaying the wrong model. This workaround can be removed when Claude Code fixes the upstream bug.

This is a pretty big patch for a bug in upstream, so feel free to reject. I was getting quite annoyed with the status line changing between chats so figured I'd make a PR.

Closes #190

## Test plan

- [x] 3 new tests: model extraction, pending-user null, missing model null
- [x] All existing tests updated and passing (67 tests across 6 files)
- [x] `tsc --noEmit` clean
- [x] Manual test: two parallel sessions, change model in one, both show correct models