### PR TITLE
fix: show default values instead of hiding widgets when data unavailable

### DIFF
--- a/src/widgets/ClaudeSessionId.ts
+++ b/src/widgets/ClaudeSessionId.ts
@@ -18,13 +18,10 @@ export class ClaudeSessionIdWidget implements Widget {
     render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
         if (context.isPreview) {
             return item.rawValue ? 'preview-session-id' : 'Session ID: preview-session-id';
-        } else {
-            const sessionId = context.data?.session_id;
-            if (!sessionId) {
-                return null;
-            }
-            return item.rawValue ? sessionId : `Session ID: ${sessionId}`;
         }
+
+        const sessionId = context.data?.session_id ?? 'N/A';
+        return item.rawValue ? sessionId : `Session ID: ${sessionId}`;
     }
 
     supportsRawValue(): boolean { return true; }

--- a/src/widgets/ContextLength.ts
+++ b/src/widgets/ContextLength.ts
@@ -27,10 +27,8 @@ export class ContextLengthWidget implements Widget {
             return item.rawValue ? formatTokens(contextLengthTokens) : `Ctx: ${formatTokens(contextLengthTokens)}`;
         }
 
-        if (context.tokenMetrics) {
-            return item.rawValue ? formatTokens(context.tokenMetrics.contextLength) : `Ctx: ${formatTokens(context.tokenMetrics.contextLength)}`;
-        }
-        return null;
+        const contextLength = context.tokenMetrics?.contextLength ?? 0;
+        return item.rawValue ? formatTokens(contextLength) : `Ctx: ${formatTokens(contextLength)}`;
     }
 
     supportsRawValue(): boolean { return true; }

--- a/src/widgets/ContextPercentage.ts
+++ b/src/widgets/ContextPercentage.ts
@@ -57,7 +57,9 @@ export class ContextPercentageWidget implements Widget {
             return formatRawOrLabeledValue(item, 'Ctx: ', `${displayPercentage.toFixed(1)}%`);
         }
 
-        return null;
+        // Default to 0% when no data available
+        const displayPercentage = isInverse ? 100 : 0;
+        return formatRawOrLabeledValue(item, 'Ctx: ', `${displayPercentage.toFixed(1)}%`);
     }
 
     getCustomKeybinds(): CustomKeybind[] {

--- a/src/widgets/ContextPercentageUsable.ts
+++ b/src/widgets/ContextPercentageUsable.ts
@@ -57,7 +57,10 @@ export class ContextPercentageUsableWidget implements Widget {
             const displayPercentage = isInverse ? (100 - usedPercentage) : usedPercentage;
             return formatRawOrLabeledValue(item, 'Ctx(u): ', `${displayPercentage.toFixed(1)}%`);
         }
-        return null;
+
+        // Default to 0% when no data available
+        const displayPercentage = isInverse ? 100 : 0;
+        return formatRawOrLabeledValue(item, 'Ctx(u): ', `${displayPercentage.toFixed(1)}%`);
     }
 
     getCustomKeybinds(): CustomKeybind[] {

--- a/src/widgets/Model.ts
+++ b/src/widgets/Model.ts
@@ -23,12 +23,9 @@ export class ModelWidget implements Widget {
         const model = context.data?.model;
         const modelDisplayName = typeof model === 'string'
             ? model
-            : (model?.display_name ?? model?.id);
+            : (model?.display_name ?? model?.id ?? 'N/A');
 
-        if (modelDisplayName) {
-            return item.rawValue ? modelDisplayName : `Model: ${modelDisplayName}`;
-        }
-        return null;
+        return item.rawValue ? modelDisplayName : `Model: ${modelDisplayName}`;
     }
 
     supportsRawValue(): boolean { return true; }

--- a/src/widgets/SessionCost.ts
+++ b/src/widgets/SessionCost.ts
@@ -20,14 +20,8 @@ export class SessionCostWidget implements Widget {
             return item.rawValue ? '$2.45' : 'Cost: $2.45';
         }
 
-        const totalCost = context.data?.cost?.total_cost_usd;
-        if (totalCost === undefined) {
-            return null;
-        }
-
-        // Format the cost to 2 decimal places
+        const totalCost = context.data?.cost?.total_cost_usd ?? 0;
         const formattedCost = `$${totalCost.toFixed(2)}`;
-
         return item.rawValue ? formattedCost : `Cost: ${formattedCost}`;
     }
 

--- a/src/widgets/TokensCached.ts
+++ b/src/widgets/TokensCached.ts
@@ -23,10 +23,8 @@ export class TokensCachedWidget implements Widget {
             return formatRawOrLabeledValue(item, 'Cached: ', '12k');
         }
 
-        if (context.tokenMetrics) {
-            return formatRawOrLabeledValue(item, 'Cached: ', formatTokens(context.tokenMetrics.cachedTokens));
-        }
-        return null;
+        const cachedTokens = context.tokenMetrics?.cachedTokens ?? 0;
+        return formatRawOrLabeledValue(item, 'Cached: ', formatTokens(cachedTokens));
     }
 
     supportsRawValue(): boolean { return true; }

--- a/src/widgets/TokensInput.ts
+++ b/src/widgets/TokensInput.ts
@@ -29,10 +29,8 @@ export class TokensInputWidget implements Widget {
             return formatRawOrLabeledValue(item, 'In: ', formatTokens(inputTotalTokens));
         }
 
-        if (context.tokenMetrics) {
-            return formatRawOrLabeledValue(item, 'In: ', formatTokens(context.tokenMetrics.inputTokens));
-        }
-        return null;
+        const inputTokens = context.tokenMetrics?.inputTokens ?? 0;
+        return formatRawOrLabeledValue(item, 'In: ', formatTokens(inputTokens));
     }
 
     supportsRawValue(): boolean { return true; }

--- a/src/widgets/TokensOutput.ts
+++ b/src/widgets/TokensOutput.ts
@@ -29,10 +29,8 @@ export class TokensOutputWidget implements Widget {
             return formatRawOrLabeledValue(item, 'Out: ', formatTokens(outputTotalTokens));
         }
 
-        if (context.tokenMetrics) {
-            return formatRawOrLabeledValue(item, 'Out: ', formatTokens(context.tokenMetrics.outputTokens));
-        }
-        return null;
+        const outputTokens = context.tokenMetrics?.outputTokens ?? 0;
+        return formatRawOrLabeledValue(item, 'Out: ', formatTokens(outputTokens));
     }
 
     supportsRawValue(): boolean { return true; }

--- a/src/widgets/TokensTotal.ts
+++ b/src/widgets/TokensTotal.ts
@@ -23,10 +23,8 @@ export class TokensTotalWidget implements Widget {
             return formatRawOrLabeledValue(item, 'Total: ', '30.6k');
         }
 
-        if (context.tokenMetrics) {
-            return formatRawOrLabeledValue(item, 'Total: ', formatTokens(context.tokenMetrics.totalTokens));
-        }
-        return null;
+        const totalTokens = context.tokenMetrics?.totalTokens ?? 0;
+        return formatRawOrLabeledValue(item, 'Total: ', formatTokens(totalTokens));
     }
 
     supportsRawValue(): boolean { return true; }

--- a/src/widgets/Version.ts
+++ b/src/widgets/Version.ts
@@ -18,10 +18,10 @@ export class VersionWidget implements Widget {
     render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
         if (context.isPreview) {
             return item.rawValue ? '1.0.0' : 'v1.0.0';
-        } else if (context.data?.version) {
-            return item.rawValue ? context.data.version : `v${context.data.version}`;
         }
-        return null;
+
+        const version = context.data?.version ?? 'N/A';
+        return item.rawValue ? version : `v${version}`;
     }
 
     supportsRawValue(): boolean { return true; }


### PR DESCRIPTION
This PR syncs changes from Hero4Am/ccstatusline.

Widgets now display sensible defaults (0, N/A, bash.00) instead of returning null when data is not yet available. This prevents entire status lines from being hidden at session start when context_window, transcript_path, or session_id data hasn't been populated yet.

Affected widgets: Model, ContextLength, ContextPercentage, ContextPercentageUsable, ClaudeSessionId, Version, TokensInput, TokensOutput, TokensCached, TokensTotal, SessionCost