### PR TITLE
Add session-budget, weekly-budget, and peak-hours widgets

### DIFF
--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -54,7 +54,10 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'context-bar', create: () => new widgets.ContextBarWidget() },
     { type: 'skills', create: () => new widgets.SkillsWidget() },
     { type: 'thinking-effort', create: () => new widgets.ThinkingEffortWidget() },
-    { type: 'vim-mode', create: () => new widgets.VimModeWidget() }
+    { type: 'vim-mode', create: () => new widgets.VimModeWidget() },
+    { type: 'session-budget', create: () => new widgets.SessionBudgetWidget() },
+    { type: 'weekly-budget', create: () => new widgets.WeeklyBudgetWidget() },
+    { type: 'peak-hours', create: () => new widgets.PeakHoursWidget() }
 ];
 
 export const LAYOUT_WIDGET_MANIFEST: LayoutWidgetManifestEntry[] = [

--- a/src/widgets/PeakHours.ts
+++ b/src/widgets/PeakHours.ts
@@ -1,0 +1,114 @@
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+
+import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
+
+const PEAK_START_HOUR = 5;  // 5am PT
+const PEAK_END_HOUR = 11;   // 11am PT
+const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+
+interface PeakTimeInfo {
+    isPeak: boolean;
+    dayName: string;
+    hour: number;
+    minute: number;
+}
+
+function getPacificTime(now: Date = new Date()): PeakTimeInfo {
+    const dtf = new Intl.DateTimeFormat('en-US', {
+        timeZone: 'America/Los_Angeles',
+        hour: 'numeric',
+        minute: 'numeric',
+        weekday: 'short',
+        hour12: false
+    });
+    const parts = Object.fromEntries(
+        dtf.formatToParts(now).map(p => [p.type, p.value])
+    );
+    const dayName = parts.weekday ?? '';
+    const hour = parseInt(parts.hour ?? '0', 10);
+    const minute = parseInt(parts.minute ?? '0', 10);
+    const isWeekday = WEEKDAYS.includes(dayName);
+    const isPeak = isWeekday && hour >= PEAK_START_HOUR && hour < PEAK_END_HOUR;
+
+    return { isPeak, dayName, hour, minute };
+}
+
+function formatDuration(totalMinutes: number): string {
+    if (totalMinutes <= 0)
+        return '0m';
+    const h = Math.floor(totalMinutes / 60);
+    const m = totalMinutes % 60;
+    if (h === 0)
+        return `${m}m`;
+    if (m === 0)
+        return `${h}h`;
+    return `${h}h${m}m`;
+}
+
+function minutesUntilHour(currentHour: number, currentMinute: number, targetHour: number): number {
+    return (targetHour - currentHour) * 60 - currentMinute;
+}
+
+function getCountdown(info: PeakTimeInfo): string {
+    const { isPeak, dayName, hour, minute } = info;
+
+    if (isPeak) {
+        return formatDuration(minutesUntilHour(hour, minute, PEAK_END_HOUR));
+    }
+
+    const dayIndex = WEEKDAYS.indexOf(dayName);
+    const isWeekday = dayIndex !== -1;
+    let daysUntil: number;
+
+    if (isWeekday && hour < PEAK_START_HOUR) {
+        daysUntil = 0;
+    } else if (dayIndex === 4 && hour >= PEAK_END_HOUR) {
+        daysUntil = 3; // Friday after peak → Monday
+    } else if (dayName === 'Sat') {
+        daysUntil = 2;
+    } else if (dayName === 'Sun') {
+        daysUntil = 1;
+    } else if (isWeekday && hour >= PEAK_END_HOUR) {
+        daysUntil = 1;
+    } else {
+        daysUntil = 0;
+    }
+
+    const totalMinutes = daysUntil * 24 * 60 + minutesUntilHour(hour, minute, PEAK_START_HOUR);
+    return formatDuration(totalMinutes);
+}
+
+export class PeakHoursWidget implements Widget {
+    getDefaultColor(): string { return 'brightRed'; }
+    getDescription(): string { return 'Shows whether Anthropic peak hours are active (weekdays 5am\u201311am PT) with countdown'; }
+    getDisplayName(): string { return 'Peak Hours'; }
+    getCategory(): string { return 'Usage'; }
+
+    getEditorDisplay(_item: WidgetItem): WidgetEditorDisplay {
+        return { displayText: this.getDisplayName() };
+    }
+
+    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+        if (context.isPreview) {
+            return formatRawOrLabeledValue(item, '', '\u26a1 Peak 3h20m');
+        }
+
+        const info = getPacificTime();
+        const countdown = getCountdown(info);
+
+        if (info.isPeak) {
+            return formatRawOrLabeledValue(item, '', `\u26a1 Peak ${countdown}`);
+        }
+
+        return formatRawOrLabeledValue(item, '', `Off-peak ${countdown}`);
+    }
+
+    supportsRawValue(): boolean { return false; }
+    supportsColors(_item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/SessionBudget.ts
+++ b/src/widgets/SessionBudget.ts
@@ -1,0 +1,62 @@
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+import {
+    getUsageErrorMessage,
+    resolveUsageWindowWithFallback
+} from '../utils/usage';
+import { FIVE_HOUR_BLOCK_MS } from '../utils/usage-types';
+
+import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
+
+function formatBudgetIndicator(usagePercent: number, elapsedMs: number, totalMs: number): string {
+    const expectedPercent = (elapsedMs / totalMs) * 100;
+    const diff = Math.round(usagePercent - expectedPercent);
+
+    if (diff > 0)
+        return `\u2191${diff}%`;
+    if (diff < 0)
+        return `\u2193${Math.abs(diff)}%`;
+    return '\u21940%';
+}
+
+export class SessionBudgetWidget implements Widget {
+    getDefaultColor(): string { return 'brightYellow'; }
+    getDescription(): string { return 'Shows 5-hour session usage with budget surplus/deficit indicator'; }
+    getDisplayName(): string { return 'Session Budget'; }
+    getCategory(): string { return 'Usage'; }
+
+    getEditorDisplay(_item: WidgetItem): WidgetEditorDisplay {
+        return { displayText: this.getDisplayName() };
+    }
+
+    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+        if (context.isPreview) {
+            return formatRawOrLabeledValue(item, '5h: ', '32% \u219334%');
+        }
+
+        const data = context.usageData ?? {};
+        if (data.error)
+            return getUsageErrorMessage(data.error);
+        if (data.sessionUsage === undefined)
+            return null;
+
+        const percent = Math.max(0, Math.min(100, data.sessionUsage));
+        const rounded = Math.round(percent);
+        const window = resolveUsageWindowWithFallback(data, context.blockMetrics);
+
+        if (window && window.elapsedMs > 0 && window.remainingMs > 0) {
+            const indicator = formatBudgetIndicator(percent, window.elapsedMs, FIVE_HOUR_BLOCK_MS);
+            return formatRawOrLabeledValue(item, '5h: ', `${rounded}% ${indicator}`);
+        }
+
+        return formatRawOrLabeledValue(item, '5h: ', `${rounded}%`);
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(_item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/WeeklyBudget.ts
+++ b/src/widgets/WeeklyBudget.ts
@@ -1,0 +1,62 @@
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+import {
+    getUsageErrorMessage,
+    resolveWeeklyUsageWindow
+} from '../utils/usage';
+import { SEVEN_DAY_WINDOW_MS } from '../utils/usage-types';
+
+import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
+
+function formatBudgetIndicator(usagePercent: number, elapsedMs: number, totalMs: number): string {
+    const expectedPercent = (elapsedMs / totalMs) * 100;
+    const diff = Math.round(usagePercent - expectedPercent);
+
+    if (diff > 0)
+        return `\u2191${diff}%`;
+    if (diff < 0)
+        return `\u2193${Math.abs(diff)}%`;
+    return '\u21940%';
+}
+
+export class WeeklyBudgetWidget implements Widget {
+    getDefaultColor(): string { return 'brightYellow'; }
+    getDescription(): string { return 'Shows weekly usage with budget surplus/deficit indicator'; }
+    getDisplayName(): string { return 'Weekly Budget'; }
+    getCategory(): string { return 'Usage'; }
+
+    getEditorDisplay(_item: WidgetItem): WidgetEditorDisplay {
+        return { displayText: this.getDisplayName() };
+    }
+
+    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+        if (context.isPreview) {
+            return formatRawOrLabeledValue(item, 'Week: ', '27% \u21939%');
+        }
+
+        const data = context.usageData ?? {};
+        if (data.error)
+            return getUsageErrorMessage(data.error);
+        if (data.weeklyUsage === undefined)
+            return null;
+
+        const percent = Math.max(0, Math.min(100, data.weeklyUsage));
+        const rounded = Math.round(percent);
+        const window = resolveWeeklyUsageWindow(data);
+
+        if (window && window.elapsedMs > 0 && window.remainingMs > 0) {
+            const indicator = formatBudgetIndicator(percent, window.elapsedMs, SEVEN_DAY_WINDOW_MS);
+            return formatRawOrLabeledValue(item, 'Week: ', `${rounded}% ${indicator}`);
+        }
+
+        return formatRawOrLabeledValue(item, 'Week: ', `${rounded}%`);
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(_item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/__tests__/PeakHours.test.ts
+++ b/src/widgets/__tests__/PeakHours.test.ts
@@ -1,0 +1,60 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import { DEFAULT_SETTINGS } from '../../types/Settings';
+import type { WidgetItem } from '../../types/Widget';
+import { PeakHoursWidget } from '../PeakHours';
+
+const baseItem: WidgetItem = { id: 'test', type: 'peak-hours' };
+
+function render(item: WidgetItem, context: RenderContext = {}): string | null {
+    return new PeakHoursWidget().render(item, context, DEFAULT_SETTINGS);
+}
+
+describe('PeakHoursWidget', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns preview text', () => {
+        expect(render(baseItem, { isPreview: true })).toBe('\u26a1 Peak 3h20m');
+    });
+
+    it('shows peak during weekday peak hours', () => {
+        // Wednesday 8:00 AM PT = Wednesday 3:00 PM UTC
+        vi.setSystemTime(new Date('2026-04-08T15:00:00Z'));
+        const result = render(baseItem);
+        expect(result).toContain('\u26a1 Peak');
+        expect(result).toContain('3h');
+    });
+
+    it('shows off-peak during weekday non-peak hours', () => {
+        // Wednesday 2:00 PM PT = Wednesday 9:00 PM UTC
+        vi.setSystemTime(new Date('2026-04-08T21:00:00Z'));
+        const result = render(baseItem);
+        expect(result).toContain('Off-peak');
+    });
+
+    it('shows off-peak on weekends', () => {
+        // Saturday 8:00 AM PT = Saturday 3:00 PM UTC
+        vi.setSystemTime(new Date('2026-04-11T15:00:00Z'));
+        const result = render(baseItem);
+        expect(result).toContain('Off-peak');
+    });
+
+    it('returns non-null for all conditions', () => {
+        vi.setSystemTime(new Date('2026-04-06T12:00:00Z'));
+        expect(render(baseItem)).not.toBeNull();
+    });
+});

--- a/src/widgets/__tests__/SessionBudget.test.ts
+++ b/src/widgets/__tests__/SessionBudget.test.ts
@@ -1,0 +1,74 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import { DEFAULT_SETTINGS } from '../../types/Settings';
+import type { WidgetItem } from '../../types/Widget';
+import * as jsonl from '../../utils/jsonl';
+import { SessionBudgetWidget } from '../SessionBudget';
+
+const baseItem: WidgetItem = { id: 'test', type: 'session-budget' };
+const rawItem: WidgetItem = { ...baseItem, rawValue: true };
+
+function render(item: WidgetItem, context: RenderContext = {}): string | null {
+    return new SessionBudgetWidget().render(item, context, DEFAULT_SETTINGS);
+}
+
+describe('SessionBudgetWidget', () => {
+    beforeEach(() => {
+        // Prevent cached block metrics from interfering
+        vi.spyOn(jsonl, 'getCachedBlockMetrics').mockReturnValue(null);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns preview text', () => {
+        expect(render(baseItem, { isPreview: true })).toBe('5h: 32% \u219334%');
+    });
+
+    it('returns null when no usage data', () => {
+        expect(render(baseItem, {})).toBeNull();
+    });
+
+    it('returns error message on usage error', () => {
+        expect(render(baseItem, { usageData: { error: 'timeout' } })).toBe('[Timeout]');
+    });
+
+    it('shows usage without indicator when no reset time', () => {
+        expect(render(baseItem, { usageData: { sessionUsage: 45 } })).toBe('5h: 45%');
+    });
+
+    it('shows usage with down arrow when under budget', () => {
+        const now = Date.now();
+        const resetAt = new Date(now + 2 * 60 * 60 * 1000).toISOString(); // 2h remaining = 3h elapsed = 60%
+        const result = render(baseItem, { usageData: { sessionUsage: 20, sessionResetAt: resetAt } });
+        // 60% expected, 20% actual → ↓40%
+        expect(result).toBe('5h: 20% \u219340%');
+    });
+
+    it('shows usage with up arrow when over budget', () => {
+        const now = Date.now();
+        const resetAt = new Date(now + 4 * 60 * 60 * 1000).toISOString(); // 4h remaining = 1h elapsed = 20%
+        const result = render(baseItem, { usageData: { sessionUsage: 60, sessionResetAt: resetAt } });
+        // 20% expected, 60% actual → ↑40%
+        expect(result).toBe('5h: 60% \u219140%');
+    });
+
+    it('supports raw value (no label)', () => {
+        const result = render(rawItem, { usageData: { sessionUsage: 30 } });
+        expect(result).toBe('30%');
+    });
+
+    it('clamps usage to 0-100', () => {
+        expect(render(baseItem, { usageData: { sessionUsage: 150 } })).toBe('5h: 100%');
+        expect(render(baseItem, { usageData: { sessionUsage: -10 } })).toBe('5h: 0%');
+    });
+});

--- a/src/widgets/__tests__/WeeklyBudget.test.ts
+++ b/src/widgets/__tests__/WeeklyBudget.test.ts
@@ -1,0 +1,58 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import { DEFAULT_SETTINGS } from '../../types/Settings';
+import type { WidgetItem } from '../../types/Widget';
+import { WeeklyBudgetWidget } from '../WeeklyBudget';
+
+const baseItem: WidgetItem = { id: 'test', type: 'weekly-budget' };
+const rawItem: WidgetItem = { ...baseItem, rawValue: true };
+
+function render(item: WidgetItem, context: RenderContext = {}): string | null {
+    return new WeeklyBudgetWidget().render(item, context, DEFAULT_SETTINGS);
+}
+
+describe('WeeklyBudgetWidget', () => {
+    it('returns preview text', () => {
+        expect(render(baseItem, { isPreview: true })).toBe('Week: 27% \u21939%');
+    });
+
+    it('returns null when no usage data', () => {
+        expect(render(baseItem, {})).toBeNull();
+    });
+
+    it('returns error message on usage error', () => {
+        expect(render(baseItem, { usageData: { error: 'api-error' } })).toBe('[API Error]');
+    });
+
+    it('shows usage without indicator when no reset time', () => {
+        expect(render(baseItem, { usageData: { weeklyUsage: 27 } })).toBe('Week: 27%');
+    });
+
+    it('shows usage with down arrow when under budget', () => {
+        const now = Date.now();
+        // 3.5 days remaining = 3.5 days elapsed = 50% expected
+        const resetAt = new Date(now + 3.5 * 24 * 60 * 60 * 1000).toISOString();
+        const result = render(baseItem, { usageData: { weeklyUsage: 20, weeklyResetAt: resetAt } });
+        // 50% expected, 20% actual → ↓30%
+        expect(result).toBe('Week: 20% \u219330%');
+    });
+
+    it('shows usage with up arrow when over budget', () => {
+        const now = Date.now();
+        // 6 days remaining = 1 day elapsed ≈ 14% expected
+        const resetAt = new Date(now + 6 * 24 * 60 * 60 * 1000).toISOString();
+        const result = render(baseItem, { usageData: { weeklyUsage: 50, weeklyResetAt: resetAt } });
+        // ~14% expected, 50% actual → ↑36%
+        expect(result).toBe('Week: 50% \u219136%');
+    });
+
+    it('supports raw value (no label)', () => {
+        const result = render(rawItem, { usageData: { weeklyUsage: 30 } });
+        expect(result).toBe('30%');
+    });
+});

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -36,3 +36,6 @@ export { LinkWidget } from './Link';
 export { SkillsWidget } from './Skills';
 export { ThinkingEffortWidget } from './ThinkingEffort';
 export { VimModeWidget } from './VimMode';
+export { SessionBudgetWidget } from './SessionBudget';
+export { WeeklyBudgetWidget } from './WeeklyBudget';
+export { PeakHoursWidget } from './PeakHours';


### PR DESCRIPTION
## Summary

Three new widgets for tracking Claude Code usage budget and Anthropic peak hours:

- **`session-budget`** — Shows 5-hour session usage with a surplus/deficit indicator relative to linear pacing. Example: `5h: 32% ↓34%` means usage is 34% below the expected pace (you have headroom). `↑` means you're burning faster than expected.
- **`weekly-budget`** — Same concept applied to the 7-day rolling window. Example: `Week: 27% ↓9%`
- **`peak-hours`** — Shows whether Anthropic's peak hours are active (weekdays 5am–11am PT / 1pm–7pm GMT) with a countdown to the next toggle. Example: `⚡ Peak 3h20m` or `Off-peak 17h37m`

### How budget indicators work

```
Expected usage = (elapsed time / total window) × 100%
Difference = actual − expected

↓ = under budget (good — headroom remaining)
↑ = over budget (burning fast)
```

### Widget types

| Type | Category | Raw Value | Colors |
|------|----------|-----------|--------|
| `session-budget` | Usage | ✅ | ✅ |
| `weekly-budget` | Usage | ✅ | ✅ |
| `peak-hours` | Usage | ❌ | ✅ |

## Implementation details

- Reuses existing `resolveUsageWindowWithFallback` and `resolveWeeklyUsageWindow` utilities for elapsed/remaining time calculation
- Reuses `formatRawOrLabeledValue`, `getUsageErrorMessage` shared helpers
- Peak hours uses `Intl.DateTimeFormat` with `America/Los_Angeles` timezone for reliable cross-locale PT conversion
- All widgets follow the standard `Widget` interface pattern with preview mode support

## Test plan

- [x] `SessionBudget` — 8 tests (preview, null data, errors, under/over budget arrows, raw value, clamping)
- [x] `WeeklyBudget` — 7 tests (preview, null data, errors, under/over budget, raw value)
- [x] `PeakHours` — 5 tests (preview, peak detection, off-peak detection, weekends, non-null guarantee)
- [x] All 20 tests pass
- [x] Lint clean (zero warnings)
- [x] No regressions in existing widget tests