### PR TITLE
feat: add compaction-counter widget

### DIFF
--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -13,6 +13,11 @@ import { StatusJSONSchema } from './types/StatusJSON';
 import { getVisibleText } from './utils/ansi';
 import { updateColorMap } from './utils/colors';
 import {
+    detectCompaction,
+    loadCompactionState,
+    saveCompactionState
+} from './utils/compaction';
+import {
     initConfigPath,
     loadSettings,
     saveSettings
@@ -141,6 +146,17 @@ async function renderMultipleLines(data: StatusJSON) {
         skillsMetrics = getSkillsMetrics(data.session_id);
     }
 
+    // Compaction detection — track context percentage drops between renders
+    let compactionCount = 0;
+    const hasCompactionWidget = lines.some(line => line.some(item => item.type === 'compaction-counter'));
+    if (hasCompactionWidget && data.session_id && data.context_window?.used_percentage !== null && data.context_window?.used_percentage !== undefined) {
+        const prevState = loadCompactionState(data.session_id);
+        const ctxPct = Math.round(data.context_window.used_percentage);
+        const newState = detectCompaction(ctxPct, prevState);
+        saveCompactionState(data.session_id, newState);
+        compactionCount = newState.count;
+    }
+
     // Create render context
     const context: RenderContext = {
         data,
@@ -150,6 +166,7 @@ async function renderMultipleLines(data: StatusJSON) {
         usageData,
         sessionDuration,
         skillsMetrics,
+        compactionData: compactionCount > 0 ? { count: compactionCount } : null,
         isPreview: false,
         minimalist: settings.minimalistMode
     };

--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -49,6 +49,13 @@ function hasSessionDurationInStatusJson(data: StatusJSON): boolean {
     return typeof durationMs === 'number' && Number.isFinite(durationMs) && durationMs >= 0;
 }
 
+function hasContextPercentage(
+    data: StatusJSON
+): data is StatusJSON & { context_window: { used_percentage: number } } {
+    const pct = data.context_window?.used_percentage;
+    return typeof pct === 'number' && Number.isFinite(pct) && pct >= 0;
+}
+
 async function readStdin(): Promise<string | null> {
     // Check if stdin is a TTY (terminal) - if it is, there's no piped data
     if (process.stdin.isTTY) {
@@ -149,12 +156,16 @@ async function renderMultipleLines(data: StatusJSON) {
     // Compaction detection — track context percentage drops between renders
     let compactionCount = 0;
     const hasCompactionWidget = lines.some(line => line.some(item => item.type === 'compaction-counter'));
-    if (hasCompactionWidget && data.session_id && data.context_window?.used_percentage !== null && data.context_window?.used_percentage !== undefined) {
+    if (hasCompactionWidget && data.session_id) {
         const prevState = loadCompactionState(data.session_id);
-        const ctxPct = Math.round(data.context_window.used_percentage);
-        const newState = detectCompaction(ctxPct, prevState);
-        saveCompactionState(data.session_id, newState);
-        compactionCount = newState.count;
+        compactionCount = prevState.count;
+        if (hasContextPercentage(data)) {
+            const newState = detectCompaction(data.context_window.used_percentage, prevState);
+            if (newState.count !== prevState.count || newState.prevCtxPct !== prevState.prevCtxPct) {
+                saveCompactionState(data.session_id, newState);
+            }
+            compactionCount = newState.count;
+        }
     }
 
     // Create render context

--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -22,6 +22,7 @@ import {
     loadSettings,
     saveSettings
 } from './utils/config';
+import { calculateContextPercentageMetrics } from './utils/context-percentage';
 import {
     getSessionDuration,
     getSpeedMetricsCollection,
@@ -47,13 +48,6 @@ import { prefetchUsageDataIfNeeded } from './utils/usage-prefetch';
 function hasSessionDurationInStatusJson(data: StatusJSON): boolean {
     const durationMs = data.cost?.total_duration_ms;
     return typeof durationMs === 'number' && Number.isFinite(durationMs) && durationMs >= 0;
-}
-
-function hasContextPercentage(
-    data: StatusJSON
-): data is StatusJSON & { context_window: { used_percentage: number } } {
-    const pct = data.context_window?.used_percentage;
-    return typeof pct === 'number' && Number.isFinite(pct) && pct >= 0;
 }
 
 async function readStdin(): Promise<string | null> {
@@ -159,9 +153,14 @@ async function renderMultipleLines(data: StatusJSON) {
     if (hasCompactionWidget && data.session_id) {
         const prevState = loadCompactionState(data.session_id);
         compactionCount = prevState.count;
-        if (hasContextPercentage(data)) {
-            const newState = detectCompaction(data.context_window.used_percentage, prevState);
-            if (newState.count !== prevState.count || newState.prevCtxPct !== prevState.prevCtxPct) {
+        const contextPercentageMetrics = calculateContextPercentageMetrics({ data, tokenMetrics });
+        if (contextPercentageMetrics !== null) {
+            const newState = detectCompaction(contextPercentageMetrics.usedPercentage, prevState, { windowSize: contextPercentageMetrics.windowSize });
+            if (
+                newState.count !== prevState.count
+                || newState.prevCtxPct !== prevState.prevCtxPct
+                || newState.prevWindowSize !== prevState.prevWindowSize
+            ) {
                 saveCompactionState(data.session_id, newState);
             }
             compactionCount = newState.count;
@@ -177,7 +176,7 @@ async function renderMultipleLines(data: StatusJSON) {
         usageData,
         sessionDuration,
         skillsMetrics,
-        compactionData: compactionCount > 0 ? { count: compactionCount } : null,
+        compactionData: hasCompactionWidget ? { count: compactionCount } : null,
         isPreview: false,
         minimalist: settings.minimalistMode
     };

--- a/src/types/RenderContext.ts
+++ b/src/types/RenderContext.ts
@@ -19,6 +19,10 @@ export interface RenderUsageData {
     error?: 'no-credentials' | 'timeout' | 'rate-limited' | 'api-error' | 'parse-error';
 }
 
+export interface CompactionData {
+    count: number;
+}
+
 export interface RenderContext {
     data?: StatusJSON;
     tokenMetrics?: TokenMetrics | null;
@@ -28,6 +32,7 @@ export interface RenderContext {
     sessionDuration?: string | null;
     blockMetrics?: BlockMetrics | null;
     skillsMetrics?: SkillsMetrics | null;
+    compactionData?: CompactionData | null;
     terminalWidth?: number | null;
     isPreview?: boolean;
     minimalist?: boolean;

--- a/src/types/RenderContext.ts
+++ b/src/types/RenderContext.ts
@@ -19,9 +19,7 @@ export interface RenderUsageData {
     error?: 'no-credentials' | 'timeout' | 'rate-limited' | 'api-error' | 'parse-error';
 }
 
-export interface CompactionData {
-    count: number;
-}
+export interface CompactionData { count: number }
 
 export interface RenderContext {
     data?: StatusJSON;

--- a/src/utils/__tests__/compaction.test.ts
+++ b/src/utils/__tests__/compaction.test.ts
@@ -6,7 +6,8 @@ import {
     beforeEach,
     describe,
     expect,
-    it
+    it,
+    vi
 } from 'vitest';
 
 import {
@@ -16,10 +17,10 @@ import {
     type CompactionState
 } from '../compaction';
 
-const fresh: CompactionState = { count: 0, prevCtxPct: 0 };
+const fresh: CompactionState = { count: 0, prevCtxPct: -1 };
 
 describe('detectCompaction', () => {
-    it('does not detect on first render (no previous state)', () => {
+    it('does not detect on first render (sentinel prevCtxPct)', () => {
         const result = detectCompaction(40, fresh);
         expect(result.count).toBe(0);
         expect(result.prevCtxPct).toBe(40);
@@ -81,24 +82,74 @@ describe('detectCompaction', () => {
 
     it('accepts custom threshold', () => {
         const prev: CompactionState = { count: 0, prevCtxPct: 10 };
-        // 1-point drop with threshold=1 should detect
         const result = detectCompaction(8, prev, 1);
         expect(result.count).toBe(1);
+    });
+
+    it('returns state unchanged for NaN input (no poison)', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 40 };
+        expect(detectCompaction(NaN, prev)).toEqual(prev);
+    });
+
+    it('returns state unchanged for Infinity input', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 40 };
+        expect(detectCompaction(Infinity, prev)).toEqual(prev);
+    });
+
+    it('returns state unchanged for negative input', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 40 };
+        expect(detectCompaction(-1, prev)).toEqual(prev);
+    });
+
+    it('detects drops using non-integer percentages', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 40.4 };
+        // 2.8-point drop, exceeds default threshold of 2
+        const result = detectCompaction(37.6, prev);
+        expect(result.count).toBe(1);
+    });
+
+    it('handles a session that starts at 0% (sentinel guards first render)', () => {
+        // sequence: -1 (fresh) -> 0 -> 5 -> 30 -> 10
+        // First three transitions: no detection. Fourth (30 -> 10) is a real drop.
+        let state = fresh;
+        state = detectCompaction(0, state);
+        expect(state).toEqual({ count: 0, prevCtxPct: 0 });
+        state = detectCompaction(5, state);
+        expect(state.count).toBe(0);
+        state = detectCompaction(30, state);
+        expect(state.count).toBe(0);
+        state = detectCompaction(10, state);
+        expect(state.count).toBe(1);
+    });
+
+    it('detects multiple sequential compactions', () => {
+        // sequence: -1 (fresh) -> 40 -> 10 -> 50 -> 20
+        let state = fresh;
+        state = detectCompaction(40, state);
+        state = detectCompaction(10, state);
+        expect(state.count).toBe(1);
+        state = detectCompaction(50, state);
+        state = detectCompaction(20, state);
+        expect(state.count).toBe(2);
+    });
+
+    it('with threshold 0, every strict drop counts', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 10 };
+        expect(detectCompaction(9.5, prev, 0).count).toBe(1);
     });
 });
 
 describe('persistence', () => {
-    let testCacheDir: string;
-    const origHome = process.env.HOME;
+    let testHome: string;
 
     beforeEach(() => {
-        testCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compaction-test-'));
-        process.env.HOME = testCacheDir;
+        testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'compaction-test-'));
+        vi.spyOn(os, 'homedir').mockReturnValue(testHome);
     });
 
     afterEach(() => {
-        process.env.HOME = origHome;
-        fs.rmSync(testCacheDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+        fs.rmSync(testHome, { recursive: true, force: true });
     });
 
     it('round-trips state through save and load', () => {
@@ -110,28 +161,104 @@ describe('persistence', () => {
 
     it('returns fresh state for unknown session', () => {
         const loaded = loadCompactionState('nonexistent');
-        expect(loaded).toEqual({ count: 0, prevCtxPct: 0 });
+        expect(loaded).toEqual({ count: 0, prevCtxPct: -1 });
     });
 
     it('sanitizes path traversal in session ID', () => {
         const malicious = '../../../../../../tmp/pwn';
         saveCompactionState(malicious, { count: 1, prevCtxPct: 50 });
 
-        // File should be inside the cache dir, not at /tmp/pwn
-        const cacheDir = path.join(testCacheDir, '.cache', 'ccstatusline', 'compaction');
+        const cacheDir = path.join(testHome, '.cache', 'ccstatusline', 'compaction');
         const files = fs.existsSync(cacheDir) ? fs.readdirSync(cacheDir) : [];
         expect(files.length).toBe(1);
         expect(files[0]).toMatch(/^compaction-[a-zA-Z0-9_-]+\.json$/);
 
-        // /tmp/pwn.json should not exist
         expect(fs.existsSync('/tmp/pwn.json')).toBe(false);
     });
 
+    it('hashes session IDs that contain only illegal characters to avoid collision', () => {
+        // Without hashing, both '....' and '!!!!' would sanitize to '____' and collide.
+        saveCompactionState('....', { count: 1, prevCtxPct: 10 });
+        saveCompactionState('!!!!', { count: 2, prevCtxPct: 20 });
+        expect(loadCompactionState('....').count).toBe(1);
+        expect(loadCompactionState('!!!!').count).toBe(2);
+    });
+
+    it('hashes empty session ID to avoid blank filename leaf', () => {
+        saveCompactionState('', { count: 1, prevCtxPct: 10 });
+        const cacheDir = path.join(testHome, '.cache', 'ccstatusline', 'compaction');
+        const files = fs.readdirSync(cacheDir);
+        expect(files.length).toBe(1);
+        expect(files[0]).not.toBe('compaction-.json');
+        expect(files[0]).toMatch(/^compaction-[a-f0-9]{32}\.json$/);
+    });
+
     it('does not throw on write failure', () => {
-        // Point HOME at a non-writable path
-        process.env.HOME = '/nonexistent/readonly';
+        vi.spyOn(os, 'homedir').mockReturnValue('/nonexistent/readonly/path');
         expect(() => {
             saveCompactionState('test', { count: 1, prevCtxPct: 50 });
         }).not.toThrow();
+    });
+
+    it('returns fresh state when cache file has corrupted JSON', () => {
+        saveCompactionState('corrupt-test', { count: 5, prevCtxPct: 50 });
+        const cacheDir = path.join(testHome, '.cache', 'ccstatusline', 'compaction');
+        const cacheFile = path.join(cacheDir, fs.readdirSync(cacheDir)[0] ?? '');
+        fs.writeFileSync(cacheFile, '{ this is not valid json');
+
+        const loaded = loadCompactionState('corrupt-test');
+        expect(loaded).toEqual({ count: 0, prevCtxPct: -1 });
+    });
+
+    it('returns fresh state when cache file exceeds size cap', () => {
+        saveCompactionState('big-test', { count: 5, prevCtxPct: 50 });
+        const cacheDir = path.join(testHome, '.cache', 'ccstatusline', 'compaction');
+        const cacheFile = path.join(cacheDir, fs.readdirSync(cacheDir)[0] ?? '');
+        fs.writeFileSync(cacheFile, 'a'.repeat(8192));
+
+        const loaded = loadCompactionState('big-test');
+        expect(loaded).toEqual({ count: 0, prevCtxPct: -1 });
+    });
+
+    it.skipIf(process.platform === 'win32')('returns fresh state when cache path is a symlink', () => {
+        const cacheDir = path.join(testHome, '.cache', 'ccstatusline', 'compaction');
+        fs.mkdirSync(cacheDir, { recursive: true });
+        const realPath = path.join(testHome, 'real.json');
+        fs.writeFileSync(realPath, JSON.stringify({ count: 99, prevCtxPct: 50 }));
+
+        // sessionId 'symlink-test' has only legal chars, so the cache filename
+        // is deterministically compaction-symlink-test.json
+        const sessionId = 'symlink-test';
+        const symlinkPath = path.join(cacheDir, `compaction-${sessionId}.json`);
+        fs.symlinkSync(realPath, symlinkPath);
+
+        const loaded = loadCompactionState(sessionId);
+        expect(loaded).toEqual({ count: 0, prevCtxPct: -1 });
+    });
+
+    it('uses zod defaults for missing fields in cache file', () => {
+        const cacheDir = path.join(testHome, '.cache', 'ccstatusline', 'compaction');
+        fs.mkdirSync(cacheDir, { recursive: true });
+        const cacheFile = path.join(cacheDir, 'compaction-partial.json');
+        fs.writeFileSync(cacheFile, JSON.stringify({}));
+
+        const loaded = loadCompactionState('partial');
+        expect(loaded).toEqual({ count: 0, prevCtxPct: -1 });
+    });
+
+    it.skipIf(process.platform === 'win32')('atomic save replaces a planted symlink rather than writing through it', () => {
+        const cacheDir = path.join(testHome, '.cache', 'ccstatusline', 'compaction');
+        fs.mkdirSync(cacheDir, { recursive: true });
+        const sessionId = 'rename-test';
+        const targetPath = path.join(cacheDir, `compaction-${sessionId}.json`);
+        const decoyTarget = path.join(testHome, 'decoy.txt');
+        fs.writeFileSync(decoyTarget, 'do not overwrite me');
+        fs.symlinkSync(decoyTarget, targetPath);
+
+        saveCompactionState(sessionId, { count: 1, prevCtxPct: 30 });
+
+        // The decoy must be untouched; the cache path is now a regular file.
+        expect(fs.readFileSync(decoyTarget, 'utf-8')).toBe('do not overwrite me');
+        expect(fs.lstatSync(targetPath).isFile()).toBe(true);
     });
 });

--- a/src/utils/__tests__/compaction.test.ts
+++ b/src/utils/__tests__/compaction.test.ts
@@ -1,0 +1,81 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import {
+    detectCompaction,
+    type CompactionState
+} from '../compaction';
+
+const fresh: CompactionState = { count: 0, prevCtxPct: 0 };
+
+describe('detectCompaction', () => {
+    it('does not detect on first render (no previous state)', () => {
+        const result = detectCompaction(40, fresh);
+        expect(result.count).toBe(0);
+        expect(result.prevCtxPct).toBe(40);
+    });
+
+    it('detects compaction when ctx drops by more than 2 points', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 40 };
+        const result = detectCompaction(30, prev);
+        expect(result.count).toBe(1);
+    });
+
+    it('does not detect when ctx drops by exactly 2 points', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 40 };
+        const result = detectCompaction(38, prev);
+        expect(result.count).toBe(0);
+    });
+
+    it('does not detect when ctx drops by 1 point (rounding noise)', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 8 };
+        const result = detectCompaction(7, prev);
+        expect(result.count).toBe(0);
+    });
+
+    it('does not detect when ctx increases', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 40 };
+        const result = detectCompaction(45, prev);
+        expect(result.count).toBe(0);
+    });
+
+    it('does not detect when ctx stays the same', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 40 };
+        const result = detectCompaction(40, prev);
+        expect(result.count).toBe(0);
+    });
+
+    it('detects 3-point drop on 1M window', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 8 };
+        const result = detectCompaction(5, prev);
+        expect(result.count).toBe(1);
+    });
+
+    it('detects large compaction on 200K window', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 85 };
+        const result = detectCompaction(30, prev);
+        expect(result.count).toBe(1);
+    });
+
+    it('increments existing count', () => {
+        const prev: CompactionState = { count: 3, prevCtxPct: 70 };
+        const result = detectCompaction(40, prev);
+        expect(result.count).toBe(4);
+    });
+
+    it('updates prevCtxPct regardless of detection', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 40 };
+        const result = detectCompaction(45, prev);
+        expect(result.prevCtxPct).toBe(45);
+    });
+
+    it('accepts custom threshold', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 10 };
+        // 1-point drop with threshold=1 should detect
+        const result = detectCompaction(8, prev, 1);
+        expect(result.count).toBe(1);
+    });
+});

--- a/src/utils/__tests__/compaction.test.ts
+++ b/src/utils/__tests__/compaction.test.ts
@@ -86,6 +86,36 @@ describe('detectCompaction', () => {
         expect(result.count).toBe(1);
     });
 
+    it('stores the current context window size when provided', () => {
+        const result = detectCompaction(40, fresh, { windowSize: 200000 });
+        expect(result).toEqual({ count: 0, prevCtxPct: 40, prevWindowSize: 200000 });
+    });
+
+    it('detects compaction when the context window size is unchanged', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 40, prevWindowSize: 200000 };
+        const result = detectCompaction(30, prev, { windowSize: 200000 });
+        expect(result.count).toBe(1);
+        expect(result.prevWindowSize).toBe(200000);
+    });
+
+    it('resets the baseline without incrementing when the context window size changes', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 40, prevWindowSize: 200000 };
+        const result = detectCompaction(8, prev, { windowSize: 1000000 });
+        expect(result).toEqual({ count: 0, prevCtxPct: 8, prevWindowSize: 1000000 });
+    });
+
+    it('learns the context window size for legacy state without incrementing', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 40 };
+        const result = detectCompaction(8, prev, { windowSize: 1000000 });
+        expect(result).toEqual({ count: 0, prevCtxPct: 8, prevWindowSize: 1000000 });
+    });
+
+    it('accepts custom threshold in options', () => {
+        const prev: CompactionState = { count: 0, prevCtxPct: 10, prevWindowSize: 200000 };
+        const result = detectCompaction(8, prev, { dropThreshold: 1, windowSize: 200000 });
+        expect(result.count).toBe(1);
+    });
+
     it('returns state unchanged for NaN input (no poison)', () => {
         const prev: CompactionState = { count: 0, prevCtxPct: 40 };
         expect(detectCompaction(NaN, prev)).toEqual(prev);
@@ -153,7 +183,7 @@ describe('persistence', () => {
     });
 
     it('round-trips state through save and load', () => {
-        const state: CompactionState = { count: 5, prevCtxPct: 42 };
+        const state: CompactionState = { count: 5, prevCtxPct: 42, prevWindowSize: 200000 };
         saveCompactionState('test-session', state);
         const loaded = loadCompactionState('test-session');
         expect(loaded).toEqual(state);

--- a/src/utils/__tests__/compaction.test.ts
+++ b/src/utils/__tests__/compaction.test.ts
@@ -1,4 +1,9 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
+    afterEach,
+    beforeEach,
     describe,
     expect,
     it
@@ -6,6 +11,8 @@ import {
 
 import {
     detectCompaction,
+    loadCompactionState,
+    saveCompactionState,
     type CompactionState
 } from '../compaction';
 
@@ -77,5 +84,54 @@ describe('detectCompaction', () => {
         // 1-point drop with threshold=1 should detect
         const result = detectCompaction(8, prev, 1);
         expect(result.count).toBe(1);
+    });
+});
+
+describe('persistence', () => {
+    let testCacheDir: string;
+    const origHome = process.env.HOME;
+
+    beforeEach(() => {
+        testCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compaction-test-'));
+        process.env.HOME = testCacheDir;
+    });
+
+    afterEach(() => {
+        process.env.HOME = origHome;
+        fs.rmSync(testCacheDir, { recursive: true, force: true });
+    });
+
+    it('round-trips state through save and load', () => {
+        const state: CompactionState = { count: 5, prevCtxPct: 42 };
+        saveCompactionState('test-session', state);
+        const loaded = loadCompactionState('test-session');
+        expect(loaded).toEqual(state);
+    });
+
+    it('returns fresh state for unknown session', () => {
+        const loaded = loadCompactionState('nonexistent');
+        expect(loaded).toEqual({ count: 0, prevCtxPct: 0 });
+    });
+
+    it('sanitizes path traversal in session ID', () => {
+        const malicious = '../../../../../../tmp/pwn';
+        saveCompactionState(malicious, { count: 1, prevCtxPct: 50 });
+
+        // File should be inside the cache dir, not at /tmp/pwn
+        const cacheDir = path.join(testCacheDir, '.cache', 'ccstatusline', 'compaction');
+        const files = fs.existsSync(cacheDir) ? fs.readdirSync(cacheDir) : [];
+        expect(files.length).toBe(1);
+        expect(files[0]).toMatch(/^compaction-[a-zA-Z0-9_-]+\.json$/);
+
+        // /tmp/pwn.json should not exist
+        expect(fs.existsSync('/tmp/pwn.json')).toBe(false);
+    });
+
+    it('does not throw on write failure', () => {
+        // Point HOME at a non-writable path
+        process.env.HOME = '/nonexistent/readonly';
+        expect(() => {
+            saveCompactionState('test', { count: 1, prevCtxPct: 50 });
+        }).not.toThrow();
     });
 });

--- a/src/utils/__tests__/context-percentage.test.ts
+++ b/src/utils/__tests__/context-percentage.test.ts
@@ -5,7 +5,10 @@ import {
 } from 'vitest';
 
 import type { RenderContext } from '../../types';
-import { calculateContextPercentage } from '../context-percentage';
+import {
+    calculateContextPercentage,
+    calculateContextPercentageMetrics
+} from '../context-percentage';
 
 describe('calculateContextPercentage', () => {
     describe('Status JSON context_window', () => {
@@ -31,6 +34,20 @@ describe('calculateContextPercentage', () => {
             expect(percentage).toBe(12.5);
         });
 
+        it('should infer the window size for raw percentage metrics when size is missing', () => {
+            const context: RenderContext = {
+                data: {
+                    model: { id: 'claude-sonnet-4-5-20250929[1m]' },
+                    context_window: { used_percentage: 4.2 }
+                }
+            };
+
+            expect(calculateContextPercentageMetrics(context)).toEqual({
+                usedPercentage: 4.2,
+                windowSize: 1000000
+            });
+        });
+
         it('should derive percentage from current usage and window size when used_percentage is missing', () => {
             const context: RenderContext = {
                 data: {
@@ -50,6 +67,27 @@ describe('calculateContextPercentage', () => {
             expect(percentage).toBe(20);
         });
 
+        it('should return derived percentage metrics from current usage when used_percentage is missing', () => {
+            const context: RenderContext = {
+                data: {
+                    context_window: {
+                        context_window_size: 200000,
+                        current_usage: {
+                            input_tokens: 20000,
+                            output_tokens: 10000,
+                            cache_creation_input_tokens: 5000,
+                            cache_read_input_tokens: 5000
+                        }
+                    }
+                }
+            };
+
+            expect(calculateContextPercentageMetrics(context)).toEqual({
+                usedPercentage: 20,
+                windowSize: 200000
+            });
+        });
+
         it('should use context_window_size as denominator when falling back to token metrics', () => {
             const context: RenderContext = {
                 data: {
@@ -67,6 +105,27 @@ describe('calculateContextPercentage', () => {
 
             const percentage = calculateContextPercentage(context);
             expect(percentage).toBe(4.2);
+        });
+
+        it('should return token-metric fallback metrics with the denominator used', () => {
+            const context: RenderContext = {
+                data: {
+                    model: { id: 'claude-3-5-sonnet-20241022' },
+                    context_window: { context_window_size: 1000000 }
+                },
+                tokenMetrics: {
+                    inputTokens: 0,
+                    outputTokens: 0,
+                    cachedTokens: 0,
+                    totalTokens: 0,
+                    contextLength: 42000
+                }
+            };
+
+            expect(calculateContextPercentageMetrics(context)).toEqual({
+                usedPercentage: 4.2,
+                windowSize: 1000000
+            });
         });
     });
 
@@ -179,6 +238,7 @@ describe('calculateContextPercentage', () => {
 
             const percentage = calculateContextPercentage(context);
             expect(percentage).toBe(0);
+            expect(calculateContextPercentageMetrics(context)).toBeNull();
         });
 
         it('should use default 200k context when model ID is undefined', () => {

--- a/src/utils/compaction.ts
+++ b/src/utils/compaction.ts
@@ -1,19 +1,24 @@
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { z } from 'zod';
 
 const DEFAULT_DROP_THRESHOLD = 2;
-const CACHE_SUBDIR = 'compaction';
+const FRESH_PREV_CTX_PCT = -1;
+const MAX_CACHE_FILE_BYTES = 4096;
+const SESSION_ID_HASH_HEX_LEN = 32;
 
 export interface CompactionState {
     count: number;
     prevCtxPct: number;
 }
 
+const FRESH: CompactionState = { count: 0, prevCtxPct: FRESH_PREV_CTX_PCT };
+
 const CompactionStateSchema = z.object({
-    count: z.number().default(0),
-    prevCtxPct: z.number().default(0)
+    count: z.number().int().nonnegative().default(0),
+    prevCtxPct: z.number().default(FRESH_PREV_CTX_PCT)
 });
 
 /**
@@ -23,16 +28,25 @@ const CompactionStateSchema = z.object({
  * the threshold indicates Claude Code compacted the conversation. The threshold
  * filters rounding noise and cache accounting wobble — a drop must exceed
  * the threshold (default: more than 2 points) to count.
+ *
+ * Returns state unchanged when currentCtxPct is non-finite or negative,
+ * preventing NaN from poisoning persistent state. The fresh-state sentinel
+ * for prevCtxPct is -1, so a session that legitimately starts at 0% is
+ * still detected correctly.
  */
 export function detectCompaction(
     currentCtxPct: number,
     state: CompactionState,
     dropThreshold: number = DEFAULT_DROP_THRESHOLD
 ): CompactionState {
+    if (!Number.isFinite(currentCtxPct) || currentCtxPct < 0) {
+        return state;
+    }
+
     let { count } = state;
     const { prevCtxPct } = state;
 
-    if (prevCtxPct > 0 && currentCtxPct < prevCtxPct - dropThreshold) {
+    if (prevCtxPct >= 0 && currentCtxPct < prevCtxPct - dropThreshold) {
         count += 1;
     }
 
@@ -40,46 +54,71 @@ export function detectCompaction(
 }
 
 function getCacheDir(): string {
-    const home = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
-    return path.join(home, '.cache', 'ccstatusline', CACHE_SUBDIR);
+    return path.join(os.homedir(), '.cache', 'ccstatusline', 'compaction');
 }
 
 function sanitizeSessionId(sessionId: string): string {
-    return sessionId.replace(/[^a-zA-Z0-9_-]/g, '_');
+    const sanitized = sessionId.replace(/[^a-zA-Z0-9_-]/g, '_');
+    // Hash if input was empty or contained any disallowed character — prevents
+    // distinct sessions with all-illegal characters from collapsing to the same
+    // cache filename, and prevents an empty leaf like "compaction-.json".
+    if (!sanitized || sanitized !== sessionId) {
+        return crypto.createHash('sha256').update(sessionId).digest('hex').slice(0, SESSION_ID_HASH_HEX_LEN);
+    }
+    return sanitized;
 }
 
 function getStatePath(sessionId: string): string {
     return path.join(getCacheDir(), `compaction-${sanitizeSessionId(sessionId)}.json`);
 }
 
-/**
- * Load compaction state for a session.
- */
 export function loadCompactionState(sessionId: string): CompactionState {
     const statePath = getStatePath(sessionId);
-    if (!fs.existsSync(statePath)) {
-        return { count: 0, prevCtxPct: 0 };
-    }
+    let fd: number | null = null;
     try {
-        const raw: unknown = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+        // O_NOFOLLOW makes opening a symlinked path fail with ELOOP rather
+        // than reading through the symlink. Combined with fstat on the open
+        // fd (rather than a separate lstat-then-read), this also closes the
+        // TOCTOU window that would otherwise let the path be swapped between
+        // the stat and the read.
+        fd = fs.openSync(statePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+        const stats = fs.fstatSync(fd);
+        if (!stats.isFile() || stats.size > MAX_CACHE_FILE_BYTES) {
+            return FRESH;
+        }
+        const raw: unknown = JSON.parse(fs.readFileSync(fd, 'utf-8'));
         const result = CompactionStateSchema.safeParse(raw);
-        return result.success ? result.data : { count: 0, prevCtxPct: 0 };
+        return result.success ? result.data : FRESH;
     } catch {
-        return { count: 0, prevCtxPct: 0 };
+        return FRESH;
+    } finally {
+        if (fd !== null) {
+            try { fs.closeSync(fd); } catch { /* ignore */ }
+        }
     }
 }
 
-/**
- * Save compaction state for a session.
- */
 export function saveCompactionState(sessionId: string, state: CompactionState): void {
+    let tmpPath: string | null = null;
     try {
         const dir = getCacheDir();
         if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir, { recursive: true });
         }
-        fs.writeFileSync(getStatePath(sessionId), JSON.stringify(state) + '\n');
+        const targetPath = getStatePath(sessionId);
+        // Write to a temp file in the same directory then rename. Rename on
+        // POSIX replaces the target atomically and does not follow symlinks
+        // at the destination — so a planted symlink at targetPath gets
+        // replaced with the real file rather than written through.
+        tmpPath = `${targetPath}.tmp.${process.pid}.${crypto.randomBytes(4).toString('hex')}`;
+        fs.writeFileSync(tmpPath, JSON.stringify(state) + '\n');
+        fs.renameSync(tmpPath, targetPath);
+        tmpPath = null;
     } catch {
-        // Best-effort — cache write failure should not break status line rendering
+        // Best-effort — cache write failure should not break status line rendering.
+        // Clean up an orphan temp file if rename failed after write succeeded.
+        if (tmpPath !== null) {
+            try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+        }
     }
 }

--- a/src/utils/compaction.ts
+++ b/src/utils/compaction.ts
@@ -12,22 +12,51 @@ const SESSION_ID_HASH_HEX_LEN = 32;
 export interface CompactionState {
     count: number;
     prevCtxPct: number;
+    prevWindowSize?: number | null;
 }
 
 const FRESH: CompactionState = { count: 0, prevCtxPct: FRESH_PREV_CTX_PCT };
 
 const CompactionStateSchema = z.object({
     count: z.number().int().nonnegative().default(0),
-    prevCtxPct: z.number().default(FRESH_PREV_CTX_PCT)
+    prevCtxPct: z.number().default(FRESH_PREV_CTX_PCT),
+    prevWindowSize: z.number().positive().nullable().optional()
 });
+
+interface DetectCompactionOptions {
+    dropThreshold?: number;
+    windowSize?: number | null;
+}
+
+function normalizeWindowSize(value: number | null | undefined): number | null {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+        return null;
+    }
+
+    return value;
+}
+
+function normalizeOptions(options: number | DetectCompactionOptions): Required<Pick<DetectCompactionOptions, 'dropThreshold'>> & Pick<DetectCompactionOptions, 'windowSize'> {
+    if (typeof options === 'number') {
+        return { dropThreshold: options, windowSize: null };
+    }
+
+    const dropThreshold = typeof options.dropThreshold === 'number' && Number.isFinite(options.dropThreshold)
+        ? options.dropThreshold
+        : DEFAULT_DROP_THRESHOLD;
+
+    return { dropThreshold, windowSize: options.windowSize ?? null };
+}
 
 /**
  * Detect context compaction events.
  *
- * Context only grows until compaction — any drop in used_percentage beyond
- * the threshold indicates Claude Code compacted the conversation. The threshold
- * filters rounding noise and cache accounting wobble — a drop must exceed
- * the threshold (default: more than 2 points) to count.
+ * Within the same context window size, context only grows until compaction, so
+ * any percentage drop beyond the threshold indicates Claude Code compacted the
+ * conversation. The threshold filters rounding noise and cache accounting
+ * wobble - a drop must exceed the threshold (default: more than 2 points) to
+ * count. When a known context window size changes, the previous percentage
+ * baseline is reset instead of counted as a compaction.
  *
  * Returns state unchanged when currentCtxPct is non-finite or negative,
  * preventing NaN from poisoning persistent state. The fresh-state sentinel
@@ -37,20 +66,29 @@ const CompactionStateSchema = z.object({
 export function detectCompaction(
     currentCtxPct: number,
     state: CompactionState,
-    dropThreshold: number = DEFAULT_DROP_THRESHOLD
+    options: number | DetectCompactionOptions = DEFAULT_DROP_THRESHOLD
 ): CompactionState {
     if (!Number.isFinite(currentCtxPct) || currentCtxPct < 0) {
         return state;
     }
 
+    const { dropThreshold, windowSize } = normalizeOptions(options);
+    const currentWindowSize = normalizeWindowSize(windowSize);
+    const prevWindowSize = normalizeWindowSize(state.prevWindowSize);
     let { count } = state;
     const { prevCtxPct } = state;
+    const hasKnownWindowChange = currentWindowSize !== null && prevWindowSize !== null && currentWindowSize !== prevWindowSize;
+    const isLearningWindowSize = currentWindowSize !== null && prevWindowSize === null && prevCtxPct >= 0;
 
-    if (prevCtxPct >= 0 && currentCtxPct < prevCtxPct - dropThreshold) {
+    if (!hasKnownWindowChange && !isLearningWindowSize && prevCtxPct >= 0 && currentCtxPct < prevCtxPct - dropThreshold) {
         count += 1;
     }
 
-    return { count, prevCtxPct: currentCtxPct };
+    return {
+        count,
+        prevCtxPct: currentCtxPct,
+        ...(currentWindowSize !== null ? { prevWindowSize: currentWindowSize } : {})
+    };
 }
 
 function getCacheDir(): string {

--- a/src/utils/compaction.ts
+++ b/src/utils/compaction.ts
@@ -1,0 +1,85 @@
+import {
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    writeFileSync
+} from 'node:fs';
+import { join } from 'node:path';
+
+import { z } from 'zod';
+
+const DEFAULT_DROP_THRESHOLD = 2;
+const CACHE_SUBDIR = 'compaction';
+
+export interface CompactionState {
+    count: number;
+    prevCtxPct: number;
+}
+
+const CompactionStateSchema = z.object({
+    count: z.number().default(0),
+    prevCtxPct: z.number().default(0)
+});
+
+/**
+ * Detect context compaction events.
+ *
+ * Context only grows until compaction — any drop in used_percentage beyond
+ * the threshold indicates Claude Code compacted the conversation. The threshold
+ * filters rounding noise and cache accounting wobble (±1 point).
+ *
+ * @param currentCtxPct - Current used_percentage from StatusJSON
+ * @param state - Previous compaction state
+ * @param dropThreshold - Minimum percentage-point drop to count as compaction (default: 2)
+ * @returns Updated compaction state
+ */
+export function detectCompaction(
+    currentCtxPct: number,
+    state: CompactionState,
+    dropThreshold: number = DEFAULT_DROP_THRESHOLD
+): CompactionState {
+    let { count } = state;
+    const { prevCtxPct } = state;
+
+    if (prevCtxPct > 0 && currentCtxPct < prevCtxPct - dropThreshold) {
+        count += 1;
+    }
+
+    return { count, prevCtxPct: currentCtxPct };
+}
+
+function getCacheDir(): string {
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
+    return join(home, '.cache', 'ccstatusline', CACHE_SUBDIR);
+}
+
+function getStatePath(sessionId: string): string {
+    return join(getCacheDir(), `compaction-${sessionId}.json`);
+}
+
+/**
+ * Load compaction state for a session.
+ */
+export function loadCompactionState(sessionId: string): CompactionState {
+    const path = getStatePath(sessionId);
+    if (!existsSync(path)) {
+        return { count: 0, prevCtxPct: 0 };
+    }
+    try {
+        const raw: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+        return CompactionStateSchema.parse(raw);
+    } catch {
+        return { count: 0, prevCtxPct: 0 };
+    }
+}
+
+/**
+ * Save compaction state for a session.
+ */
+export function saveCompactionState(sessionId: string, state: CompactionState): void {
+    const dir = getCacheDir();
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(getStatePath(sessionId), JSON.stringify(state) + '\n');
+}

--- a/src/utils/compaction.ts
+++ b/src/utils/compaction.ts
@@ -4,6 +4,7 @@ import {
     readFileSync,
     writeFileSync
 } from 'node:fs';
+import * as os from 'node:os';
 import { join } from 'node:path';
 
 import { z } from 'zod';
@@ -26,7 +27,8 @@ const CompactionStateSchema = z.object({
  *
  * Context only grows until compaction — any drop in used_percentage beyond
  * the threshold indicates Claude Code compacted the conversation. The threshold
- * filters rounding noise and cache accounting wobble (±1 point).
+ * filters rounding noise and cache accounting wobble — a drop must exceed
+ * the threshold (default: more than 2 points) to count.
  *
  * @param currentCtxPct - Current used_percentage from StatusJSON
  * @param state - Previous compaction state
@@ -49,12 +51,16 @@ export function detectCompaction(
 }
 
 function getCacheDir(): string {
-    const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
     return join(home, '.cache', 'ccstatusline', CACHE_SUBDIR);
 }
 
+function sanitizeSessionId(sessionId: string): string {
+    return sessionId.replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
 function getStatePath(sessionId: string): string {
-    return join(getCacheDir(), `compaction-${sessionId}.json`);
+    return join(getCacheDir(), `compaction-${sanitizeSessionId(sessionId)}.json`);
 }
 
 /**
@@ -77,9 +83,13 @@ export function loadCompactionState(sessionId: string): CompactionState {
  * Save compaction state for a session.
  */
 export function saveCompactionState(sessionId: string, state: CompactionState): void {
-    const dir = getCacheDir();
-    if (!existsSync(dir)) {
-        mkdirSync(dir, { recursive: true });
+    try {
+        const dir = getCacheDir();
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+        }
+        writeFileSync(getStatePath(sessionId), JSON.stringify(state) + '\n');
+    } catch {
+        // Best-effort — cache write failure should not break status line rendering
     }
-    writeFileSync(getStatePath(sessionId), JSON.stringify(state) + '\n');
 }

--- a/src/utils/compaction.ts
+++ b/src/utils/compaction.ts
@@ -1,12 +1,6 @@
-import {
-    existsSync,
-    mkdirSync,
-    readFileSync,
-    writeFileSync
-} from 'node:fs';
-import * as os from 'node:os';
-import { join } from 'node:path';
-
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { z } from 'zod';
 
 const DEFAULT_DROP_THRESHOLD = 2;
@@ -29,11 +23,6 @@ const CompactionStateSchema = z.object({
  * the threshold indicates Claude Code compacted the conversation. The threshold
  * filters rounding noise and cache accounting wobble — a drop must exceed
  * the threshold (default: more than 2 points) to count.
- *
- * @param currentCtxPct - Current used_percentage from StatusJSON
- * @param state - Previous compaction state
- * @param dropThreshold - Minimum percentage-point drop to count as compaction (default: 2)
- * @returns Updated compaction state
  */
 export function detectCompaction(
     currentCtxPct: number,
@@ -52,7 +41,7 @@ export function detectCompaction(
 
 function getCacheDir(): string {
     const home = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
-    return join(home, '.cache', 'ccstatusline', CACHE_SUBDIR);
+    return path.join(home, '.cache', 'ccstatusline', CACHE_SUBDIR);
 }
 
 function sanitizeSessionId(sessionId: string): string {
@@ -60,20 +49,21 @@ function sanitizeSessionId(sessionId: string): string {
 }
 
 function getStatePath(sessionId: string): string {
-    return join(getCacheDir(), `compaction-${sanitizeSessionId(sessionId)}.json`);
+    return path.join(getCacheDir(), `compaction-${sanitizeSessionId(sessionId)}.json`);
 }
 
 /**
  * Load compaction state for a session.
  */
 export function loadCompactionState(sessionId: string): CompactionState {
-    const path = getStatePath(sessionId);
-    if (!existsSync(path)) {
+    const statePath = getStatePath(sessionId);
+    if (!fs.existsSync(statePath)) {
         return { count: 0, prevCtxPct: 0 };
     }
     try {
-        const raw: unknown = JSON.parse(readFileSync(path, 'utf-8'));
-        return CompactionStateSchema.parse(raw);
+        const raw: unknown = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+        const result = CompactionStateSchema.safeParse(raw);
+        return result.success ? result.data : { count: 0, prevCtxPct: 0 };
     } catch {
         return { count: 0, prevCtxPct: 0 };
     }
@@ -85,10 +75,10 @@ export function loadCompactionState(sessionId: string): CompactionState {
 export function saveCompactionState(sessionId: string, state: CompactionState): void {
     try {
         const dir = getCacheDir();
-        if (!existsSync(dir)) {
-            mkdirSync(dir, { recursive: true });
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true });
         }
-        writeFileSync(getStatePath(sessionId), JSON.stringify(state) + '\n');
+        fs.writeFileSync(getStatePath(sessionId), JSON.stringify(state) + '\n');
     } catch {
         // Best-effort — cache write failure should not break status line rendering
     }

--- a/src/utils/context-percentage.ts
+++ b/src/utils/context-percentage.ts
@@ -6,21 +6,41 @@ import {
     getModelContextIdentifier
 } from './model-context';
 
+export interface ContextPercentageMetrics {
+    usedPercentage: number;
+    windowSize: number | null;
+}
+
 /**
- * Calculate context window usage percentage based on model's max tokens
+ * Calculate context window usage percentage and the denominator used for that
+ * percentage. Returns null when neither status JSON nor transcript metrics can
+ * provide context usage.
  */
-export function calculateContextPercentage(context: RenderContext): number {
+export function calculateContextPercentageMetrics(context: Pick<RenderContext, 'data' | 'tokenMetrics'>): ContextPercentageMetrics | null {
     const contextWindowMetrics = getContextWindowMetrics(context.data);
-    if (contextWindowMetrics.usedPercentage !== null) {
-        return contextWindowMetrics.usedPercentage;
-    }
-
-    if (!context.tokenMetrics) {
-        return 0;
-    }
-
     const modelIdentifier = getModelContextIdentifier(context.data?.model);
     const contextConfig = getContextConfig(modelIdentifier, contextWindowMetrics.windowSize);
 
-    return Math.min(100, (context.tokenMetrics.contextLength / contextConfig.maxTokens) * 100);
+    if (contextWindowMetrics.usedPercentage !== null) {
+        return {
+            usedPercentage: contextWindowMetrics.usedPercentage,
+            windowSize: contextConfig.maxTokens
+        };
+    }
+
+    if (!context.tokenMetrics) {
+        return null;
+    }
+
+    return {
+        usedPercentage: Math.min(100, (context.tokenMetrics.contextLength / contextConfig.maxTokens) * 100),
+        windowSize: contextConfig.maxTokens
+    };
+}
+
+/**
+ * Calculate context window usage percentage based on model's max tokens.
+ */
+export function calculateContextPercentage(context: RenderContext): number {
+    return calculateContextPercentageMetrics(context)?.usedPercentage ?? 0;
 }

--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -80,7 +80,8 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'worktree-mode', create: () => new widgets.GitWorktreeModeWidget() },
     { type: 'worktree-name', create: () => new widgets.GitWorktreeNameWidget() },
     { type: 'worktree-branch', create: () => new widgets.GitWorktreeBranchWidget() },
-    { type: 'worktree-original-branch', create: () => new widgets.GitWorktreeOriginalBranchWidget() }
+    { type: 'worktree-original-branch', create: () => new widgets.GitWorktreeOriginalBranchWidget() },
+    { type: 'compaction-counter', create: () => new widgets.CompactionCounterWidget() }
 ];
 
 export const LAYOUT_WIDGET_MANIFEST: LayoutWidgetManifestEntry[] = [

--- a/src/widgets/CompactionCounter.ts
+++ b/src/widgets/CompactionCounter.ts
@@ -30,7 +30,8 @@ export class CompactionCounterWidget implements Widget {
         }
 
         const count = context.compactionData?.count;
-        if (!count) return null;
+        if (!count)
+            return null;
 
         return `\u21BB${count}`;
     }

--- a/src/widgets/CompactionCounter.ts
+++ b/src/widgets/CompactionCounter.ts
@@ -1,10 +1,105 @@
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
 import type {
+    CustomKeybind,
     Widget,
     WidgetEditorDisplay,
     WidgetItem
 } from '../types/Widget';
+
+const COMPACTION_ICON = '↻';
+const COMPACTION_NERD_FONT_ICON = '\uF021';
+const FORMATS = ['icon-space-number', 'text-and-number', 'number'] as const;
+type CompactionCounterFormat = typeof FORMATS[number];
+
+const DEFAULT_FORMAT: CompactionCounterFormat = 'icon-space-number';
+const CYCLE_FORMAT_ACTION = 'cycle-format';
+const TOGGLE_HIDE_ZERO_ACTION = 'toggle-hide-zero';
+const TOGGLE_NERD_FONT_ACTION = 'toggle-nerd-font';
+const HIDE_ZERO_METADATA_KEY = 'hideZero';
+const NERD_FONT_METADATA_KEY = 'nerdFont';
+
+function getFormat(item: WidgetItem): CompactionCounterFormat {
+    const format = item.metadata?.format;
+    return (FORMATS as readonly string[]).includes(format ?? '') ? (format as CompactionCounterFormat) : DEFAULT_FORMAT;
+}
+
+function removeNerdFont(item: WidgetItem): WidgetItem {
+    const { [NERD_FONT_METADATA_KEY]: removedNerdFont, ...restMetadata } = item.metadata ?? {};
+    void removedNerdFont;
+
+    return {
+        ...item,
+        metadata: Object.keys(restMetadata).length > 0 ? restMetadata : undefined
+    };
+}
+
+function setFormat(item: WidgetItem, format: CompactionCounterFormat): WidgetItem {
+    if (format === DEFAULT_FORMAT) {
+        const { format: removedFormat, ...restMetadata } = item.metadata ?? {};
+        void removedFormat;
+
+        return {
+            ...item,
+            metadata: Object.keys(restMetadata).length > 0 ? restMetadata : undefined
+        };
+    }
+
+    const { [NERD_FONT_METADATA_KEY]: removedNerdFont, ...restMetadata } = item.metadata ?? {};
+    void removedNerdFont;
+
+    return {
+        ...item,
+        metadata: {
+            ...restMetadata,
+            format
+        }
+    };
+}
+
+function isNerdFontEnabled(item: WidgetItem): boolean {
+    return item.metadata?.[NERD_FONT_METADATA_KEY] === 'true' && getFormat(item) === DEFAULT_FORMAT;
+}
+
+function isHideZeroEnabled(item: WidgetItem): boolean {
+    return item.metadata?.[HIDE_ZERO_METADATA_KEY] === 'true';
+}
+
+function toggleHideZero(item: WidgetItem): WidgetItem {
+    return {
+        ...item,
+        metadata: {
+            ...(item.metadata ?? {}),
+            [HIDE_ZERO_METADATA_KEY]: (!isHideZeroEnabled(item)).toString()
+        }
+    };
+}
+
+function toggleNerdFont(item: WidgetItem): WidgetItem {
+    if (getFormat(item) !== DEFAULT_FORMAT) {
+        return removeNerdFont(item);
+    }
+
+    if (!isNerdFontEnabled(item)) {
+        return {
+            ...item,
+            metadata: {
+                ...(item.metadata ?? {}),
+                [NERD_FONT_METADATA_KEY]: 'true'
+            }
+        };
+    }
+
+    return removeNerdFont(item);
+}
+
+function formatCount(count: number, format: CompactionCounterFormat, icon: string): string {
+    switch (format) {
+        case 'icon-space-number': return `${icon} ${count}`;
+        case 'text-and-number': return `Compactions: ${count}`;
+        case 'number': return String(count);
+    }
+}
 
 /**
  * Displays a count of context compaction events in the current session.
@@ -13,27 +108,75 @@ import type {
  * approaches the context window limit. This widget tracks how many times
  * compaction has occurred by detecting drops in used_percentage between renders.
  *
- * Hidden when count is 0. Shows ↻N when compactions have occurred.
+ * Shows ↻ N by default, including ↻ 0 before compaction occurs. Can be
+ * configured to hide when count is 0.
  */
 export class CompactionCounterWidget implements Widget {
     getDefaultColor(): string { return 'yellow'; }
-    getDescription(): string { return 'Count of context compaction events in the current session. Hidden when no compactions have occurred.'; }
+    getDescription(): string { return 'Count of context compaction events in the current session.'; }
     getDisplayName(): string { return 'Compaction Counter'; }
     getCategory(): string { return 'Context'; }
     getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
-        return { displayText: 'Compaction Counter' };
+        const modifiers: string[] = [getFormat(item)];
+        if (isNerdFontEnabled(item)) {
+            modifiers.push('nerd font');
+        }
+        if (isHideZeroEnabled(item)) {
+            modifiers.push('hide zero');
+        }
+
+        return {
+            displayText: 'Compaction Counter',
+            modifierText: `(${modifiers.join(', ')})`
+        };
+    }
+
+    handleEditorAction(action: string, item: WidgetItem): WidgetItem | null {
+        if (action === CYCLE_FORMAT_ACTION) {
+            const currentFormat = getFormat(item);
+            const nextFormat = FORMATS[(FORMATS.indexOf(currentFormat) + 1) % FORMATS.length] ?? DEFAULT_FORMAT;
+
+            return setFormat(item, nextFormat);
+        }
+
+        if (action === TOGGLE_HIDE_ZERO_ACTION) {
+            return toggleHideZero(item);
+        }
+
+        if (action === TOGGLE_NERD_FONT_ACTION) {
+            return toggleNerdFont(item);
+        }
+
+        return null;
     }
 
     render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
+        const format = getFormat(item);
+        const icon = isNerdFontEnabled(item) ? COMPACTION_NERD_FONT_ICON : COMPACTION_ICON;
+
         if (context.isPreview) {
-            return '↻2';
+            return formatCount(2, format, icon);
         }
 
-        const count = context.compactionData?.count;
-        if (count === undefined || count === 0)
+        const count = context.compactionData?.count ?? 0;
+        if (count === 0 && isHideZeroEnabled(item))
             return null;
 
-        return `↻${count}`;
+        return formatCount(count, format, icon);
+    }
+
+    getCustomKeybinds(item?: WidgetItem): CustomKeybind[] {
+        const keybinds: CustomKeybind[] = [
+            { key: 'f', label: '(f)ormat', action: CYCLE_FORMAT_ACTION }
+        ];
+
+        if (item === undefined || getFormat(item) === DEFAULT_FORMAT) {
+            keybinds.push({ key: 'n', label: '(n)erd font', action: TOGGLE_NERD_FONT_ACTION });
+        }
+
+        keybinds.push({ key: 'h', label: '(h)ide when zero', action: TOGGLE_HIDE_ZERO_ACTION });
+
+        return keybinds;
     }
 
     supportsRawValue(): boolean { return false; }

--- a/src/widgets/CompactionCounter.ts
+++ b/src/widgets/CompactionCounter.ts
@@ -20,22 +20,22 @@ export class CompactionCounterWidget implements Widget {
     getDescription(): string { return 'Count of context compaction events in the current session. Hidden when no compactions have occurred.'; }
     getDisplayName(): string { return 'Compaction Counter'; }
     getCategory(): string { return 'Context'; }
-    getEditorDisplay(_item: WidgetItem): WidgetEditorDisplay {
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
         return { displayText: 'Compaction Counter' };
     }
 
-    render(_item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
         if (context.isPreview) {
-            return '\u21BB2';
+            return '↻2';
         }
 
         const count = context.compactionData?.count;
-        if (!count)
+        if (count === undefined || count === 0)
             return null;
 
-        return `\u21BB${count}`;
+        return `↻${count}`;
     }
 
     supportsRawValue(): boolean { return false; }
-    supportsColors(_item: WidgetItem): boolean { return true; }
+    supportsColors(item: WidgetItem): boolean { return true; }
 }

--- a/src/widgets/CompactionCounter.ts
+++ b/src/widgets/CompactionCounter.ts
@@ -1,0 +1,40 @@
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+
+/**
+ * Displays a count of context compaction events in the current session.
+ *
+ * Claude Code periodically compacts (summarizes) conversation context when it
+ * approaches the context window limit. This widget tracks how many times
+ * compaction has occurred by detecting drops in used_percentage between renders.
+ *
+ * Hidden when count is 0. Shows ↻N when compactions have occurred.
+ */
+export class CompactionCounterWidget implements Widget {
+    getDefaultColor(): string { return 'yellow'; }
+    getDescription(): string { return 'Count of context compaction events in the current session. Hidden when no compactions have occurred.'; }
+    getDisplayName(): string { return 'Compaction Counter'; }
+    getCategory(): string { return 'Context'; }
+    getEditorDisplay(_item: WidgetItem): WidgetEditorDisplay {
+        return { displayText: 'Compaction Counter' };
+    }
+
+    render(_item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+        if (context.isPreview) {
+            return '\u21BB2';
+        }
+
+        const count = context.compactionData?.count;
+        if (!count) return null;
+
+        return `\u21BB${count}`;
+    }
+
+    supportsRawValue(): boolean { return false; }
+    supportsColors(_item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/ContextPercentage.ts
+++ b/src/widgets/ContextPercentage.ts
@@ -6,11 +6,7 @@ import type {
     WidgetEditorDisplay,
     WidgetItem
 } from '../types/Widget';
-import { getContextWindowMetrics } from '../utils/context-window';
-import {
-    getContextConfig,
-    getModelContextIdentifier
-} from '../utils/model-context';
+import { calculateContextPercentageMetrics } from '../utils/context-percentage';
 
 import {
     getContextInverseModifierText,
@@ -52,7 +48,7 @@ export class ContextPercentageWidget implements Widget {
     render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
         const isInverse = isContextInverse(item);
         const sliderMode = getContextSliderMode(item);
-        const contextWindowMetrics = getContextWindowMetrics(context.data);
+        const contextPercentageMetrics = calculateContextPercentageMetrics(context);
 
         if (context.isPreview) {
             const previewPercent = isInverse ? 90.7 : 9.3;
@@ -63,20 +59,8 @@ export class ContextPercentageWidget implements Widget {
             return formatRawOrLabeledValue(item, 'Ctx: ', `${previewPercent.toFixed(1)}%`);
         }
 
-        if (contextWindowMetrics.usedPercentage !== null) {
-            const displayPercentage = isInverse ? (100 - contextWindowMetrics.usedPercentage) : contextWindowMetrics.usedPercentage;
-            const sliderResult = renderContextSlider(sliderMode, displayPercentage);
-            if (sliderResult !== null) {
-                return formatRawOrLabeledValue(item, 'Ctx: ', sliderResult);
-            }
-            return formatRawOrLabeledValue(item, 'Ctx: ', `${displayPercentage.toFixed(1)}%`);
-        }
-
-        if (context.tokenMetrics) {
-            const modelIdentifier = getModelContextIdentifier(context.data?.model);
-            const contextConfig = getContextConfig(modelIdentifier, contextWindowMetrics.windowSize);
-            const usedPercentage = Math.min(100, (context.tokenMetrics.contextLength / contextConfig.maxTokens) * 100);
-            const displayPercentage = isInverse ? (100 - usedPercentage) : usedPercentage;
+        if (contextPercentageMetrics !== null) {
+            const displayPercentage = isInverse ? (100 - contextPercentageMetrics.usedPercentage) : contextPercentageMetrics.usedPercentage;
             const sliderResult = renderContextSlider(sliderMode, displayPercentage);
             if (sliderResult !== null) {
                 return formatRawOrLabeledValue(item, 'Ctx: ', sliderResult);

--- a/src/widgets/__tests__/CompactionCounter.test.ts
+++ b/src/widgets/__tests__/CompactionCounter.test.ts
@@ -1,21 +1,29 @@
 import {
     describe,
     expect,
-    it
+    it,
+    vi
 } from 'vitest';
 
 import type {
     RenderContext,
     WidgetItem
 } from '../../types';
+import type { CompactionData } from '../../types/RenderContext';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import { CompactionCounterWidget } from '../CompactionCounter';
+
+vi.mock('child_process', () => ({
+    execSync: vi.fn(),
+    execFileSync: vi.fn(),
+    spawnSync: vi.fn()
+}));
 
 const ITEM: WidgetItem = { id: 'compaction-counter', type: 'compaction-counter' };
 
 function render(options: {
     isPreview?: boolean;
-    compactionData?: { count: number } | null;
+    compactionData?: CompactionData | null;
 } = {}) {
     const widget = new CompactionCounterWidget();
     const context: RenderContext = {
@@ -69,12 +77,13 @@ describe('CompactionCounterWidget', () => {
             expect(render({ compactionData: null })).toBeNull();
         });
 
-        it('returns null when context.data is absent', () => {
-            expect(render()).toBeNull();
-        });
-
         it('returns sample data in preview mode', () => {
             expect(render({ isPreview: true })).toBe('↻2');
+        });
+
+        it('preview mode ignores live compactionData', () => {
+            // Verify preview short-circuits before reading compactionData
+            expect(render({ isPreview: true, compactionData: { count: 99 } })).toBe('↻2');
         });
     });
 

--- a/src/widgets/__tests__/CompactionCounter.test.ts
+++ b/src/widgets/__tests__/CompactionCounter.test.ts
@@ -1,0 +1,87 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import type {
+    RenderContext,
+    WidgetItem
+} from '../../types';
+import { DEFAULT_SETTINGS } from '../../types/Settings';
+import { CompactionCounterWidget } from '../CompactionCounter';
+
+const ITEM: WidgetItem = { id: 'compaction-counter', type: 'compaction-counter' };
+
+function makeContext(overrides: Partial<RenderContext> = {}): RenderContext {
+    return { ...overrides };
+}
+
+describe('CompactionCounterWidget', () => {
+    describe('metadata', () => {
+        it('has correct display name', () => {
+            expect(new CompactionCounterWidget().getDisplayName()).toBe('Compaction Counter');
+        });
+
+        it('has correct category', () => {
+            expect(new CompactionCounterWidget().getCategory()).toBe('Context');
+        });
+
+        it('does not support raw value', () => {
+            expect(new CompactionCounterWidget().supportsRawValue()).toBe(false);
+        });
+
+        it('supports colors', () => {
+            expect(new CompactionCounterWidget().supportsColors(ITEM)).toBe(true);
+        });
+
+        it('has correct default color', () => {
+            expect(new CompactionCounterWidget().getDefaultColor()).toBe('yellow');
+        });
+    });
+
+    describe('render()', () => {
+        it('renders compaction count with arrow', () => {
+            const ctx = makeContext({ compactionData: { count: 3 } });
+            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBe('\u21BB3');
+        });
+
+        it('renders count of 1', () => {
+            const ctx = makeContext({ compactionData: { count: 1 } });
+            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBe('\u21BB1');
+        });
+
+        it('returns null when count is 0', () => {
+            const ctx = makeContext({ compactionData: { count: 0 } });
+            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBeNull();
+        });
+
+        it('returns null when compactionData is undefined', () => {
+            const ctx = makeContext();
+            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBeNull();
+        });
+
+        it('returns null when compactionData is null', () => {
+            const ctx = makeContext({ compactionData: null });
+            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBeNull();
+        });
+
+        it('returns null when context.data is absent', () => {
+            const ctx = makeContext();
+            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBeNull();
+        });
+
+        it('returns sample data in preview mode', () => {
+            const ctx = makeContext({ isPreview: true });
+            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBe('\u21BB2');
+        });
+    });
+
+    describe('editor', () => {
+        it('has correct editor display', () => {
+            expect(new CompactionCounterWidget().getEditorDisplay(ITEM)).toEqual({
+                displayText: 'Compaction Counter'
+            });
+        });
+    });
+});

--- a/src/widgets/__tests__/CompactionCounter.test.ts
+++ b/src/widgets/__tests__/CompactionCounter.test.ts
@@ -13,8 +13,16 @@ import { CompactionCounterWidget } from '../CompactionCounter';
 
 const ITEM: WidgetItem = { id: 'compaction-counter', type: 'compaction-counter' };
 
-function makeContext(overrides: Partial<RenderContext> = {}): RenderContext {
-    return { ...overrides };
+function render(options: {
+    isPreview?: boolean;
+    compactionData?: { count: number } | null;
+} = {}) {
+    const widget = new CompactionCounterWidget();
+    const context: RenderContext = {
+        isPreview: options.isPreview,
+        compactionData: options.compactionData
+    };
+    return widget.render(ITEM, context, DEFAULT_SETTINGS);
 }
 
 describe('CompactionCounterWidget', () => {
@@ -42,46 +50,37 @@ describe('CompactionCounterWidget', () => {
 
     describe('render()', () => {
         it('renders compaction count with arrow', () => {
-            const ctx = makeContext({ compactionData: { count: 3 } });
-            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBe('\u21BB3');
+            expect(render({ compactionData: { count: 3 } })).toBe('↻3');
         });
 
         it('renders count of 1', () => {
-            const ctx = makeContext({ compactionData: { count: 1 } });
-            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBe('\u21BB1');
+            expect(render({ compactionData: { count: 1 } })).toBe('↻1');
         });
 
         it('returns null when count is 0', () => {
-            const ctx = makeContext({ compactionData: { count: 0 } });
-            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBeNull();
+            expect(render({ compactionData: { count: 0 } })).toBeNull();
         });
 
         it('returns null when compactionData is undefined', () => {
-            const ctx = makeContext();
-            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBeNull();
+            expect(render()).toBeNull();
         });
 
         it('returns null when compactionData is null', () => {
-            const ctx = makeContext({ compactionData: null });
-            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBeNull();
+            expect(render({ compactionData: null })).toBeNull();
         });
 
         it('returns null when context.data is absent', () => {
-            const ctx = makeContext();
-            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBeNull();
+            expect(render()).toBeNull();
         });
 
         it('returns sample data in preview mode', () => {
-            const ctx = makeContext({ isPreview: true });
-            expect(new CompactionCounterWidget().render(ITEM, ctx, DEFAULT_SETTINGS)).toBe('\u21BB2');
+            expect(render({ isPreview: true })).toBe('↻2');
         });
     });
 
     describe('editor', () => {
         it('has correct editor display', () => {
-            expect(new CompactionCounterWidget().getEditorDisplay(ITEM)).toEqual({
-                displayText: 'Compaction Counter'
-            });
+            expect(new CompactionCounterWidget().getEditorDisplay(ITEM)).toEqual({ displayText: 'Compaction Counter' });
         });
     });
 });

--- a/src/widgets/__tests__/CompactionCounter.test.ts
+++ b/src/widgets/__tests__/CompactionCounter.test.ts
@@ -24,13 +24,14 @@ const ITEM: WidgetItem = { id: 'compaction-counter', type: 'compaction-counter' 
 function render(options: {
     isPreview?: boolean;
     compactionData?: CompactionData | null;
+    item?: WidgetItem;
 } = {}) {
     const widget = new CompactionCounterWidget();
     const context: RenderContext = {
         isPreview: options.isPreview,
         compactionData: options.compactionData
     };
-    return widget.render(ITEM, context, DEFAULT_SETTINGS);
+    return widget.render(options.item ?? ITEM, context, DEFAULT_SETTINGS);
 }
 
 describe('CompactionCounterWidget', () => {
@@ -57,39 +58,210 @@ describe('CompactionCounterWidget', () => {
     });
 
     describe('render()', () => {
-        it('renders compaction count with arrow', () => {
-            expect(render({ compactionData: { count: 3 } })).toBe('↻3');
+        it('renders compaction count with icon, space, and number by default', () => {
+            expect(render({ compactionData: { count: 3 } })).toBe('↻ 3');
         });
 
         it('renders count of 1', () => {
-            expect(render({ compactionData: { count: 1 } })).toBe('↻1');
+            expect(render({ compactionData: { count: 1 } })).toBe('↻ 1');
         });
 
-        it('returns null when count is 0', () => {
-            expect(render({ compactionData: { count: 0 } })).toBeNull();
+        it('renders alternate configured formats', () => {
+            expect(render({
+                compactionData: { count: 3 },
+                item: { ...ITEM, metadata: { format: 'text-and-number' } }
+            })).toBe('Compactions: 3');
+            expect(render({
+                compactionData: { count: 3 },
+                item: { ...ITEM, metadata: { format: 'number' } }
+            })).toBe('3');
         });
 
-        it('returns null when compactionData is undefined', () => {
-            expect(render()).toBeNull();
+        it('renders the Nerd Font glyph when enabled', () => {
+            expect(render({
+                compactionData: { count: 3 },
+                item: { ...ITEM, metadata: { nerdFont: 'true' } }
+            })).toBe('\uF021 3');
+            expect(render({
+                compactionData: { count: 3 },
+                item: { ...ITEM, metadata: { format: 'icon-number', nerdFont: 'true' } }
+            })).toBe('\uF021 3');
         });
 
-        it('returns null when compactionData is null', () => {
-            expect(render({ compactionData: null })).toBeNull();
+        it('treats legacy icon-number metadata as the default format', () => {
+            expect(render({
+                compactionData: { count: 3 },
+                item: { ...ITEM, metadata: { format: 'icon-number' } }
+            })).toBe('↻ 3');
+        });
+
+        it('does not render the Nerd Font glyph for text-only formats', () => {
+            expect(render({
+                compactionData: { count: 3 },
+                item: { ...ITEM, metadata: { format: 'text-and-number', nerdFont: 'true' } }
+            })).toBe('Compactions: 3');
+            expect(render({
+                compactionData: { count: 3 },
+                item: { ...ITEM, metadata: { format: 'number', nerdFont: 'true' } }
+            })).toBe('3');
+        });
+
+        it('renders count of 0 by default', () => {
+            expect(render({ compactionData: { count: 0 } })).toBe('↻ 0');
+        });
+
+        it('renders 0 when compactionData is undefined', () => {
+            expect(render()).toBe('↻ 0');
+        });
+
+        it('renders 0 when compactionData is null', () => {
+            expect(render({ compactionData: null })).toBe('↻ 0');
+        });
+
+        it('returns null when count is 0 and hide zero is enabled', () => {
+            expect(render({
+                compactionData: { count: 0 },
+                item: { ...ITEM, metadata: { hideZero: 'true' } }
+            })).toBeNull();
+        });
+
+        it('renders positive counts when hide zero is enabled', () => {
+            expect(render({
+                compactionData: { count: 3 },
+                item: { ...ITEM, metadata: { hideZero: 'true' } }
+            })).toBe('↻ 3');
         });
 
         it('returns sample data in preview mode', () => {
-            expect(render({ isPreview: true })).toBe('↻2');
+            expect(render({ isPreview: true })).toBe('↻ 2');
+        });
+
+        it('returns formatted sample data in preview mode', () => {
+            expect(render({
+                isPreview: true,
+                item: { ...ITEM, metadata: { format: 'text-and-number' } }
+            })).toBe('Compactions: 2');
         });
 
         it('preview mode ignores live compactionData', () => {
             // Verify preview short-circuits before reading compactionData
-            expect(render({ isPreview: true, compactionData: { count: 99 } })).toBe('↻2');
+            expect(render({ isPreview: true, compactionData: { count: 99 } })).toBe('↻ 2');
         });
     });
 
     describe('editor', () => {
+        it('uses f and n as keybinds for the default format', () => {
+            expect(new CompactionCounterWidget().getCustomKeybinds(ITEM)).toEqual([
+                { key: 'f', label: '(f)ormat', action: 'cycle-format' },
+                { key: 'n', label: '(n)erd font', action: 'toggle-nerd-font' },
+                { key: 'h', label: '(h)ide when zero', action: 'toggle-hide-zero' }
+            ]);
+        });
+
+        it('hides the nerd font keybind for non-default formats', () => {
+            expect(new CompactionCounterWidget().getCustomKeybinds({
+                ...ITEM,
+                metadata: { format: 'text-and-number' }
+            })).toEqual([
+                { key: 'f', label: '(f)ormat', action: 'cycle-format' },
+                { key: 'h', label: '(h)ide when zero', action: 'toggle-hide-zero' }
+            ]);
+        });
+
         it('has correct editor display', () => {
-            expect(new CompactionCounterWidget().getEditorDisplay(ITEM)).toEqual({ displayText: 'Compaction Counter' });
+            expect(new CompactionCounterWidget().getEditorDisplay(ITEM)).toEqual({
+                displayText: 'Compaction Counter',
+                modifierText: '(icon-space-number)'
+            });
+        });
+
+        it('shows configured format in the editor display', () => {
+            expect(new CompactionCounterWidget().getEditorDisplay({
+                ...ITEM,
+                metadata: { format: 'number' }
+            })).toEqual({
+                displayText: 'Compaction Counter',
+                modifierText: '(number)'
+            });
+        });
+
+        it('shows nerd font in the editor display when enabled', () => {
+            expect(new CompactionCounterWidget().getEditorDisplay({
+                ...ITEM,
+                metadata: { nerdFont: 'true' }
+            })).toEqual({
+                displayText: 'Compaction Counter',
+                modifierText: '(icon-space-number, nerd font)'
+            });
+        });
+
+        it('shows hide zero in the editor display when enabled', () => {
+            expect(new CompactionCounterWidget().getEditorDisplay({
+                ...ITEM,
+                metadata: { hideZero: 'true' }
+            })).toEqual({
+                displayText: 'Compaction Counter',
+                modifierText: '(icon-space-number, hide zero)'
+            });
+        });
+
+        it('ignores stale icon-number format metadata in the editor display', () => {
+            expect(new CompactionCounterWidget().getEditorDisplay({
+                ...ITEM,
+                metadata: { format: 'icon-number', nerdFont: 'true' }
+            })).toEqual({
+                displayText: 'Compaction Counter',
+                modifierText: '(icon-space-number, nerd font)'
+            });
+        });
+
+        it('cycles icon-space-number -> text-and-number -> number -> icon-space-number', () => {
+            const widget = new CompactionCounterWidget();
+            const textAndNumber = widget.handleEditorAction('cycle-format', ITEM);
+            const number = widget.handleEditorAction('cycle-format', textAndNumber ?? ITEM);
+            const iconSpaceNumber = widget.handleEditorAction('cycle-format', number ?? ITEM);
+
+            expect(textAndNumber?.metadata?.format).toBe('text-and-number');
+            expect(number?.metadata?.format).toBe('number');
+            expect(iconSpaceNumber?.metadata?.format).toBeUndefined();
+        });
+
+        it('removes nerd font metadata when cycling away from icon-space-number', () => {
+            const widget = new CompactionCounterWidget();
+            const base: WidgetItem = { ...ITEM, metadata: { nerdFont: 'true' } };
+            const textAndNumber = widget.handleEditorAction('cycle-format', base);
+
+            expect(textAndNumber?.metadata?.format).toBe('text-and-number');
+            expect(textAndNumber?.metadata?.nerdFont).toBeUndefined();
+        });
+
+        it('toggles nerd font metadata on and off', () => {
+            const widget = new CompactionCounterWidget();
+            const enabled = widget.handleEditorAction('toggle-nerd-font', ITEM);
+            const disabled = widget.handleEditorAction('toggle-nerd-font', enabled ?? ITEM);
+
+            expect(enabled?.metadata?.nerdFont).toBe('true');
+            expect(disabled?.metadata?.nerdFont).toBeUndefined();
+        });
+
+        it('toggles hide zero metadata on and off', () => {
+            const widget = new CompactionCounterWidget();
+            const enabled = widget.handleEditorAction('toggle-hide-zero', ITEM);
+            const disabled = widget.handleEditorAction('toggle-hide-zero', enabled ?? ITEM);
+
+            expect(enabled?.metadata?.hideZero).toBe('true');
+            expect(disabled?.metadata?.hideZero).toBe('false');
+        });
+
+        it('does not enable nerd font for non-default formats', () => {
+            const widget = new CompactionCounterWidget();
+            const enabled = widget.handleEditorAction('toggle-nerd-font', {
+                ...ITEM,
+                metadata: { format: 'text-and-number' }
+            });
+
+            expect(enabled?.metadata?.format).toBe('text-and-number');
+            expect(enabled?.metadata?.nerdFont).toBeUndefined();
         });
     });
 });

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -62,3 +62,4 @@ export { GitWorktreeModeWidget } from './GitWorktreeMode';
 export { GitWorktreeNameWidget } from './GitWorktreeName';
 export { GitWorktreeBranchWidget } from './GitWorktreeBranch';
 export { GitWorktreeOriginalBranchWidget } from './GitWorktreeOriginalBranch';
+export { CompactionCounterWidget } from './CompactionCounter';


### PR DESCRIPTION
## Summary

- Adds a `compaction-counter` widget that tracks context compaction events per session
- When Claude Code compacts conversation context, `used_percentage` drops — this widget detects the drop and displays `↻N`
- Addresses the detection gap noted in #92 by using statusline data instead of JSONL transcripts

## How It Works

Context only grows until compaction — any drop in `used_percentage` > 2 percentage points between consecutive renders is counted as a compaction event. The 2-point threshold filters rounding noise and cache accounting wobble (±1 point) while reliably catching real compaction events on both 200K and 1M context windows.

Per-session state is stored in `~/.cache/ccstatusline/compaction/compaction-{sessionId}.json`, following the skills caching pattern.

### Caveats

- Manual `/compact` detection is delayed until the next assistant message (no statusline update on `/compact` itself)
- `used_percentage` excludes system overhead (~15%, per anthropics/claude-code#34537), but relative drops between renders are still observable
- The 2% threshold is a reasonable starting point; real-world telemetry would help calibrate further

## Changes

| File | Change |
|------|--------|
| `src/utils/compaction.ts` | New — detection logic + session state I/O (Zod-validated) |
| `src/widgets/CompactionCounter.ts` | New — widget class (returns `↻N` or null, supports preview mode) |
| `src/utils/__tests__/compaction.test.ts` | New — 11 detection unit tests |
| `src/widgets/__tests__/CompactionCounter.test.ts` | New — 13 widget tests |
| `src/types/RenderContext.ts` | Added `CompactionData` interface and `compactionData` field |
| `src/ccstatusline.ts` | Compaction detection in render pipeline (conditional, only when widget is configured) |
| `src/utils/widget-manifest.ts` | Registered `compaction-counter` |
| `src/widgets/index.ts` | Barrel export |

## Design Decisions

- **No configurable threshold** — kept simple for first contribution. 2% handles both 200K and 1M windows.
- **Conditional gathering** — compaction detection only runs when the widget is present in the configured layout (follows existing pattern for speed/skills widgets)
- **Zod validation** on state file parse to handle corruption gracefully
- **JSON state files** (not JSONL) since we only track 2 numbers per session

## Test Plan

- [x] `bun test` — 24 new tests pass (11 detection + 13 widget), no regressions
- [x] `bun run lint` — zero errors, zero warnings
- [x] `bun run build` — succeeds, `dist/ccstatusline.js` produced
- [x] 3 pre-existing keychain test failures confirmed present on main (not introduced by this PR)

## Recent changes

  - **Security:** Sanitize session ID before using in cache filename to prevent path traversal
  - **Reliability:** Cache write failures are now best-effort — no longer crash the status line
  - **Tests:** Added persistence round-trip, path traversal regression, and write failure tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)