### PR TITLE
feat: add hyperlink support to GitBranch and GitRootDir widgets

### DIFF
--- a/src/utils/__tests__/hyperlink.test.ts
+++ b/src/utils/__tests__/hyperlink.test.ts
@@ -1,0 +1,49 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import {
+    buildIdeFileUrl,
+    encodeGitRefForUrlPath,
+    parseGitHubBaseUrl
+} from '../hyperlink';
+
+describe('parseGitHubBaseUrl', () => {
+    it('supports scp-style SSH remotes', () => {
+        expect(parseGitHubBaseUrl('git@github.com:owner/repo.git')).toBe('https://github.com/owner/repo');
+    });
+
+    it('supports ssh URL remotes', () => {
+        expect(parseGitHubBaseUrl('ssh://git@github.com/owner/repo.git')).toBe('https://github.com/owner/repo');
+    });
+
+    it('supports credentialed HTTPS remotes', () => {
+        expect(parseGitHubBaseUrl('https://token@github.com/owner/repo.git')).toBe('https://github.com/owner/repo');
+    });
+
+    it('rejects non-GitHub remotes', () => {
+        expect(parseGitHubBaseUrl('https://gitlab.com/owner/repo.git')).toBeNull();
+    });
+});
+
+describe('encodeGitRefForUrlPath', () => {
+    it('encodes reserved characters while preserving branch separators', () => {
+        expect(encodeGitRefForUrlPath('feature/issue#1')).toBe('feature/issue%231');
+    });
+});
+
+describe('buildIdeFileUrl', () => {
+    it('builds encoded IDE links for POSIX paths', () => {
+        expect(buildIdeFileUrl('/Users/example/my repo#1', 'cursor')).toBe('cursor://file/Users/example/my%20repo%231');
+    });
+
+    it('builds IDE links for Windows drive-letter paths', () => {
+        expect(buildIdeFileUrl('C:/Work/my repo#1', 'vscode')).toBe('vscode://file/C:/Work/my%20repo%231');
+    });
+
+    it('builds IDE links for UNC paths', () => {
+        expect(buildIdeFileUrl('\\\\server\\share\\my repo', 'cursor')).toBe('cursor://file//server/share/my%20repo');
+    });
+});

--- a/src/utils/hyperlink.ts
+++ b/src/utils/hyperlink.ts
@@ -1,26 +1,93 @@
+export const IDE_LINK_MODES = [
+    'vscode',
+    'cursor'
+] as const;
+
+export type IdeLinkMode = (typeof IDE_LINK_MODES)[number];
+
 export function renderOsc8Link(url: string, text: string): string {
     return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
 }
 
+function parseGitHubRepositoryPath(pathname: string): string | null {
+    const trimmedPath = pathname.replace(/^\/+|\/+$/g, '').replace(/\.git$/, '');
+    const segments = trimmedPath.split('/').filter(Boolean);
+
+    if (segments.length !== 2) {
+        return null;
+    }
+
+    return `${segments[0]}/${segments[1]}`;
+}
+
 /**
  * Converts a git remote URL to a GitHub HTTPS base URL.
- * Handles both SSH (git@github.com:owner/repo.git) and HTTPS formats.
+ * Handles SSH, HTTPS, and ssh:// URL formats.
  * Returns null if the remote is not a GitHub URL.
  */
 export function parseGitHubBaseUrl(remoteUrl: string): string | null {
     const trimmed = remoteUrl.trim();
+    if (trimmed.length === 0) {
+        return null;
+    }
 
-    // SSH format: git@github.com:owner/repo.git
-    const sshMatch = /^git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/.exec(trimmed);
+    const sshMatch = /^(?:[^@]+@)?github\.com:([^/]+\/[^/]+?)(?:\.git)?\/?$/.exec(trimmed);
     if (sshMatch?.[1]) {
         return `https://github.com/${sshMatch[1]}`;
     }
 
-    // HTTPS format: https://github.com/owner/repo.git
-    const httpsMatch = /^https?:\/\/github\.com\/([^/]+\/[^/]+?)(?:\.git)?$/.exec(trimmed);
-    if (httpsMatch?.[1]) {
-        return `https://github.com/${httpsMatch[1]}`;
+    try {
+        const parsedUrl = new URL(trimmed);
+        const supportedProtocols = new Set([
+            'http:',
+            'https:',
+            'ssh:',
+            'git:'
+        ]);
+
+        if (parsedUrl.hostname.toLowerCase() !== 'github.com' || !supportedProtocols.has(parsedUrl.protocol)) {
+            return null;
+        }
+
+        const repoPath = parseGitHubRepositoryPath(parsedUrl.pathname);
+        if (!repoPath) {
+            return null;
+        }
+
+        return `https://github.com/${repoPath}`;
+    } catch {
+        return null;
+    }
+}
+
+export function encodeGitRefForUrlPath(ref: string): string {
+    return ref
+        .split('/')
+        .map(segment => encodeURIComponent(segment))
+        .join('/');
+}
+
+function encodeFilePathForUri(path: string): string {
+    return path
+        .replace(/\\/g, '/')
+        .split('/')
+        .map(segment => encodeURIComponent(segment))
+        .join('/');
+}
+
+export function buildIdeFileUrl(filePath: string, ideLinkMode: IdeLinkMode): string {
+    const normalizedPath = filePath.replace(/\\/g, '/');
+    const uncMatch = /^\/\/([^/]+)(\/.*)?$/.exec(normalizedPath);
+    if (uncMatch?.[1]) {
+        const encodedPath = encodeFilePathForUri(uncMatch[2] ?? '/');
+        return `${ideLinkMode}://file//${uncMatch[1]}${encodedPath}`;
     }
 
-    return null;
+    const driveMatch = /^([A-Za-z]:)(\/.*)?$/.exec(normalizedPath);
+    if (driveMatch?.[1]) {
+        const encodedPath = encodeFilePathForUri(driveMatch[2] ?? '/');
+        return `${ideLinkMode}://file/${driveMatch[1]}${encodedPath}`;
+    }
+
+    return `${ideLinkMode}://file${encodeFilePathForUri(normalizedPath)}`;
 }

--- a/src/widgets/GitBranch.ts
+++ b/src/widgets/GitBranch.ts
@@ -11,6 +11,7 @@ import {
     runGit
 } from '../utils/git';
 import {
+    encodeGitRefForUrlPath,
     parseGitHubBaseUrl,
     renderOsc8Link
 } from '../utils/hyperlink';
@@ -81,7 +82,7 @@ export class GitBranchWidget implements Widget {
             const remoteUrl = runGit('remote get-url origin', context);
             const baseUrl = remoteUrl ? parseGitHubBaseUrl(remoteUrl) : null;
             if (baseUrl) {
-                return renderOsc8Link(`${baseUrl}/tree/${branch}`, displayText);
+                return renderOsc8Link(`${baseUrl}/tree/${encodeGitRefForUrlPath(branch)}`, displayText);
             }
         }
 

--- a/src/widgets/GitRootDir.ts
+++ b/src/widgets/GitRootDir.ts
@@ -10,7 +10,12 @@ import {
     isInsideGitWorkTree,
     runGit
 } from '../utils/git';
-import { renderOsc8Link } from '../utils/hyperlink';
+import type { IdeLinkMode } from '../utils/hyperlink';
+import {
+    IDE_LINK_MODES,
+    buildIdeFileUrl,
+    renderOsc8Link
+} from '../utils/hyperlink';
 
 import { makeModifierText } from './shared/editor-display';
 import {
@@ -19,13 +24,15 @@ import {
     handleToggleNoGitAction,
     isHideNoGitEnabled
 } from './shared/git-no-git';
-import {
-    isMetadataFlagEnabled,
-    toggleMetadataFlag
-} from './shared/metadata';
+import { isMetadataFlagEnabled } from './shared/metadata';
 
-const LINK_KEY = 'linkToCursor';
+const IDE_LINK_KEY = 'linkToIDE';
+const LEGACY_CURSOR_LINK_KEY = 'linkToCursor';
 const TOGGLE_LINK_ACTION = 'toggle-link';
+const IDE_LINK_LABELS: Record<IdeLinkMode, string> = {
+    vscode: 'link-vscode',
+    cursor: 'link-cursor'
+};
 
 export class GitRootDirWidget implements Widget {
     getDefaultColor(): string { return 'cyan'; }
@@ -33,13 +40,13 @@ export class GitRootDirWidget implements Widget {
     getDisplayName(): string { return 'Git Root Dir'; }
     getCategory(): string { return 'Git'; }
     getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
-        const isLink = isMetadataFlagEnabled(item, LINK_KEY);
+        const ideLinkMode = this.getIdeLinkMode(item);
         const modifiers: string[] = [];
         const noGitText = getHideNoGitModifierText(item);
         if (noGitText)
             modifiers.push('hide \'no git\'');
-        if (isLink)
-            modifiers.push('Cursor link');
+        if (ideLinkMode)
+            modifiers.push(IDE_LINK_LABELS[ideLinkMode]);
         return {
             displayText: this.getDisplayName(),
             modifierText: makeModifierText(modifiers)
@@ -48,18 +55,18 @@ export class GitRootDirWidget implements Widget {
 
     handleEditorAction(action: string, item: WidgetItem): WidgetItem | null {
         if (action === TOGGLE_LINK_ACTION) {
-            return toggleMetadataFlag(item, LINK_KEY);
+            return this.cycleIdeLinkMode(item);
         }
         return handleToggleNoGitAction(action, item);
     }
 
     render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
         const hideNoGit = isHideNoGitEnabled(item);
-        const isLink = isMetadataFlagEnabled(item, LINK_KEY);
+        const ideLinkMode = this.getIdeLinkMode(item);
 
         if (context.isPreview) {
             const name = 'my-repo';
-            return isLink ? renderOsc8Link('cursor://file/Users/example/my-repo', name) : name;
+            return ideLinkMode ? renderOsc8Link(buildIdeFileUrl('/Users/example/my-repo', ideLinkMode), name) : name;
         }
 
         if (!isInsideGitWorkTree(context)) {
@@ -73,8 +80,8 @@ export class GitRootDirWidget implements Widget {
 
         const name = this.getRootDirName(rootDir);
 
-        if (isLink) {
-            return renderOsc8Link(`cursor://file${rootDir}`, name);
+        if (ideLinkMode) {
+            return renderOsc8Link(buildIdeFileUrl(rootDir, ideLinkMode), name);
         }
 
         return name;
@@ -95,10 +102,45 @@ export class GitRootDirWidget implements Widget {
     getCustomKeybinds(): CustomKeybind[] {
         return [
             ...getHideNoGitKeybinds(),
-            { key: 'l', label: '(l)ink to Cursor', action: TOGGLE_LINK_ACTION }
+            { key: 'l', label: '(l)ink to IDE', action: TOGGLE_LINK_ACTION }
         ];
     }
 
     supportsRawValue(): boolean { return false; }
     supportsColors(item: WidgetItem): boolean { return true; }
+
+    private getIdeLinkMode(item: WidgetItem): IdeLinkMode | null {
+        const configuredMode = item.metadata?.[IDE_LINK_KEY];
+        if (configuredMode && IDE_LINK_MODES.includes(configuredMode as IdeLinkMode)) {
+            return configuredMode as IdeLinkMode;
+        }
+
+        if (isMetadataFlagEnabled(item, LEGACY_CURSOR_LINK_KEY)) {
+            return 'cursor';
+        }
+
+        return null;
+    }
+
+    private cycleIdeLinkMode(item: WidgetItem): WidgetItem {
+        const currentMode = this.getIdeLinkMode(item);
+        const currentIndex = currentMode ? IDE_LINK_MODES.indexOf(currentMode) : -1;
+        const nextMode = currentIndex === IDE_LINK_MODES.length - 1 ? null : (IDE_LINK_MODES[currentIndex + 1] ?? null);
+        const {
+            [IDE_LINK_KEY]: removedIdeLink,
+            [LEGACY_CURSOR_LINK_KEY]: removedLegacyLink,
+            ...restMetadata
+        } = item.metadata ?? {};
+
+        void removedIdeLink;
+        void removedLegacyLink;
+
+        return {
+            ...item,
+            metadata: nextMode ? {
+                ...restMetadata,
+                [IDE_LINK_KEY]: nextMode
+            } : (Object.keys(restMetadata).length > 0 ? restMetadata : undefined)
+        };
+    }
 }

--- a/src/widgets/Link.tsx
+++ b/src/widgets/Link.tsx
@@ -14,6 +14,7 @@ import type {
     WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
+import { renderOsc8Link } from '../utils/hyperlink';
 import { shouldInsertInput } from '../utils/input-guards';
 
 function isValidHttpUrl(url: string): boolean {
@@ -58,10 +59,6 @@ function buildMetadata(widget: WidgetItem, urlValue: string, textValue: string):
         ...widget,
         metadata
     };
-}
-
-function renderOsc8Link(url: string, text: string): string {
-    return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
 }
 
 function getLinkLabel(item: WidgetItem): { url: string; label: string } {

--- a/src/widgets/__tests__/GitBranch.test.ts
+++ b/src/widgets/__tests__/GitBranch.test.ts
@@ -10,6 +10,7 @@ import {
 import type { RenderContext } from '../../types/RenderContext';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { renderOsc8Link } from '../../utils/hyperlink';
 import { GitBranchWidget } from '../GitBranch';
 
 vi.mock('child_process', () => ({ execSync: vi.fn() }));
@@ -25,6 +26,8 @@ function render(options: {
     cwd?: string;
     hideNoGit?: boolean;
     isPreview?: boolean;
+    linkToGitHub?: boolean;
+    metadata?: Record<string, string>;
     rawValue?: boolean;
 } = {}) {
     const widget = new GitBranchWidget();
@@ -32,11 +35,16 @@ function render(options: {
         isPreview: options.isPreview,
         data: options.cwd ? { cwd: options.cwd } : undefined
     };
+    const metadata = {
+        ...options.metadata,
+        ...(options.hideNoGit ? { hideNoGit: 'true' } : {}),
+        ...(options.linkToGitHub ? { linkToGitHub: 'true' } : {})
+    };
     const item: WidgetItem = {
         id: 'git-branch',
         type: 'git-branch',
         rawValue: options.rawValue,
-        metadata: options.hideNoGit ? { hideNoGit: 'true' } : undefined
+        metadata: Object.keys(metadata).length > 0 ? metadata : undefined
     };
 
     return widget.render(item, context, DEFAULT_SETTINGS);
@@ -79,6 +87,17 @@ describe('GitBranchWidget', () => {
         expect(render({ rawValue: true })).toBe('feature/worktree');
     });
 
+    it('should render encoded GitHub branch links', () => {
+        mockExecSync.mockReturnValueOnce('true\n');
+        mockExecSync.mockReturnValueOnce('feature/issue#1');
+        mockExecSync.mockReturnValueOnce('ssh://git@github.com/owner/repo.git');
+
+        expect(render({ linkToGitHub: true })).toBe(renderOsc8Link(
+            'https://github.com/owner/repo/tree/feature/issue%231',
+            '⎇ feature/issue#1'
+        ));
+    });
+
     it('should render no git when probe returns false', () => {
         mockExecSync.mockReturnValue('false\n');
 
@@ -102,5 +121,13 @@ describe('GitBranchWidget', () => {
         mockExecSync.mockImplementation(() => { throw new Error('No git'); });
 
         expect(render()).toBe('⎇ no git');
+    });
+
+    it('should keep plain text when GitHub remote cannot be parsed', () => {
+        mockExecSync.mockReturnValueOnce('true\n');
+        mockExecSync.mockReturnValueOnce('feature/worktree');
+        mockExecSync.mockReturnValueOnce('https://gitlab.com/owner/repo.git');
+
+        expect(render({ linkToGitHub: true })).toBe('⎇ feature/worktree');
     });
 });

--- a/src/widgets/__tests__/GitRootDir.test.ts
+++ b/src/widgets/__tests__/GitRootDir.test.ts
@@ -10,6 +10,10 @@ import {
 import type { RenderContext } from '../../types/RenderContext';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import {
+    buildIdeFileUrl,
+    renderOsc8Link
+} from '../../utils/hyperlink';
 import { GitRootDirWidget } from '../GitRootDir';
 
 vi.mock('child_process', () => ({ execSync: vi.fn() }));
@@ -43,6 +47,19 @@ describe('GitRootDirWidget', () => {
 
     it('should render preview', () => {
         expect(render({ isPreview: true })).toBe('my-repo');
+    });
+
+    it('should render preview for vscode IDE links', () => {
+        const widget = new GitRootDirWidget();
+
+        expect(widget.render({
+            id: 'git-root-dir',
+            type: 'git-root-dir',
+            metadata: { linkToIDE: 'vscode' }
+        }, { isPreview: true }, DEFAULT_SETTINGS)).toBe(renderOsc8Link(
+            buildIdeFileUrl('/Users/example/my-repo', 'vscode'),
+            'my-repo'
+        ));
     });
 
     it('should render root directory name', () => {
@@ -83,6 +100,36 @@ describe('GitRootDirWidget', () => {
         expect(render()).toBe('C:');
     });
 
+    it('should render encoded vscode IDE links for repository roots', () => {
+        const widget = new GitRootDirWidget();
+        mockExecSync.mockReturnValueOnce('true\n');
+        mockExecSync.mockReturnValueOnce('C:/Work/my repo#1');
+
+        expect(widget.render({
+            id: 'git-root-dir',
+            type: 'git-root-dir',
+            metadata: { linkToIDE: 'vscode' }
+        }, {}, DEFAULT_SETTINGS)).toBe(renderOsc8Link(
+            buildIdeFileUrl('C:/Work/my repo#1', 'vscode'),
+            'my repo#1'
+        ));
+    });
+
+    it('should continue honoring legacy cursor link metadata', () => {
+        const widget = new GitRootDirWidget();
+        mockExecSync.mockReturnValueOnce('true\n');
+        mockExecSync.mockReturnValueOnce('/some/path/my repo#1');
+
+        expect(widget.render({
+            id: 'git-root-dir',
+            type: 'git-root-dir',
+            metadata: { linkToCursor: 'true' }
+        }, {}, DEFAULT_SETTINGS)).toBe(renderOsc8Link(
+            buildIdeFileUrl('/some/path/my repo#1', 'cursor'),
+            'my repo#1'
+        ));
+    });
+
     it('should render no git when probe returns false', () => {
         mockExecSync.mockReturnValue('false\n');
 
@@ -99,6 +146,52 @@ describe('GitRootDirWidget', () => {
         mockExecSync.mockImplementation(() => { throw new Error('No git'); });
 
         expect(render({ hideNoGit: true })).toBeNull();
+    });
+
+    it('should cycle IDE link modes in the editor', () => {
+        const widget = new GitRootDirWidget();
+        const base: WidgetItem = { id: 'git-root-dir', type: 'git-root-dir' };
+
+        const vscode = widget.handleEditorAction('toggle-link', base);
+        const cursor = widget.handleEditorAction('toggle-link', vscode ?? base);
+        const cleared = widget.handleEditorAction('toggle-link', cursor ?? base);
+
+        expect(vscode?.metadata?.linkToIDE).toBe('vscode');
+        expect(cursor?.metadata?.linkToIDE).toBe('cursor');
+        expect(cleared?.metadata?.linkToIDE).toBeUndefined();
+    });
+
+    it('should migrate legacy cursor metadata when cycling IDE link modes', () => {
+        const widget = new GitRootDirWidget();
+        const updated = widget.handleEditorAction('toggle-link', {
+            id: 'git-root-dir',
+            type: 'git-root-dir',
+            metadata: { linkToCursor: 'true' }
+        });
+
+        expect(updated?.metadata?.linkToCursor).toBeUndefined();
+        expect(updated?.metadata?.linkToIDE).toBeUndefined();
+    });
+
+    it('should show IDE link modifier text in the editor display', () => {
+        const widget = new GitRootDirWidget();
+        const display = widget.getEditorDisplay({
+            id: 'git-root-dir',
+            type: 'git-root-dir',
+            metadata: { linkToIDE: 'cursor' }
+        });
+
+        expect(display.modifierText).toBe('(link-cursor)');
+    });
+
+    it('should expose IDE link keybind', () => {
+        const widget = new GitRootDirWidget();
+
+        expect(widget.getCustomKeybinds()).toContainEqual({
+            key: 'l',
+            label: '(l)ink to IDE',
+            action: 'toggle-link'
+        });
     });
 
     it('should disable raw value support', () => {

--- a/src/widgets/__tests__/GitWidgetSharedBehavior.test.ts
+++ b/src/widgets/__tests__/GitWidgetSharedBehavior.test.ts
@@ -32,9 +32,9 @@ const cases: { name: string; itemType: string; widget: GitWidget }[] = [
 
 describe('Git widget shared behavior', () => {
     it.each(cases)('$name should expose hide-no-git keybind', ({ widget }) => {
-        expect(widget.getCustomKeybinds()).toEqual([
+        expect(widget.getCustomKeybinds()).toContainEqual(
             { key: 'h', label: '(h)ide \'no git\' message', action: 'toggle-nogit' }
-        ]);
+        );
     });
 
     it.each(cases)('$name should toggle hideNoGit metadata', ({ widget, itemType }) => {


### PR DESCRIPTION
## Summary

- **Git Branch** gains a `(l)ink to GitHub` toggle: when enabled, the branch name becomes a clickable OSC 8 terminal hyperlink pointing to `https://github.com/owner/repo/tree/<branch>`. Only activates when the git remote is a GitHub URL — non-GitHub remotes display plain text.
- **Git Root Dir** gains a `(l)ink to Cursor` toggle: when enabled, the project/subtree root name becomes a clickable `cursor://file/<path>` hyperlink that opens the directory in Cursor.
- New shared utility `src/utils/hyperlink.ts` provides `renderOsc8Link` and `parseGitHubBaseUrl` helpers, used by both widgets.

## Test plan

- [ ] In TUI, select Git Branch widget, press `l` to toggle GitHub link on/off — modifier text shows `(GitHub link)` when active
- [ ] In a GitHub-hosted repo, status line branch name is clickable and opens the correct GitHub tree URL
- [ ] In a non-GitHub repo (GitLab, Bitbucket, etc.), branch displays as plain text even with link enabled
- [ ] In TUI, select Git Root Dir widget, press `l` to toggle Cursor link on/off — modifier text shows `(Cursor link)` when active
- [ ] Status line project root name is clickable and opens the directory in Cursor
- [ ] All 17 existing GitBranch + GitRootDir tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)