### PR TITLE
fix: use formatTokens in ContextBar for proper M/k formatting

### DIFF
--- a/src/widgets/ContextBar.ts
+++ b/src/widgets/ContextBar.ts
@@ -11,6 +11,7 @@ import {
     getContextConfig,
     getModelContextIdentifier
 } from '../utils/model-context';
+import { formatTokens } from '../utils/renderer';
 import { makeUsageProgressBar } from '../utils/usage';
 
 type DisplayMode = 'progress' | 'progress-short';
@@ -61,7 +62,7 @@ export class ContextBarWidget implements Widget {
         const barWidth = displayMode === 'progress' ? 32 : 16;
 
         if (context.isPreview) {
-            const previewDisplay = `${makeUsageProgressBar(25, barWidth)} 50k/200k (25%)`;
+            const previewDisplay = `${makeUsageProgressBar(25, barWidth)} 50.0k/200.0k (25%)`;
             return item.rawValue ? previewDisplay : `Context: ${previewDisplay}`;
         }
 
@@ -86,9 +87,7 @@ export class ContextBarWidget implements Widget {
         const percent = (used / total) * 100;
         const clampedPercent = Math.max(0, Math.min(100, percent));
 
-        const usedK = Math.round(used / 1000);
-        const totalK = Math.round(total / 1000);
-        const display = `${makeUsageProgressBar(clampedPercent, barWidth)} ${usedK}k/${totalK}k (${Math.round(clampedPercent)}%)`;
+        const display = `${makeUsageProgressBar(clampedPercent, barWidth)} ${formatTokens(used)}/${formatTokens(total)} (${Math.round(clampedPercent)}%)`;
 
         return item.rawValue ? display : `Context: ${display}`;
     }


### PR DESCRIPTION
## Summary
- ContextBar widget was using inline `Math.round(used / 1000)` with a hardcoded `k` suffix, causing 1M context windows to display as `1000k`
- Now uses the shared `formatTokens()` utility from `renderer.ts` which shows `1.0M` for values >= 1M and `k` for smaller values
- This is consistent with how `ContextLength`, `TokensTotal`, and other widgets already format token counts

## Test plan
- [ ] Verify context bar shows `1.0M` for 1M context window models (e.g., Opus 4.6 [1m])
- [ ] Verify smaller values still show as `k` (e.g., `50.0k`)
- [ ] Run `bun test` to confirm no regressions