### PR TITLE
fix: detect claude-sonnet-4-6 as 1M context window by default

### DIFF
--- a/src/utils/__tests__/model-context.test.ts
+++ b/src/utils/__tests__/model-context.test.ts
@@ -104,6 +104,29 @@ describe('getContextConfig', () => {
         });
     });
 
+    describe('Models with 1M context as default (no suffix required)', () => {
+        it('should return 1M context window for claude-sonnet-4-6', () => {
+            const config = getContextConfig('claude-sonnet-4-6');
+
+            expect(config.maxTokens).toBe(1000000);
+            expect(config.usableTokens).toBe(800000);
+        });
+
+        it('should return 1M context window for claude-sonnet-4-6 with Bedrock prefix', () => {
+            const config = getContextConfig('us.anthropic.claude-sonnet-4-6-20260101-v1:0');
+
+            expect(config.maxTokens).toBe(1000000);
+            expect(config.usableTokens).toBe(800000);
+        });
+
+        it('should still prioritise explicit context_window_size over known-1M-default lookup', () => {
+            const config = getContextConfig('claude-sonnet-4-6', 200000);
+
+            expect(config.maxTokens).toBe(200000);
+            expect(config.usableTokens).toBe(160000);
+        });
+    });
+
     describe('Older/default models', () => {
         it('should return 200k context window for older Sonnet 3.5 model', () => {
             const config = getContextConfig('claude-3-5-sonnet-20241022');

--- a/src/utils/model-context.ts
+++ b/src/utils/model-context.ts
@@ -11,6 +11,13 @@ interface ModelIdentifier {
 const DEFAULT_CONTEXT_WINDOW_SIZE = 200000;
 const USABLE_CONTEXT_RATIO = 0.8;
 
+// Models where 1M context is the default (not an opt-in variant requiring a [1m] suffix).
+// Sonnet 4.6 and later report as plain "claude-sonnet-4-6" with no size hint in the display
+// name, unlike Opus 4.6 which reports as "Opus 4.6 (1M context)".
+const DEFAULT_1M_CONTEXT_MODEL_PREFIXES = [
+    'claude-sonnet-4-6',
+];
+
 function toValidWindowSize(value: number | null | undefined): number | null {
     if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
         return null;
@@ -97,6 +104,15 @@ export function getContextConfig(modelIdentifier?: string, contextWindowSize?: n
         return {
             maxTokens: inferredWindowSize,
             usableTokens: Math.floor(inferredWindowSize * USABLE_CONTEXT_RATIO)
+        };
+    }
+
+    // Fall back to known 1M-default models for cases where the display name
+    // doesn't include a context size hint (e.g. "claude-sonnet-4-6").
+    if (DEFAULT_1M_CONTEXT_MODEL_PREFIXES.some(prefix => modelIdentifier.includes(prefix))) {
+        return {
+            maxTokens: 1_000_000,
+            usableTokens: Math.floor(1_000_000 * USABLE_CONTEXT_RATIO)
         };
     }
 


### PR DESCRIPTION
## Problem

`claude-sonnet-4-6` reports its model identifier without a context size hint (e.g. no `(1M context)` in the display name). This causes `getContextConfig` to fall through to the 200K default, showing inflated context percentages (~5× too high).

Contrast with `claude-opus-4-6`, which reports display name `"Opus 4.6 (1M context)"` — the existing regex catches that correctly.

## Root cause

The `parseContextWindowSize` function relies on the model identifier containing a size hint like `[1m]`, `(1M)`, or `1M context`. For Sonnet 4.5, 1M was an opt-in variant (hence the `[1m]` suffix). For **Sonnet 4.6, 1M is the default** — but the display name Claude Code reports is just `"Claude Sonnet 4.6"`, with no size hint.

## Fix

Add a `DEFAULT_1M_CONTEXT_MODEL_PREFIXES` lookup that catches model identifiers containing `claude-sonnet-4-6` (including AWS Bedrock-prefixed variants) and returns 1M when the regex inference fails.

Explicit `context_window_size` from the status JSON still takes full precedence over this lookup.

## Tests

Three new test cases in `model-context.test.ts`:
- Plain `claude-sonnet-4-6` → 1M ✓
- Bedrock-prefixed `us.anthropic.claude-sonnet-4-6-...-v1:0` → 1M ✓  
- Explicit `contextWindowSize: 200000` still overrides → 200K ✓

All 22 tests pass.