### PR TITLE
fix: prevent UserPromptSubmit regex from matching Unix paths as skill names

### DIFF
--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -250,7 +250,7 @@ async function handleHook(): Promise<void> {
         if (data.hook_event_name === 'PreToolUse' && data.tool_name === 'Skill') {
             skillName = data.tool_input?.skill ?? '';
         } else if (data.hook_event_name === 'UserPromptSubmit') {
-            const match = /^\/([a-zA-Z0-9_:-]+)/.exec(data.prompt ?? '');
+            const match = /^\/([a-zA-Z0-9_:-]+)(?:\s|$)/.exec(data.prompt ?? '');
             if (match) {
                 skillName = match[1] ?? '';
             }


### PR DESCRIPTION
## Summary

Fixes #272

The `UserPromptSubmit` hook regex incorrectly matches Unix-style absolute paths (e.g., `/Users/...`, `/bin/...`, `/home/...`) as skill names, causing the Skills widget to display wrong values like "Users" or "bin".

## Changes

Changed the regex in `handleHook()` from:

```typescript
const match = /^\/([a-zA-Z0-9_:-]+)/.exec(data.prompt ?? '');
```

to:

```typescript
const match = /^\/([a-zA-Z0-9_:-]+)(?:\s|$)/.exec(data.prompt ?? '');
```

The key insight is the structural difference between a slash command and a file path: a skill name is followed by whitespace or end-of-string, while a path segment is followed by `/`. This makes the fix platform-agnostic — no need to enumerate OS-specific path prefixes.

## Test Plan

- [x] Simulated `UserPromptSubmit` with `/Users/username/projects/app` → no longer captured as "Users"
- [x] Simulated `UserPromptSubmit` with `/commit` → correctly captured as "commit"
- [x] Simulated `UserPromptSubmit` with `/pua:on` → correctly captured as "pua:on"
- [x] Simulated `PreToolUse` with `Skill` tool → unchanged, works correctly