### PR TITLE
feat: add ThinkingEffort widget to display thinking effort level

### DIFF
--- a/src/types/StatusJSON.ts
+++ b/src/types/StatusJSON.ts
@@ -54,6 +54,11 @@ export const StatusJSONSchema = z.looseObject({
         ]).nullable().optional(),
         used_percentage: CoercedNumberSchema.nullable().optional(),
         remaining_percentage: CoercedNumberSchema.nullable().optional()
+    }).nullable().optional(),
+    thinking: z.object({
+        enabled: z.boolean().optional(),
+        budget_tokens: z.number().nullable().optional(),
+        effort: z.enum(['low', 'medium', 'high']).optional()
     }).nullable().optional()
 });
 

--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -52,7 +52,8 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'reset-timer', create: () => new widgets.BlockResetTimerWidget() },
     { type: 'weekly-reset-timer', create: () => new widgets.WeeklyResetTimerWidget() },
     { type: 'context-bar', create: () => new widgets.ContextBarWidget() },
-    { type: 'skills', create: () => new widgets.SkillsWidget() }
+    { type: 'skills', create: () => new widgets.SkillsWidget() },
+    { type: 'thinking-effort', create: () => new widgets.ThinkingEffortWidget() }
 ];
 
 export const LAYOUT_WIDGET_MANIFEST: LayoutWidgetManifestEntry[] = [

--- a/src/widgets/ThinkingEffort.ts
+++ b/src/widgets/ThinkingEffort.ts
@@ -1,0 +1,67 @@
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+
+import { loadClaudeSettings } from '../utils/claude-settings';
+
+export type ThinkingEffortLevel = 'low' | 'medium' | 'high';
+
+/**
+ * Resolve thinking effort from StatusJSON or Claude settings.
+ * Priority: StatusJSON > Claude settings > undefined
+ */
+async function resolveThinkingEffort(context: RenderContext): Promise<ThinkingEffortLevel | undefined> {
+    // 1. Try StatusJSON (if Claude Code exposes it via status line hook)
+    const thinking = context.data?.thinking;
+    if (thinking?.effort) {
+        return thinking.effort;
+    }
+
+    // 2. Fall back to Claude Code settings.json
+    try {
+        const settings = await loadClaudeSettings({ logErrors: false });
+        const raw = settings as Record<string, unknown>;
+
+        // Claude Code uses "thinkingMode" field: "low" | "medium" | "high"
+        if (typeof raw.thinkingMode === 'string') {
+            const mode = raw.thinkingMode.toLowerCase();
+            if (mode === 'low' || mode === 'medium' || mode === 'high') {
+                return mode;
+            }
+        }
+    } catch {
+        // Settings unavailable, return undefined
+    }
+
+    return undefined;
+}
+
+export class ThinkingEffortWidget implements Widget {
+    getDefaultColor(): string { return 'magenta'; }
+    getDescription(): string { return 'Displays the current thinking effort level (low, medium, high)'; }
+    getDisplayName(): string { return 'Thinking Effort'; }
+    getCategory(): string { return 'Core'; }
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
+        return { displayText: this.getDisplayName() };
+    }
+
+    async render(item: WidgetItem, context: RenderContext, settings: Settings): Promise<string | null> {
+        if (context.isPreview) {
+            return item.rawValue ? 'high' : 'Thinking: high';
+        }
+
+        const effort = await resolveThinkingEffort(context);
+        if (!effort) {
+            return null;
+        }
+
+        return item.rawValue ? effort : `Thinking: ${effort}`;
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/__tests__/ThinkingEffort.test.ts
+++ b/src/widgets/__tests__/ThinkingEffort.test.ts
@@ -1,0 +1,115 @@
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import { ThinkingEffortWidget } from '../ThinkingEffort';
+
+// Mock claude-settings to avoid filesystem reads in tests
+vi.mock('../../utils/claude-settings', () => ({
+    loadClaudeSettings: vi.fn()
+}));
+
+import { loadClaudeSettings } from '../../utils/claude-settings';
+
+const mockedLoadSettings = vi.mocked(loadClaudeSettings);
+
+function makeContext(thinkingData?: { enabled?: boolean; effort?: 'low' | 'medium' | 'high' } | null): object {
+    return {
+        data: thinkingData !== undefined ? { thinking: thinkingData } : undefined,
+        isPreview: false
+    };
+}
+
+describe('ThinkingEffortWidget', () => {
+    let widget: ThinkingEffortWidget;
+
+    beforeEach(() => {
+        widget = new ThinkingEffortWidget();
+        vi.clearAllMocks();
+        mockedLoadSettings.mockResolvedValue({} as never);
+    });
+
+    describe('metadata', () => {
+        it('has correct display name', () => {
+            expect(widget.getDisplayName()).toBe('Thinking Effort');
+        });
+
+        it('has correct category', () => {
+            expect(widget.getCategory()).toBe('Core');
+        });
+
+        it('supports raw value', () => {
+            expect(widget.supportsRawValue()).toBe(true);
+        });
+
+        it('supports colors', () => {
+            expect(widget.supportsColors({ type: 'thinking-effort' } as never)).toBe(true);
+        });
+    });
+
+    describe('preview mode', () => {
+        it('returns labelled preview', async () => {
+            const result = await widget.render({ type: 'thinking-effort', rawValue: false } as never, { isPreview: true } as never, {} as never);
+            expect(result).toBe('Thinking: high');
+        });
+
+        it('returns raw preview', async () => {
+            const result = await widget.render({ type: 'thinking-effort', rawValue: true } as never, { isPreview: true } as never, {} as never);
+            expect(result).toBe('high');
+        });
+    });
+
+    describe('StatusJSON data', () => {
+        it('returns effort from StatusJSON', async () => {
+            const ctx = makeContext({ effort: 'medium' });
+            const result = await widget.render({ type: 'thinking-effort', rawValue: false } as never, ctx as never, {} as never);
+            expect(result).toBe('Thinking: medium');
+        });
+
+        it('returns raw effort from StatusJSON', async () => {
+            const ctx = makeContext({ effort: 'low' });
+            const result = await widget.render({ type: 'thinking-effort', rawValue: true } as never, ctx as never, {} as never);
+            expect(result).toBe('low');
+        });
+
+        it('returns null when thinking data is null', async () => {
+            const ctx = makeContext(null);
+            const result = await widget.render({ type: 'thinking-effort', rawValue: false } as never, ctx as never, {} as never);
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('Claude settings fallback', () => {
+        it('reads thinkingMode from settings when no StatusJSON', async () => {
+            mockedLoadSettings.mockResolvedValue({ thinkingMode: 'high' } as never);
+            const ctx = makeContext(undefined);
+            const result = await widget.render({ type: 'thinking-effort', rawValue: false } as never, ctx as never, {} as never);
+            expect(result).toBe('Thinking: high');
+        });
+
+        it('handles case-insensitive thinkingMode', async () => {
+            mockedLoadSettings.mockResolvedValue({ thinkingMode: 'HIGH' } as never);
+            const ctx = makeContext(undefined);
+            const result = await widget.render({ type: 'thinking-effort', rawValue: false } as never, ctx as never, {} as never);
+            expect(result).toBe('Thinking: high');
+        });
+
+        it('returns null when thinkingMode not set', async () => {
+            mockedLoadSettings.mockResolvedValue({} as never);
+            const ctx = makeContext(undefined);
+            const result = await widget.render({ type: 'thinking-effort', rawValue: false } as never, ctx as never, {} as never);
+            expect(result).toBeNull();
+        });
+
+        it('returns null when settings read fails', async () => {
+            mockedLoadSettings.mockRejectedValue(new Error('settings unavailable'));
+            const ctx = makeContext(undefined);
+            const result = await widget.render({ type: 'thinking-effort', rawValue: false } as never, ctx as never, {} as never);
+            expect(result).toBeNull();
+        });
+    });
+});

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -34,3 +34,4 @@ export { WeeklyResetTimerWidget } from './WeeklyResetTimer';
 export { ContextBarWidget } from './ContextBar';
 export { LinkWidget } from './Link';
 export { SkillsWidget } from './Skills';
+export { ThinkingEffortWidget } from './ThinkingEffort';


### PR DESCRIPTION
## Summary

Adds a new `thinking-effort` widget that displays the current thinking effort level (low, medium, high) in the status bar. Closes #209.

### Usage

Add to your status line config via the TUI or directly in settings:
```json
{ "type": "thinking-effort", "color": "magenta" }
```

### Data Source

The widget resolves thinking effort from two sources (in priority order):

1. **StatusJSON** — `thinking.effort` field from Claude Code status line hook (future-compatible)
2. **Claude settings** — `thinkingMode` key in `~/.claude/settings.json` (current fallback)

### Display

| Mode | Example output |
|------|---------------|
| Normal | `Thinking: high` |
| Raw value | `high` |
| Preview | `Thinking: high` |

### Changes

| File | Change |
|------|--------|
| `src/types/StatusJSON.ts` | Add optional `thinking` field with `enabled`, `budget_tokens`, `effort` |
| `src/widgets/ThinkingEffort.ts` | New widget implementation |
| `src/widgets/index.ts` | Export `ThinkingEffortWidget` |
| `src/utils/widget-manifest.ts` | Register `thinking-effort` type |
| `src/widgets/__tests__/ThinkingEffort.test.ts` | 13 unit tests covering all code paths |

All 13 new tests pass. Pre-existing test failures are unrelated to this PR (57 failures also present on `main`).