### PR TITLE
Scope usage per CLAUDE_CONFIG_DIR, includin authentication

### DIFF
--- a/src/utils/__tests__/usage-fetch.test.ts
+++ b/src/utils/__tests__/usage-fetch.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
+import { createHash } from 'node:crypto';
 import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
@@ -129,8 +130,11 @@ https.request = (...args) => {
 
 const { fetchUsageData } = await import(${JSON.stringify(usageModulePath)});
 
-const lockFile = path.join(os.homedir(), '.cache', 'ccstatusline', 'usage.lock');
-const cacheFile = path.join(os.homedir(), '.cache', 'ccstatusline', 'usage.json');
+import { createHash as _createHash } from 'node:crypto';
+const _claudeConfigDir = process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), '.claude');
+const _configHash = _createHash('sha256').update(path.resolve(_claudeConfigDir)).digest('hex').slice(0, 16);
+const lockFile = path.join(os.homedir(), '.cache', 'ccstatusline', 'usage-' + _configHash + '.lock');
+const cacheFile = path.join(os.homedir(), '.cache', 'ccstatusline', 'usage-' + _configHash + '.json');
 const nowMs = Number(process.env.TEST_NOW_MS || Date.now());
 Date.now = () => nowMs;
 
@@ -574,7 +578,8 @@ describe('fetchUsageData error handling', () => {
         try {
             const home = harness.createTokenHome('legacy-lock');
             const lockDir = path.join(home.home, '.cache', 'ccstatusline');
-            const lockFile = path.join(lockDir, 'usage.lock');
+            const configHash = createHash('sha256').update(path.resolve(home.claudeConfig)).digest('hex').slice(0, 16);
+            const lockFile = path.join(lockDir, `usage-${configHash}.lock`);
 
             fs.mkdirSync(lockDir, { recursive: true });
             fs.writeFileSync(lockFile, '');
@@ -591,6 +596,37 @@ describe('fetchUsageData error handling', () => {
             expect(result.first).toEqual({ error: 'timeout' });
             expect(result.second).toEqual({ error: 'timeout' });
             expect(result.requestCount).toBe(0);
+        } finally {
+            harness.cleanup();
+        }
+    });
+
+    it('falls back to credentials file when CLAUDE_CONFIG_DIR is set and keychain is unavailable', () => {
+        const harness = createProbeHarness();
+
+        try {
+            const home = harness.createTokenHome('creds-file-fallback');
+
+            // Run with CLAUDE_CONFIG_DIR set but no security binary in PATH.
+            // The config-dir-specific keychain lookup and default keychain lookup
+            // both fail, so it should fall back to the credentials file.
+            const result = harness.runProbe({
+                claudeConfigDir: home.claudeConfig,
+                home: home.home,
+                mode: 'success',
+                nowMs,
+                pathDir: '/nonexistent',
+                responseBody: successResponseBody
+            });
+
+            expect(result.first).toEqual({
+                sessionUsage: 42,
+                sessionResetAt: '2030-01-01T00:00:00.000Z',
+                weeklyUsage: 17,
+                weeklyResetAt: '2030-01-07T00:00:00.000Z'
+            });
+            expect(result.requestCount).toBe(1);
+            expect(result.requestHost).toBe('api.anthropic.com');
         } finally {
             harness.cleanup();
         }

--- a/src/utils/usage-fetch.ts
+++ b/src/utils/usage-fetch.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as https from 'https';
 import { HttpsProxyAgent } from 'https-proxy-agent';
+import { createHash } from 'node:crypto';
 import * as os from 'os';
 import * as path from 'path';
 import { z } from 'zod';
@@ -15,8 +16,18 @@ import { UsageErrorSchema } from './usage-types';
 
 // Cache configuration
 const CACHE_DIR = path.join(os.homedir(), '.cache', 'ccstatusline');
-const CACHE_FILE = path.join(CACHE_DIR, 'usage.json');
-const LOCK_FILE = path.join(CACHE_DIR, 'usage.lock');
+
+function getUsageCachePath(): string {
+    const configDir = path.resolve(getClaudeConfigDir());
+    const configHash = createHash('sha256').update(configDir).digest('hex').slice(0, 16);
+    return path.join(CACHE_DIR, `usage-${configHash}.json`);
+}
+
+function getUsageLockPath(): string {
+    const configDir = path.resolve(getClaudeConfigDir());
+    const configHash = createHash('sha256').update(configDir).digest('hex').slice(0, 16);
+    return path.join(CACHE_DIR, `usage-${configHash}.lock`);
+}
 const CACHE_MAX_AGE = 180; // seconds
 const LOCK_MAX_AGE = 30;   // rate limit: only try API once per 30 seconds
 const DEFAULT_RATE_LIMIT_BACKOFF = 300; // seconds
@@ -301,19 +312,30 @@ function readUsageTokenFromCredentialsFile(): string | null {
     }
 }
 
+// Claude Code stores per-profile keychain entries with the service name
+// "Claude Code-credentials-{first 8 hex chars of SHA-256(configDir)}".
+function getMacKeychainServiceForConfigDir(): string {
+    const configDir = path.resolve(getClaudeConfigDir());
+    const suffix = createHash('sha256').update(configDir).digest('hex').slice(0, 8);
+    return `${MACOS_USAGE_CREDENTIALS_SERVICE}-${suffix}`;
+}
+
 export function getUsageToken(): string | null {
     if (process.platform !== 'darwin') {
         return readUsageTokenFromCredentialsFile();
     }
 
-    return readUsageTokenFromMacKeychainService(MACOS_USAGE_CREDENTIALS_SERVICE)
+    // Try the keychain entry specific to the current config dir first, then fall
+    // back to the default entry and the mtime-sorted candidate scan.
+    return readUsageTokenFromMacKeychainService(getMacKeychainServiceForConfigDir())
+        ?? readUsageTokenFromMacKeychainService(MACOS_USAGE_CREDENTIALS_SERVICE)
         ?? readUsageTokenFromMacKeychainCandidates()
         ?? readUsageTokenFromCredentialsFile();
 }
 
 function readStaleUsageCache(): UsageData | null {
     try {
-        return parseCachedUsageData(fs.readFileSync(CACHE_FILE, 'utf8'));
+        return parseCachedUsageData(fs.readFileSync(getUsageCachePath(), 'utf8'));
     } catch {
         return null;
     }
@@ -322,7 +344,7 @@ function readStaleUsageCache(): UsageData | null {
 function writeUsageLock(blockedUntil: number, error: UsageLockError): void {
     try {
         ensureCacheDirExists();
-        fs.writeFileSync(LOCK_FILE, JSON.stringify({ blockedUntil, error }));
+        fs.writeFileSync(getUsageLockPath(), JSON.stringify({ blockedUntil, error }));
     } catch {
         // Ignore lock file errors
     }
@@ -332,7 +354,7 @@ function readActiveUsageLock(now: number): { blockedUntil: number; error: UsageL
     let hasValidJsonLock = false;
 
     try {
-        const parsed = parseJsonWithSchema(fs.readFileSync(LOCK_FILE, 'utf8'), UsageLockSchema);
+        const parsed = parseJsonWithSchema(fs.readFileSync(getUsageLockPath(), 'utf8'), UsageLockSchema);
         if (parsed) {
             hasValidJsonLock = true;
             if (parsed.blockedUntil > now) {
@@ -352,7 +374,7 @@ function readActiveUsageLock(now: number): { blockedUntil: number; error: UsageL
     }
 
     try {
-        const lockStat = fs.statSync(LOCK_FILE);
+        const lockStat = fs.statSync(getUsageLockPath());
         const lockMtime = Math.floor(lockStat.mtimeMs / 1000);
         const blockedUntil = lockMtime + LOCK_MAX_AGE;
         if (blockedUntil > now) {
@@ -491,10 +513,11 @@ export async function fetchUsageData(): Promise<UsageData> {
 
     // Check file cache
     try {
-        const stat = fs.statSync(CACHE_FILE);
+        const usageCachePath = getUsageCachePath();
+        const stat = fs.statSync(usageCachePath);
         const fileAge = now - Math.floor(stat.mtimeMs / 1000);
         if (fileAge < CACHE_MAX_AGE) {
-            const fileData = parseCachedUsageData(fs.readFileSync(CACHE_FILE, 'utf8'));
+            const fileData = parseCachedUsageData(fs.readFileSync(usageCachePath, 'utf8'));
             if (fileData && !fileData.error) {
                 return cacheUsageData(fileData, now);
             }
@@ -546,7 +569,7 @@ export async function fetchUsageData(): Promise<UsageData> {
         // Save to cache
         try {
             ensureCacheDirExists();
-            fs.writeFileSync(CACHE_FILE, JSON.stringify(usageData));
+            fs.writeFileSync(getUsageCachePath(), JSON.stringify(usageData));
         } catch {
             // Ignore cache write errors
         }


### PR DESCRIPTION
This pull request updates the usage tracking logic to support multiple configuration profiles by scoping the usage cache and lock files to the current config directory. It also improves the logic for retrieving API credentials, especially on macOS, by first checking for a config-directory-specific keychain entry. The test suite has been updated to reflect these changes and add coverage for the new fallback behavior.

  The usage cache (usage.json) and lock file (usage.lock) were shared
  across all Claude Code profiles, causing session-usage, weekly-usage,
  reset-timer and weekly-reset-timer widgets to display data from the
  wrong account when CLAUDE_CONFIG_DIR pointed to a non-default profile.

  Replace the hardcoded file paths with per-profile paths using a
  SHA-256 hash of the resolved CLAUDE_CONFIG_DIR, matching the existing
  pattern used by getBlockCachePath() in jsonl-cache.ts.

  Claude Code stores per-profile credentials in the macOS keychain using the service
  name Claude Code-credentials-{sha256(configDir)[:8]}. For ~/.claude-boost, that's
  Claude Code-credentials-ac4e02fa. The old code never looked up this specific entry —
  it only tried the generic Claude Code-credentials service, then sorted all candidates by mtime.