### PR TITLE
feat: display days in formatUsageDuration when >= 24 hours

### DIFF
--- a/src/utils/__tests__/usage-windows.test.ts
+++ b/src/utils/__tests__/usage-windows.test.ts
@@ -4,10 +4,64 @@ import {
     it
 } from 'vitest';
 
-import { getUsageErrorMessage } from '../usage-windows';
+import { getUsageErrorMessage, formatUsageDuration } from '../usage-windows';
 
 describe('getUsageErrorMessage', () => {
     it('returns the rate-limited label', () => {
         expect(getUsageErrorMessage('rate-limited')).toBe('[Rate limited]');
+    });
+});
+
+describe('formatUsageDuration', () => {
+    it('formats minutes only', () => {
+        expect(formatUsageDuration(30 * 60 * 1000)).toBe('0hr 30m');
+    });
+
+    it('formats hours only', () => {
+        expect(formatUsageDuration(2 * 60 * 60 * 1000)).toBe('2hr');
+    });
+
+    it('formats hours and minutes', () => {
+        expect(formatUsageDuration(2.5 * 60 * 60 * 1000)).toBe('2hr 30m');
+    });
+
+    it('formats days when >= 24 hours', () => {
+        // 36 hours 30 minutes
+        const ms = (36 * 60 + 30) * 60 * 1000;
+        expect(formatUsageDuration(ms)).toBe('1d 12hr 30m');
+    });
+
+    it('formats days without minutes', () => {
+        const ms = 48 * 60 * 60 * 1000;
+        expect(formatUsageDuration(ms)).toBe('2d');
+    });
+
+    it('formats days only (exact multiple)', () => {
+        const ms = 24 * 60 * 60 * 1000;
+        expect(formatUsageDuration(ms)).toBe('1d');
+    });
+
+    // Compact mode
+    it('compact: formats hours and minutes', () => {
+        expect(formatUsageDuration(2.5 * 60 * 60 * 1000, true)).toBe('2h30m');
+    });
+
+    it('compact: formats days', () => {
+        const ms = (36 * 60 + 30) * 60 * 1000;
+        expect(formatUsageDuration(ms, true)).toBe('1d12h30m');
+    });
+
+    it('compact: formats days without minutes', () => {
+        const ms = 48 * 60 * 60 * 1000;
+        expect(formatUsageDuration(ms, true)).toBe('2d0h');
+    });
+
+    it('handles zero duration', () => {
+        expect(formatUsageDuration(0)).toBe('0hr');
+        expect(formatUsageDuration(0, true)).toBe('0h');
+    });
+
+    it('clamps negative values to zero', () => {
+        expect(formatUsageDuration(-1000)).toBe('0hr');
     });
 });

--- a/src/utils/usage-windows.ts
+++ b/src/utils/usage-windows.ts
@@ -91,18 +91,30 @@ export function resolveWeeklyUsageWindow(usageData: UsageData, nowMs = Date.now(
 
 export function formatUsageDuration(durationMs: number, compact = false): string {
     const clampedMs = Math.max(0, durationMs);
-    const elapsedHours = Math.floor(clampedMs / (1000 * 60 * 60));
-    const elapsedMinutes = Math.floor((clampedMs % (1000 * 60 * 60)) / (1000 * 60));
+    const totalMinutes = Math.floor(clampedMs / (1000 * 60));
+    const days = Math.floor(totalMinutes / (60 * 24));
+    const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+    const minutes = totalMinutes % 60;
 
     if (compact) {
-        return elapsedMinutes === 0 ? `${elapsedHours}h` : `${elapsedHours}h${elapsedMinutes}m`;
+        if (days > 0) {
+            return minutes === 0 ? `${days}d${hours}h` : `${days}d${hours}h${minutes}m`;
+        }
+        return minutes === 0 ? `${hours}h` : `${hours}h${minutes}m`;
     }
 
-    if (elapsedMinutes === 0) {
-        return `${elapsedHours}hr`;
+    if (days > 0) {
+        if (minutes === 0) {
+            return hours === 0 ? `${days}d` : `${days}d ${hours}hr`;
+        }
+        return `${days}d ${hours}hr ${minutes}m`;
     }
 
-    return `${elapsedHours}hr ${elapsedMinutes}m`;
+    if (minutes === 0) {
+        return `${hours}hr`;
+    }
+
+    return `${hours}hr ${minutes}m`;
 }
 
 export function getUsageErrorMessage(error: UsageError): string {


### PR DESCRIPTION
## Summary

Fixes #210 — when usage duration exceeds 24 hours, the status bar now shows days instead of large hour counts.

### Before
```
36hr 30m     (normal)
36h30m       (compact)
```

### After
```
1d 12hr 30m  (normal)
1d12h30m     (compact)
```

### Examples
| Duration | Normal | Compact |
|----------|--------|---------|
| 30 min | `0hr 30m` | `0h30m` |
| 2 hr | `2hr` | `2h` |
| 24 hr | `1d` | `1d0h` |
| 36 hr 30 min | `1d 12hr 30m` | `1d12h30m` |
| 48 hr | `2d` | `2d0h` |

### Tests
11 new test cases for `formatUsageDuration` covering days, hours, minutes, compact mode, zero, and negative values. All 12 tests pass.

### Changes
- `src/utils/usage-windows.ts`: add day calculation to `formatUsageDuration`
- `src/utils/__tests__/usage-windows.test.ts`: add comprehensive tests