### PR TITLE
feat: Configurable terminal tab title

### DIFF
--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -28,6 +28,7 @@ import {
     renderStatusLine
 } from './utils/renderer';
 import { advanceGlobalSeparatorIndex } from './utils/separator-index';
+import { resolveTerminalTitle } from './utils/terminal-title';
 import {
     getSkillsFilePath,
     getSkillsMetrics
@@ -178,6 +179,16 @@ async function renderMultipleLines(data: StatusJSON) {
 
                 globalSeparatorIndex = advanceGlobalSeparatorIndex(globalSeparatorIndex, lineItems);
             }
+        }
+    }
+
+    // Emit terminal tab title if configured
+    if (settings.terminalTitle.enabled) {
+        const title = resolveTerminalTitle(settings.terminalTitle.template, context);
+        if (title) {
+            // OSC 1 sets the terminal tab title; write to stderr to avoid
+            // interfering with the status line output on stdout
+            process.stderr.write(`\x1b]1;${title}\x07`);
         }
     }
 

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -58,6 +58,10 @@ export const SettingsSchema = z.object({
         theme: undefined,
         autoAlign: false
     }),
+    terminalTitle: z.object({
+        enabled: z.boolean().default(false),
+        template: z.string().default('{task} | {repo}/{branch}')
+    }).default({ enabled: false, template: '{task} | {repo}/{branch}' }),
     updatemessage: z.object({
         message: z.string().nullable().optional(),
         remaining: z.number().nullable().optional()

--- a/src/utils/__tests__/terminal-title.test.ts
+++ b/src/utils/__tests__/terminal-title.test.ts
@@ -1,0 +1,109 @@
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+
+// Mock homedir for task file reads
+vi.mock('os', async () => {
+    const actual = await vi.importActual('os');
+    return {
+        ...actual,
+        homedir: () => join(tmpdir(), 'ccstatusline-test-home')
+    };
+});
+
+// Mock git commands
+vi.mock('../git', () => ({
+    runGit: (cmd: string) => {
+        if (cmd === 'branch --show-current') return 'main';
+        if (cmd === 'rev-parse --show-toplevel') return '/Users/test/my-repo';
+        return null;
+    }
+}));
+
+// Import after mocks
+const { resolveTerminalTitle } = await import('../terminal-title');
+
+function taskDir(): string {
+    return join(tmpdir(), 'ccstatusline-test-home', '.cache', 'ccstatusline', 'tasks');
+}
+
+function writeTask(sessionId: string, data: Record<string, string>): void {
+    const dir = taskDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `claude-task-${sessionId}`), JSON.stringify(data), 'utf8');
+}
+
+const baseContext: RenderContext = {
+    data: {
+        session_id: 'test-session',
+        model: { display_name: 'Opus 4.6' },
+        workspace: { current_dir: '/Users/test/my-repo' }
+    }
+};
+
+describe('resolveTerminalTitle', () => {
+    beforeEach(() => {
+        mkdirSync(taskDir(), { recursive: true });
+    });
+
+    afterEach(() => {
+        try { rmSync(taskDir(), { recursive: true, force: true }); } catch { /* ignore */ }
+    });
+
+    it('resolves repo and branch', () => {
+        const result = resolveTerminalTitle('{repo}/{branch}', baseContext);
+        expect(result).toBe('my-repo/main');
+    });
+
+    it('resolves model', () => {
+        const result = resolveTerminalTitle('{model}', baseContext);
+        expect(result).toBe('Opus 4.6');
+    });
+
+    it('resolves dir', () => {
+        const result = resolveTerminalTitle('{dir}', baseContext);
+        expect(result).toBe('my-repo');
+    });
+
+    it('resolves task from file', () => {
+        writeTask('test-session', { task: 'Fix auth bug' });
+        const result = resolveTerminalTitle('{task}', baseContext);
+        expect(result).toBe('Fix auth bug');
+    });
+
+    it('drops empty segments', () => {
+        // No task file exists, so {task} is empty
+        const result = resolveTerminalTitle('{task} | {repo}/{branch}', baseContext);
+        expect(result).toBe('my-repo/main');
+    });
+
+    it('keeps both segments when task exists', () => {
+        writeTask('test-session', { task: 'Build API' });
+        const result = resolveTerminalTitle('{task} | {repo}/{branch}', baseContext);
+        expect(result).toBe('Build API | my-repo/main');
+    });
+
+    it('returns null when all segments are empty', () => {
+        const emptyContext: RenderContext = { data: {} };
+        const result = resolveTerminalTitle('{task}', emptyContext);
+        expect(result).toBeNull();
+    });
+
+    it('handles string model format', () => {
+        const ctx: RenderContext = {
+            data: { model: 'Claude Haiku' }
+        };
+        const result = resolveTerminalTitle('{model}', ctx);
+        expect(result).toBe('Claude Haiku');
+    });
+});

--- a/src/utils/terminal-title.ts
+++ b/src/utils/terminal-title.ts
@@ -1,14 +1,16 @@
 import { readFileSync } from 'fs';
+import { homedir } from 'os';
 import { basename, join } from 'path';
 
 import type { RenderContext } from '../types/RenderContext';
-import { getTaskDir } from '../widgets/TaskObjective';
 
 import { runGit } from './git';
 
+const TASK_DIR = join(homedir(), '.cache', 'ccstatusline', 'tasks');
+
 function getTaskFromFile(sessionId: string): string | null {
     try {
-        const content = readFileSync(join(getTaskDir(), `claude-task-${sessionId}`), 'utf8').trim();
+        const content = readFileSync(join(TASK_DIR, `claude-task-${sessionId}`), 'utf8').trim();
         if (!content) return null;
         try {
             const data = JSON.parse(content) as { task?: string };

--- a/src/utils/terminal-title.ts
+++ b/src/utils/terminal-title.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'fs';
+import { basename, join } from 'path';
+
+import type { RenderContext } from '../types/RenderContext';
+import { getTaskDir } from '../widgets/TaskObjective';
+
+import { runGit } from './git';
+
+function getTaskFromFile(sessionId: string): string | null {
+    try {
+        const content = readFileSync(join(getTaskDir(), `claude-task-${sessionId}`), 'utf8').trim();
+        if (!content) return null;
+        try {
+            const data = JSON.parse(content) as { task?: string };
+            return data.task ?? null;
+        } catch {
+            return content.split('\n')[0] ?? null;
+        }
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Resolve a terminal title template string.
+ *
+ * Supported placeholders:
+ *   {task}   - task objective from the session task file
+ *   {repo}   - git repository name
+ *   {branch} - current git branch
+ *   {model}  - model display name
+ *   {dir}    - current working directory basename
+ *
+ * Segments separated by ' | ' are dropped if all their placeholders resolved
+ * to empty, so "Task: {task} | {repo}/{branch}" gracefully falls back to
+ * just "{repo}/{branch}" when no task is set.
+ */
+export function resolveTerminalTitle(template: string, context: RenderContext): string | null {
+    const sessionId = context.data?.session_id;
+    const task = sessionId ? getTaskFromFile(sessionId) : null;
+    const branch = runGit('branch --show-current', context);
+    const repoPath = runGit('rev-parse --show-toplevel', context);
+    const repo = repoPath ? basename(repoPath) : null;
+    const model = typeof context.data?.model === 'string'
+        ? context.data.model
+        : context.data?.model?.display_name ?? null;
+    const dir = context.data?.workspace?.current_dir
+        ? basename(context.data.workspace.current_dir)
+        : null;
+
+    const vars: Record<string, string | null> = {
+        task, repo, branch, model, dir
+    };
+
+    // Split by ' | ' segments, resolve each, drop empty segments
+    const segments = template.split(' | ').map(segment => {
+        const resolved = segment.replace(/\{(\w+)\}/g, (_, key: string) => vars[key] ?? '');
+        // If the segment is empty after resolving (all placeholders were empty), skip it
+        return resolved.trim();
+    }).filter(s => s.length > 0);
+
+    if (segments.length === 0) return null;
+    return segments.join(' | ');
+}

--- a/src/widgets/__tests__/CurrentWorkingDir.test.ts
+++ b/src/widgets/__tests__/CurrentWorkingDir.test.ts
@@ -48,6 +48,10 @@ describe('CurrentWorkingDirWidget', () => {
             startCaps: [],
             endCaps: [],
             autoAlign: false
+        },
+        terminalTitle: {
+            enabled: false,
+            template: '{task} | {repo}/{branch}'
         }
     };
 


### PR DESCRIPTION
## Summary

Sets the terminal tab title via OSC 1 escape sequence after each status line render, using a configurable template with smart segment dropping.

- Template placeholders: `{task}`, `{repo}`, `{branch}`, `{model}`, `{dir}`
- Segments separated by ` | ` are dropped when all their placeholders resolve to empty
- Example: `{task} | {repo}/{branch}` falls back to `{repo}/{branch}` when no task is set
- Title emitted via stderr to avoid interfering with stdout status line output

### Configuration

```json
{
  "terminalTitle": {
    "enabled": false,
    "template": "{task} | {repo}/{branch}"
  }
}
```

Disabled by default. Supported by most modern terminals (iTerm2, Terminal.app, Windows Terminal).

### Files changed
- `src/utils/terminal-title.ts` — template resolver (new)
- `src/utils/__tests__/terminal-title.test.ts` — tests (new)
- `src/types/Settings.ts` — added `terminalTitle` to schema
- `src/ccstatusline.ts` — emit title after render
- `src/widgets/__tests__/CurrentWorkingDir.test.ts` — test fixture update

The `{task}` placeholder reads task files from `~/.cache/ccstatusline/tasks/` if they exist (e.g., written by the task-objective widget in #263), but works independently — all other placeholders resolve from git and the Claude Code status JSON.

## Test plan

- [x] Unit tests for template resolution, segment dropping, task file reading
- [ ] Enable terminal title in config, verify tab title updates
- [ ] Verify `{task}` gracefully resolves to empty when no task files exist
- [ ] Disable terminal title, verify tab title stops updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)
