### PR TITLE
feat: add refreshInterval configuration for Claude Code status line

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -19,10 +19,13 @@ import {
     CCSTATUSLINE_COMMANDS,
     getClaudeSettingsPath,
     getExistingStatusLine,
+    getRefreshInterval,
     installStatusLine,
     isBunxAvailable,
+    isClaudeCodeVersionAtLeast,
     isInstalled,
     isKnownCommand,
+    setRefreshInterval,
     uninstallStatusLine
 } from '../utils/claude-settings';
 import { cloneSettings } from '../utils/clone-settings';
@@ -50,6 +53,7 @@ import {
     LineSelector,
     MainMenu,
     PowerlineSetup,
+    RefreshIntervalMenu,
     StatusLinePreview,
     TerminalOptionsMenu,
     TerminalWidthMenu,
@@ -73,7 +77,8 @@ type AppScreen = 'main'
     | 'globalOverrides'
     | 'confirm'
     | 'powerline'
-    | 'install';
+    | 'install'
+    | 'refreshInterval';
 
 interface ConfirmDialogState {
     message: string;
@@ -112,6 +117,8 @@ export const App: React.FC = () => {
     const [existingStatusLine, setExistingStatusLine] = useState<string | null>(null);
     const [flashMessage, setFlashMessage] = useState<FlashMessage | null>(null);
     const [previewIsTruncated, setPreviewIsTruncated] = useState(false);
+    const [currentRefreshInterval, setCurrentRefreshInterval] = useState<number | null>(null);
+    const [supportsRefreshInterval] = useState(() => isClaudeCodeVersionAtLeast('2.1.97'));
 
     useEffect(() => {
         // Load existing status line
@@ -124,6 +131,7 @@ export const App: React.FC = () => {
             setOriginalSettings(cloneSettings(loadedSettings));
         });
         void isInstalled().then(setIsClaudeInstalled);
+        void getRefreshInterval().then(setCurrentRefreshInterval);
 
         // Check for Powerline fonts on startup (use sync version that doesn't call execSync)
         const fontStatus = checkPowerlineFonts();
@@ -197,7 +205,7 @@ export const App: React.FC = () => {
                 message,
                 cancelScreen: 'install',
                 action: async () => {
-                    await installStatusLine(useBunx);
+                    await installStatusLine(useBunx, supportsRefreshInterval);
                     setIsClaudeInstalled(true);
                     setExistingStatusLine(command);
                     setScreen('main');
@@ -206,7 +214,7 @@ export const App: React.FC = () => {
             });
             setScreen('confirm');
         });
-    }, []);
+    }, [supportsRefreshInterval]);
 
     const handleNpxInstall = useCallback(() => {
         setMenuSelections(prev => ({ ...prev, install: 0 }));
@@ -236,6 +244,7 @@ export const App: React.FC = () => {
                     await uninstallStatusLine();
                     setIsClaudeInstalled(false);
                     setExistingStatusLine(null);
+                    setCurrentRefreshInterval(null);
                     setScreen('main');
                     setConfirmDialog(null);
                 }
@@ -266,6 +275,9 @@ export const App: React.FC = () => {
                 break;
             case 'install':
                 handleInstallUninstall();
+                break;
+            case 'configureStatusLine':
+                setScreen('refreshInterval');
                 break;
             case 'starGithub':
                 setConfirmDialog({
@@ -493,6 +505,34 @@ export const App: React.FC = () => {
                         onSelectBunx={handleBunxInstall}
                         onCancel={handleInstallMenuCancel}
                         initialSelection={menuSelections.install}
+                    />
+                )}
+                {screen === 'refreshInterval' && (
+                    <RefreshIntervalMenu
+                        currentInterval={currentRefreshInterval}
+                        supportsRefreshInterval={supportsRefreshInterval}
+                        onUpdate={(interval) => {
+                            const previous = currentRefreshInterval;
+                            setCurrentRefreshInterval(interval);
+                            void setRefreshInterval(interval)
+                                .then(() => {
+                                    setFlashMessage({
+                                        text: '✓ Refresh interval updated',
+                                        color: 'green'
+                                    });
+                                })
+                                .catch(() => {
+                                    setCurrentRefreshInterval(previous);
+                                    setFlashMessage({
+                                        text: '✗ Failed to save refresh interval',
+                                        color: 'red'
+                                    });
+                                });
+                            setScreen('main');
+                        }}
+                        onBack={() => {
+                            setScreen('main');
+                        }}
                     />
                 )}
                 {screen === 'powerline' && (

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -19,7 +19,6 @@ import {
     CCSTATUSLINE_COMMANDS,
     getClaudeSettingsPath,
     getExistingStatusLine,
-    getRefreshInterval,
     installStatusLine,
     isBunxAvailable,
     isClaudeCodeVersionAtLeast,
@@ -44,6 +43,7 @@ import {
 } from '../utils/powerline';
 import { getPackageVersion } from '../utils/terminal';
 
+import { loadClaudeStatusLineState } from './claude-status';
 import {
     ColorMenu,
     ConfirmDialog,
@@ -121,9 +121,10 @@ export const App: React.FC = () => {
     const [supportsRefreshInterval] = useState(() => isClaudeCodeVersionAtLeast('2.1.97'));
 
     useEffect(() => {
-        // Load existing status line
-        void getExistingStatusLine().then(setExistingStatusLine);
-
+        void loadClaudeStatusLineState().then((statusLineState) => {
+            setExistingStatusLine(statusLineState.existingStatusLine);
+            setCurrentRefreshInterval(statusLineState.refreshInterval);
+        });
         void loadSettings().then((loadedSettings) => {
             // Set global chalk level based on settings (default to 256 colors for compatibility)
             chalk.level = loadedSettings.colorLevel;
@@ -131,7 +132,6 @@ export const App: React.FC = () => {
             setOriginalSettings(cloneSettings(loadedSettings));
         });
         void isInstalled().then(setIsClaudeInstalled);
-        void getRefreshInterval().then(setCurrentRefreshInterval);
 
         // Check for Powerline fonts on startup (use sync version that doesn't call execSync)
         const fontStatus = checkPowerlineFonts();
@@ -206,8 +206,10 @@ export const App: React.FC = () => {
                 cancelScreen: 'install',
                 action: async () => {
                     await installStatusLine(useBunx, supportsRefreshInterval);
+                    const installedStatusLineState = await loadClaudeStatusLineState();
                     setIsClaudeInstalled(true);
-                    setExistingStatusLine(command);
+                    setExistingStatusLine(installedStatusLineState.existingStatusLine ?? command);
+                    setCurrentRefreshInterval(installedStatusLineState.refreshInterval);
                     setScreen('main');
                     setConfirmDialog(null);
                 }

--- a/src/tui/__tests__/claude-status.test.ts
+++ b/src/tui/__tests__/claude-status.test.ts
@@ -1,0 +1,69 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    afterAll,
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import { saveClaudeSettings } from '../../utils/claude-settings';
+import { loadClaudeStatusLineState } from '../claude-status';
+
+const ORIGINAL_CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR;
+let testClaudeConfigDir = '';
+
+beforeEach(() => {
+    testClaudeConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-claude-status-'));
+    process.env.CLAUDE_CONFIG_DIR = testClaudeConfigDir;
+});
+
+afterEach(() => {
+    if (testClaudeConfigDir) {
+        fs.rmSync(testClaudeConfigDir, { recursive: true, force: true });
+    }
+});
+
+afterAll(() => {
+    if (ORIGINAL_CLAUDE_CONFIG_DIR === undefined) {
+        delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+        process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CLAUDE_CONFIG_DIR;
+    }
+});
+
+describe('loadClaudeStatusLineState', () => {
+    it('loads both the installed command and refresh interval from Claude settings', async () => {
+        await saveClaudeSettings({
+            statusLine: {
+                type: 'command',
+                command: 'npx -y ccstatusline@latest',
+                padding: 0,
+                refreshInterval: 10
+            }
+        });
+
+        await expect(loadClaudeStatusLineState()).resolves.toEqual({
+            existingStatusLine: 'npx -y ccstatusline@latest',
+            refreshInterval: 10
+        });
+    });
+
+    it('returns null refreshInterval when Claude settings do not define one', async () => {
+        await saveClaudeSettings({
+            statusLine: {
+                type: 'command',
+                command: 'npx -y ccstatusline@latest',
+                padding: 0
+            }
+        });
+
+        await expect(loadClaudeStatusLineState()).resolves.toEqual({
+            existingStatusLine: 'npx -y ccstatusline@latest',
+            refreshInterval: null
+        });
+    });
+});

--- a/src/tui/claude-status.ts
+++ b/src/tui/claude-status.ts
@@ -1,0 +1,24 @@
+import {
+    getExistingStatusLine,
+    getRefreshInterval
+} from '../utils/claude-settings';
+
+export interface ClaudeStatusLineState {
+    existingStatusLine: string | null;
+    refreshInterval: number | null;
+}
+
+export async function loadClaudeStatusLineState(): Promise<ClaudeStatusLineState> {
+    const [
+        existingStatusLine,
+        refreshInterval
+    ] = await Promise.all([
+        getExistingStatusLine(),
+        getRefreshInterval()
+    ]);
+
+    return {
+        existingStatusLine,
+        refreshInterval
+    };
+}

--- a/src/tui/components/MainMenu.tsx
+++ b/src/tui/components/MainMenu.tsx
@@ -15,6 +15,7 @@ export type MainMenuOption = 'lines'
     | 'terminalConfig'
     | 'globalOverrides'
     | 'install'
+    | 'configureStatusLine'
     | 'starGithub'
     | 'save'
     | 'exit';
@@ -75,15 +76,27 @@ export const MainMenu: React.FC<MainMenuProps> = ({
                 'Set global padding, separators, and color overrides that apply to all widgets'
         },
         '-' as const,
-        {
-            label: isClaudeInstalled
-                ? '🔌 Uninstall from Claude Code'
-                : '📦 Install to Claude Code',
-            value: 'install',
-            description: isClaudeInstalled
-                ? 'Remove ccstatusline from your Claude Code settings'
-                : 'Add ccstatusline to your Claude Code settings for automatic status line rendering'
-        }
+        ...(isClaudeInstalled
+            ? [
+                {
+                    label: '🔧 Configure Status Line',
+                    value: 'configureStatusLine' as MainMenuOption,
+                    description: 'Configure Claude Code status line settings like refresh interval'
+                },
+                {
+                    label: '🔌 Uninstall from Claude Code',
+                    value: 'install' as MainMenuOption,
+                    description: 'Remove ccstatusline from your Claude Code settings'
+                }
+            ]
+            : [
+                {
+                    label: '📦 Install to Claude Code',
+                    value: 'install' as MainMenuOption,
+                    description: 'Add ccstatusline to your Claude Code settings for automatic status line rendering'
+                }
+            ]
+        )
     ];
 
     if (hasChanges) {

--- a/src/tui/components/RefreshIntervalMenu.tsx
+++ b/src/tui/components/RefreshIntervalMenu.tsx
@@ -1,0 +1,166 @@
+import {
+    Box,
+    Text,
+    useInput
+} from 'ink';
+import React, { useState } from 'react';
+
+import { shouldInsertInput } from '../../utils/input-guards';
+
+import {
+    List,
+    type ListEntry
+} from './List';
+
+type ConfigureStatusLineValue = 'refreshInterval';
+
+function getRefreshIntervalSublabel(interval: number | null, supported: boolean): string {
+    if (!supported) {
+        return '(requires Claude Code >=2.1.97)';
+    }
+
+    if (interval === null) {
+        return '(not set)';
+    }
+
+    return `(${interval}s)`;
+}
+
+export function buildConfigureStatusLineItems(
+    refreshInterval: number | null,
+    supportsRefreshInterval: boolean
+): ListEntry<ConfigureStatusLineValue>[] {
+    return [
+        {
+            label: '🔄 Refresh Interval',
+            sublabel: getRefreshIntervalSublabel(refreshInterval, supportsRefreshInterval),
+            value: 'refreshInterval',
+            disabled: !supportsRefreshInterval,
+            description: supportsRefreshInterval
+                ? 'How often Claude Code refreshes the status line by re-running the command. Enter value in seconds (1-60), or leave empty to remove.'
+                : 'This setting requires Claude Code version 2.1.97 or later. Please update Claude Code to use this feature.'
+        }
+    ];
+}
+
+export function validateRefreshIntervalInput(value: string): string | null {
+    if (value === '') {
+        return null;
+    }
+
+    const parsed = parseInt(value, 10);
+
+    if (isNaN(parsed)) {
+        return 'Please enter a valid number';
+    }
+
+    if (parsed < 1) {
+        return `Minimum interval is 1s (you entered ${parsed}s)`;
+    }
+
+    if (parsed > 60) {
+        return `Maximum interval is 60s (you entered ${parsed}s)`;
+    }
+
+    return null;
+}
+
+export interface RefreshIntervalMenuProps {
+    currentInterval: number | null;
+    supportsRefreshInterval: boolean;
+    onUpdate: (interval: number | null) => void;
+    onBack: () => void;
+}
+
+export const RefreshIntervalMenu: React.FC<RefreshIntervalMenuProps> = ({
+    currentInterval,
+    supportsRefreshInterval,
+    onUpdate,
+    onBack
+}) => {
+    const [editingRefreshInterval, setEditingRefreshInterval] = useState(false);
+    const [refreshInput, setRefreshInput] = useState(currentInterval !== null ? String(currentInterval) : '10');
+    const [validationError, setValidationError] = useState<string | null>(null);
+
+    useInput((input, key) => {
+        if (editingRefreshInterval) {
+            if (key.return) {
+                if (refreshInput === '') {
+                    onUpdate(null);
+                    setEditingRefreshInterval(false);
+                    setValidationError(null);
+                    return;
+                }
+
+                const error = validateRefreshIntervalInput(refreshInput);
+
+                if (error) {
+                    setValidationError(error);
+                } else {
+                    const value = parseInt(refreshInput, 10);
+                    onUpdate(value);
+                    setEditingRefreshInterval(false);
+                    setValidationError(null);
+                }
+            } else if (key.escape) {
+                setRefreshInput(currentInterval !== null ? String(currentInterval) : '10');
+                setEditingRefreshInterval(false);
+                setValidationError(null);
+            } else if (key.backspace) {
+                setRefreshInput(refreshInput.slice(0, -1));
+                setValidationError(null);
+            } else if (key.delete) {
+                // No cursor position in simple input
+            } else if (shouldInsertInput(input, key) && /\d/.test(input)) {
+                const newValue = refreshInput + input;
+                if (newValue.length <= 2) {
+                    setRefreshInput(newValue);
+                    setValidationError(null);
+                }
+            }
+            return;
+        }
+
+        if (key.escape) {
+            onBack();
+        }
+    });
+
+    return (
+        <Box flexDirection='column'>
+            <Text bold>Configure Status Line</Text>
+            <Text color='white'>Configure Claude Code status line settings</Text>
+
+            {editingRefreshInterval ? (
+                <Box marginTop={1} flexDirection='column'>
+                    <Text>
+                        Enter refresh interval in seconds (1-60):
+                        {' '}
+                        {refreshInput}
+                        {refreshInput.length > 0 ? 's' : ''}
+                    </Text>
+                    {validationError ? (
+                        <Text color='red'>{validationError}</Text>
+                    ) : (
+                        <Text dimColor>Press Enter to confirm, ESC to cancel. Leave empty to remove.</Text>
+                    )}
+                </Box>
+            ) : (
+                <List
+                    marginTop={1}
+                    items={buildConfigureStatusLineItems(currentInterval, supportsRefreshInterval)}
+                    onSelect={(value) => {
+                        if (value === 'back') {
+                            onBack();
+                            return;
+                        }
+
+                        setRefreshInput(currentInterval !== null ? String(currentInterval) : '10');
+                        setEditingRefreshInterval(true);
+                    }}
+                    showBackButton={true}
+                />
+            )}
+        </Box>
+    );
+};

--- a/src/tui/components/RefreshIntervalMenu.tsx
+++ b/src/tui/components/RefreshIntervalMenu.tsx
@@ -14,6 +14,10 @@ import {
 
 type ConfigureStatusLineValue = 'refreshInterval';
 
+function getRefreshInputValue(interval: number | null): string {
+    return interval === null ? '' : String(interval);
+}
+
 function getRefreshIntervalSublabel(interval: number | null, supported: boolean): string {
     if (!supported) {
         return '(requires Claude Code >=2.1.97)';
@@ -79,7 +83,7 @@ export const RefreshIntervalMenu: React.FC<RefreshIntervalMenuProps> = ({
     onBack
 }) => {
     const [editingRefreshInterval, setEditingRefreshInterval] = useState(false);
-    const [refreshInput, setRefreshInput] = useState(currentInterval !== null ? String(currentInterval) : '10');
+    const [refreshInput, setRefreshInput] = useState(() => getRefreshInputValue(currentInterval));
     const [validationError, setValidationError] = useState<string | null>(null);
 
     useInput((input, key) => {
@@ -103,7 +107,7 @@ export const RefreshIntervalMenu: React.FC<RefreshIntervalMenuProps> = ({
                     setValidationError(null);
                 }
             } else if (key.escape) {
-                setRefreshInput(currentInterval !== null ? String(currentInterval) : '10');
+                setRefreshInput(getRefreshInputValue(currentInterval));
                 setEditingRefreshInterval(false);
                 setValidationError(null);
             } else if (key.backspace) {
@@ -155,7 +159,7 @@ export const RefreshIntervalMenu: React.FC<RefreshIntervalMenuProps> = ({
                             return;
                         }
 
-                        setRefreshInput(currentInterval !== null ? String(currentInterval) : '10');
+                        setRefreshInput(getRefreshInputValue(currentInterval));
                         setEditingRefreshInterval(true);
                     }}
                     showBackButton={true}

--- a/src/tui/components/__tests__/RefreshIntervalMenu.test.ts
+++ b/src/tui/components/__tests__/RefreshIntervalMenu.test.ts
@@ -1,0 +1,63 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import {
+    buildConfigureStatusLineItems,
+    validateRefreshIntervalInput
+} from '../RefreshIntervalMenu';
+
+describe('validateRefreshIntervalInput', () => {
+    it('should accept empty string (remove interval)', () => {
+        expect(validateRefreshIntervalInput('')).toBeNull();
+    });
+
+    it('should accept valid values within range', () => {
+        expect(validateRefreshIntervalInput('1')).toBeNull();
+        expect(validateRefreshIntervalInput('10')).toBeNull();
+        expect(validateRefreshIntervalInput('30')).toBeNull();
+        expect(validateRefreshIntervalInput('60')).toBeNull();
+    });
+
+    it('should reject values below minimum', () => {
+        expect(validateRefreshIntervalInput('0')).toContain('Minimum');
+    });
+
+    it('should reject values above maximum', () => {
+        expect(validateRefreshIntervalInput('61')).toContain('Maximum');
+    });
+
+    it('should reject non-numeric input', () => {
+        expect(validateRefreshIntervalInput('abc')).toContain('valid number');
+    });
+});
+
+describe('buildConfigureStatusLineItems', () => {
+    it('should show (not set) when interval is null and supported', () => {
+        const items = buildConfigureStatusLineItems(null, true);
+        expect(items[0]?.sublabel).toBe('(not set)');
+    });
+
+    it('should show seconds for set intervals', () => {
+        const items = buildConfigureStatusLineItems(10, true);
+        expect(items[0]?.sublabel).toBe('(10s)');
+    });
+
+    it('should show seconds for small values', () => {
+        const items = buildConfigureStatusLineItems(1, true);
+        expect(items[0]?.sublabel).toBe('(1s)');
+    });
+
+    it('should show version requirement when not supported', () => {
+        const items = buildConfigureStatusLineItems(null, false);
+        expect(items[0]?.sublabel).toContain('requires Claude Code');
+        expect(items[0]?.disabled).toBe(true);
+    });
+
+    it('should not be disabled when supported', () => {
+        const items = buildConfigureStatusLineItems(10, true);
+        expect(items[0]?.disabled).toBeFalsy();
+    });
+});

--- a/src/tui/components/__tests__/RefreshIntervalMenu.test.ts
+++ b/src/tui/components/__tests__/RefreshIntervalMenu.test.ts
@@ -1,13 +1,63 @@
+import { render } from 'ink';
+import { PassThrough } from 'node:stream';
+import React from 'react';
 import {
     describe,
     expect,
-    it
+    it,
+    vi
 } from 'vitest';
 
 import {
+    RefreshIntervalMenu,
     buildConfigureStatusLineItems,
     validateRefreshIntervalInput
 } from '../RefreshIntervalMenu';
+
+class MockTtyStream extends PassThrough {
+    isTTY = true;
+    columns = 120;
+    rows = 40;
+
+    setRawMode() {
+        return this;
+    }
+
+    ref() {
+        return this;
+    }
+
+    unref() {
+        return this;
+    }
+}
+
+interface CapturedWriteStream extends NodeJS.WriteStream { getOutput: () => string }
+
+function createMockStdin(): NodeJS.ReadStream {
+    return new MockTtyStream() as unknown as NodeJS.ReadStream;
+}
+
+function createMockStdout(): CapturedWriteStream {
+    const stream = new MockTtyStream();
+    const chunks: string[] = [];
+
+    stream.on('data', (chunk: Buffer | string) => {
+        chunks.push(chunk.toString());
+    });
+
+    return Object.assign(stream as unknown as NodeJS.WriteStream, {
+        getOutput() {
+            return chunks.join('');
+        }
+    });
+}
+
+function flushInk() {
+    return new Promise((resolve) => {
+        setTimeout(resolve, 25);
+    });
+}
 
 describe('validateRefreshIntervalInput', () => {
     it('should accept empty string (remove interval)', () => {
@@ -59,5 +109,51 @@ describe('buildConfigureStatusLineItems', () => {
     it('should not be disabled when supported', () => {
         const items = buildConfigureStatusLineItems(10, true);
         expect(items[0]?.disabled).toBeFalsy();
+    });
+});
+
+describe('RefreshIntervalMenu', () => {
+    it('keeps an unset interval empty when reopening the editor', async () => {
+        const stdin = createMockStdin();
+        const stdout = createMockStdout();
+        const stderr = createMockStdout();
+        const onUpdate = vi.fn();
+        const onBack = vi.fn();
+        const instance = render(
+            React.createElement(RefreshIntervalMenu, {
+                currentInterval: null,
+                supportsRefreshInterval: true,
+                onUpdate,
+                onBack
+            }),
+            {
+                stdin,
+                stdout,
+                stderr,
+                debug: true,
+                exitOnCtrlC: false,
+                patchConsole: false
+            }
+        );
+
+        try {
+            await flushInk();
+            stdin.write('\r');
+            await flushInk();
+
+            expect(stdout.getOutput()).toContain('Enter refresh interval in seconds (1-60):');
+            expect(stdout.getOutput()).not.toContain('10s');
+
+            stdin.write('\r');
+            await flushInk();
+
+            expect(onUpdate).toHaveBeenCalledWith(null);
+        } finally {
+            instance.unmount();
+            instance.cleanup();
+            stdin.destroy();
+            stdout.destroy();
+            stderr.destroy();
+        }
     });
 });

--- a/src/tui/components/index.ts
+++ b/src/tui/components/index.ts
@@ -7,6 +7,7 @@ export * from './ItemsEditor';
 export * from './LineSelector';
 export * from './MainMenu';
 export * from './PowerlineSetup';
+export * from './RefreshIntervalMenu';
 export * from './StatusLinePreview';
 export * from './TerminalOptionsMenu';
 export * from './TerminalWidthMenu';

--- a/src/types/ClaudeSettings.ts
+++ b/src/types/ClaudeSettings.ts
@@ -8,6 +8,7 @@ export interface ClaudeSettings {
         type: string;
         command: string;
         padding?: number;
+        refreshInterval?: number;
     };
     [key: string]: unknown;
 }

--- a/src/utils/__tests__/claude-settings.test.ts
+++ b/src/utils/__tests__/claude-settings.test.ts
@@ -122,6 +122,10 @@ describe('isKnownCommand', () => {
     it('should match command containing ccstatusline.ts', () => {
         expect(isKnownCommand('bun run /home/user/ccstatusline/src/ccstatusline.ts')).toBe(true);
     });
+
+    it('should match command containing a quoted ccstatusline.ts path', () => {
+        expect(isKnownCommand('bun run "/Users/Jane Doe/ccstatusline/src/ccstatusline.ts"')).toBe(true);
+    });
 });
 
 describe('buildCommand via installStatusLine', () => {
@@ -462,6 +466,17 @@ describe('backup and error handling behavior', () => {
             statusLine: {
                 type: 'command',
                 command: `${CCSTATUSLINE_COMMANDS.NPM} --config /tmp/settings.json`
+            }
+        });
+
+        await expect(isInstalled()).resolves.toBe(true);
+    });
+
+    it('isInstalled should accept quoted local development commands when padding is undefined', async () => {
+        await saveClaudeSettings({
+            statusLine: {
+                type: 'command',
+                command: 'bun run "/Users/Jane Doe/ccstatusline/src/ccstatusline.ts"'
             }
         });
 

--- a/src/utils/__tests__/claude-settings.test.ts
+++ b/src/utils/__tests__/claude-settings.test.ts
@@ -1,3 +1,4 @@
+import * as childProcess from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -14,13 +15,17 @@ import {
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import {
     CCSTATUSLINE_COMMANDS,
+    getClaudeCodeVersion,
     getClaudeSettingsPath,
     getExistingStatusLine,
+    getRefreshInterval,
     installStatusLine,
+    isClaudeCodeVersionAtLeast,
     isInstalled,
     isKnownCommand,
     loadClaudeSettings,
     saveClaudeSettings,
+    setRefreshInterval,
     uninstallStatusLine
 } from '../claude-settings';
 import { initConfigPath } from '../config';
@@ -33,6 +38,13 @@ function readInstalledCommand(): string {
     const content = fs.readFileSync(settingsPath, 'utf-8');
     const data = JSON.parse(content) as { statusLine?: { command?: string } };
     return data.statusLine?.command ?? '';
+}
+
+function readInstalledRefreshInterval(): number | undefined {
+    const settingsPath = getClaudeSettingsPath();
+    const content = fs.readFileSync(settingsPath, 'utf-8');
+    const data = JSON.parse(content) as { statusLine?: { refreshInterval?: number } };
+    return data.statusLine?.refreshInterval;
 }
 
 function writeRawClaudeSettings(content: string): void {
@@ -106,6 +118,10 @@ describe('isKnownCommand', () => {
     it('should not match prefix that is a substring', () => {
         expect(isKnownCommand('npx -y ccstatusline@latestFOO')).toBe(false);
     });
+
+    it('should match command containing ccstatusline.ts', () => {
+        expect(isKnownCommand('bun run /home/user/ccstatusline/src/ccstatusline.ts')).toBe(true);
+    });
 });
 
 describe('buildCommand via installStatusLine', () => {
@@ -173,6 +189,102 @@ describe('buildCommand via installStatusLine', () => {
                 hooks: [{ type: 'command', command: `${installedCommand} --hook` }]
             }
         ]);
+    });
+});
+
+describe('installStatusLine refreshInterval', () => {
+    it('should set refreshInterval to 10 when version is supported', async () => {
+        initConfigPath();
+        await installStatusLine(false, true);
+        expect(readInstalledRefreshInterval()).toBe(10);
+    });
+
+    it('should not set refreshInterval when version is unsupported', async () => {
+        initConfigPath();
+        await installStatusLine(false, false);
+        expect(readInstalledRefreshInterval()).toBeUndefined();
+    });
+
+    it('should preserve existing refreshInterval on re-install', async () => {
+        writeRawClaudeSettings(JSON.stringify({
+            statusLine: {
+                type: 'command',
+                command: CCSTATUSLINE_COMMANDS.NPM,
+                padding: 0,
+                refreshInterval: 5
+            }
+        }));
+        await installStatusLine(false, true);
+        expect(readInstalledRefreshInterval()).toBe(5);
+    });
+});
+
+describe('refreshInterval', () => {
+    it('getRefreshInterval should return null when no settings exist', async () => {
+        await expect(getRefreshInterval()).resolves.toBeNull();
+    });
+
+    it('getRefreshInterval should return null when statusLine has no refreshInterval', async () => {
+        await saveClaudeSettings({
+            statusLine: {
+                type: 'command',
+                command: CCSTATUSLINE_COMMANDS.NPM,
+                padding: 0
+            }
+        });
+        await expect(getRefreshInterval()).resolves.toBeNull();
+    });
+
+    it('getRefreshInterval should return the configured value', async () => {
+        await saveClaudeSettings({
+            statusLine: {
+                type: 'command',
+                command: CCSTATUSLINE_COMMANDS.NPM,
+                padding: 0,
+                refreshInterval: 5
+            }
+        });
+        await expect(getRefreshInterval()).resolves.toBe(5);
+    });
+
+    it('setRefreshInterval should set the value on existing statusLine', async () => {
+        await saveClaudeSettings({
+            statusLine: {
+                type: 'command',
+                command: CCSTATUSLINE_COMMANDS.NPM,
+                padding: 0
+            }
+        });
+
+        await setRefreshInterval(15);
+
+        const settings = await loadClaudeSettings();
+        expect(settings.statusLine?.refreshInterval).toBe(15);
+    });
+
+    it('setRefreshInterval with null should remove refreshInterval', async () => {
+        await saveClaudeSettings({
+            statusLine: {
+                type: 'command',
+                command: CCSTATUSLINE_COMMANDS.NPM,
+                padding: 0,
+                refreshInterval: 10
+            }
+        });
+
+        await setRefreshInterval(null);
+
+        const settings = await loadClaudeSettings();
+        expect(settings.statusLine?.refreshInterval).toBeUndefined();
+    });
+
+    it('setRefreshInterval should do nothing when no statusLine exists', async () => {
+        await saveClaudeSettings({});
+
+        await setRefreshInterval(10);
+
+        const settings = await loadClaudeSettings();
+        expect(settings.statusLine).toBeUndefined();
     });
 });
 
@@ -354,5 +466,64 @@ describe('backup and error handling behavior', () => {
         });
 
         await expect(isInstalled()).resolves.toBe(true);
+    });
+});
+
+describe('getClaudeCodeVersion', () => {
+    it('should parse version from claude --version output', () => {
+        vi.spyOn(childProcess, 'execSync').mockReturnValue('2.1.97 (Claude Code)\n');
+        expect(getClaudeCodeVersion()).toBe('2.1.97');
+    });
+
+    it('should parse version without suffix text', () => {
+        vi.spyOn(childProcess, 'execSync').mockReturnValue('3.0.0\n');
+        expect(getClaudeCodeVersion()).toBe('3.0.0');
+    });
+
+    it('should return null when claude is not installed', () => {
+        vi.spyOn(childProcess, 'execSync').mockImplementation(() => { throw new Error('not found'); });
+        expect(getClaudeCodeVersion()).toBeNull();
+    });
+
+    it('should return null for unexpected output', () => {
+        vi.spyOn(childProcess, 'execSync').mockReturnValue('unknown output');
+        expect(getClaudeCodeVersion()).toBeNull();
+    });
+});
+
+describe('isClaudeCodeVersionAtLeast', () => {
+    it('should return true when version equals minimum', () => {
+        vi.spyOn(childProcess, 'execSync').mockReturnValue('2.1.97 (Claude Code)\n');
+        expect(isClaudeCodeVersionAtLeast('2.1.97')).toBe(true);
+    });
+
+    it('should return true when patch is higher', () => {
+        vi.spyOn(childProcess, 'execSync').mockReturnValue('2.1.100 (Claude Code)\n');
+        expect(isClaudeCodeVersionAtLeast('2.1.97')).toBe(true);
+    });
+
+    it('should return true when minor is higher', () => {
+        vi.spyOn(childProcess, 'execSync').mockReturnValue('2.2.0 (Claude Code)\n');
+        expect(isClaudeCodeVersionAtLeast('2.1.97')).toBe(true);
+    });
+
+    it('should return true when major is higher', () => {
+        vi.spyOn(childProcess, 'execSync').mockReturnValue('3.0.0 (Claude Code)\n');
+        expect(isClaudeCodeVersionAtLeast('2.1.97')).toBe(true);
+    });
+
+    it('should return false when version is lower', () => {
+        vi.spyOn(childProcess, 'execSync').mockReturnValue('2.1.96 (Claude Code)\n');
+        expect(isClaudeCodeVersionAtLeast('2.1.97')).toBe(false);
+    });
+
+    it('should return false when minor is lower', () => {
+        vi.spyOn(childProcess, 'execSync').mockReturnValue('2.0.100 (Claude Code)\n');
+        expect(isClaudeCodeVersionAtLeast('2.1.97')).toBe(false);
+    });
+
+    it('should return false when claude is not installed', () => {
+        vi.spyOn(childProcess, 'execSync').mockImplementation(() => { throw new Error('not found'); });
+        expect(isClaudeCodeVersionAtLeast('2.1.97')).toBe(false);
     });
 });

--- a/src/utils/claude-settings.ts
+++ b/src/utils/claude-settings.ts
@@ -32,7 +32,7 @@ export function isKnownCommand(command: string): boolean {
     const prefixes = [CCSTATUSLINE_COMMANDS.NPM, CCSTATUSLINE_COMMANDS.BUNX, CCSTATUSLINE_COMMANDS.SELF_MANAGED];
     // Also match local development commands (e.g., "bun run /path/to/ccstatusline.ts")
     return prefixes.some(prefix => command === prefix || command.startsWith(`${prefix} --config `))
-        || /(?:^|\s|\/|\\)ccstatusline\.ts(?:\s|$)/.test(command);
+        || /(?:^|[\s"'\\/])ccstatusline\.ts(?=$|[\s"'])/.test(command);
 }
 
 function needsQuoting(filePath: string): boolean {

--- a/src/utils/claude-settings.ts
+++ b/src/utils/claude-settings.ts
@@ -30,7 +30,9 @@ export const CCSTATUSLINE_COMMANDS = {
 
 export function isKnownCommand(command: string): boolean {
     const prefixes = [CCSTATUSLINE_COMMANDS.NPM, CCSTATUSLINE_COMMANDS.BUNX, CCSTATUSLINE_COMMANDS.SELF_MANAGED];
-    return prefixes.some(prefix => command === prefix || command.startsWith(`${prefix} --config `));
+    // Also match local development commands (e.g., "bun run /path/to/ccstatusline.ts")
+    return prefixes.some(prefix => command === prefix || command.startsWith(`${prefix} --config `))
+        || /(?:^|\s|\/|\\)ccstatusline\.ts(?:\s|$)/.test(command);
 }
 
 function needsQuoting(filePath: string): boolean {
@@ -195,6 +197,40 @@ export function isBunxAvailable(): boolean {
     }
 }
 
+export function getClaudeCodeVersion(): string | null {
+    try {
+        const output = execSync('claude --version', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'], timeout: 5000 }).trim();
+        // Output is like "2.1.97 (Claude Code)" — extract the version number
+        const match = /^(\d+\.\d+\.\d+)/.exec(output);
+        return match?.[1] ?? null;
+    } catch {
+        return null;
+    }
+}
+
+export function isClaudeCodeVersionAtLeast(minVersion: string): boolean {
+    const version = getClaudeCodeVersion();
+    if (!version) {
+        return false;
+    }
+
+    const current = version.split('.').map(Number);
+    const minimum = minVersion.split('.').map(Number);
+
+    for (let i = 0; i < 3; i++) {
+        const c = current[i] ?? 0;
+        const m = minimum[i] ?? 0;
+        if (c > m) {
+            return true;
+        }
+        if (c < m) {
+            return false;
+        }
+    }
+
+    return true; // equal
+}
+
 function buildCommand(baseCommand: string): string {
     if (isCustomConfigPath()) {
         return `${baseCommand} --config ${quotePathIfNeeded(getConfigPath())}`;
@@ -221,7 +257,7 @@ async function loadSavedSettingsForHookSync(): Promise<Settings | null> {
     }
 }
 
-export async function installStatusLine(useBunx = false): Promise<void> {
+export async function installStatusLine(useBunx = false, supportsRefreshInterval = false): Promise<void> {
     let settings: ClaudeSettings;
 
     const backupPath = await backupClaudeSettings('.orig');
@@ -238,11 +274,17 @@ export async function installStatusLine(useBunx = false): Promise<void> {
         : CCSTATUSLINE_COMMANDS.NPM;
 
     // Update settings with our status line (confirmation already handled in TUI)
+    const existingRefreshInterval = settings.statusLine?.refreshInterval;
     settings.statusLine = {
         type: 'command',
         command: buildCommand(baseCommand),
         padding: 0
     };
+
+    // Only set refreshInterval if Claude Code version supports it (>=2.1.97)
+    if (supportsRefreshInterval) {
+        settings.statusLine.refreshInterval = existingRefreshInterval ?? 10;
+    }
 
     await saveClaudeSettings(settings);
 
@@ -283,4 +325,35 @@ export async function getExistingStatusLine(): Promise<string | null> {
     } catch {
         return null; // Can't read settings, return null
     }
+}
+
+export async function getRefreshInterval(): Promise<number | null> {
+    try {
+        const settings = await loadClaudeSettings({ logErrors: false });
+        return settings.statusLine?.refreshInterval ?? null;
+    } catch {
+        return null;
+    }
+}
+
+export async function setRefreshInterval(interval: number | null): Promise<void> {
+    let settings: ClaudeSettings;
+
+    try {
+        settings = await loadClaudeSettings({ logErrors: false });
+    } catch {
+        return;
+    }
+
+    if (!settings.statusLine) {
+        return;
+    }
+
+    if (interval === null) {
+        delete settings.statusLine.refreshInterval;
+    } else {
+        settings.statusLine.refreshInterval = interval;
+    }
+
+    await saveClaudeSettings(settings);
 }


### PR DESCRIPTION
## Summary

- Adds a new **Configure Status Line** menu option when ccstatusline is installed in Claude Code
- Lets users configure the `refreshInterval` setting (in seconds) that controls how often Claude Code re-runs the status line command
- Detects Claude Code version via `claude --version` and gates the feature behind `>=2.1.97` (shows disabled with version requirement message for older versions)
- Sets a default of 10 seconds on fresh install, preserves existing value on re-install

<img width="461" height="120" alt="Screenshot_2026-04-09_15-08-54" src="https://github.com/user-attachments/assets/26b918db-a71e-4097-ba65-496f9e6ae923" />
<img width="676" height="173" alt="Screenshot_2026-04-09_15-09-23" src="https://github.com/user-attachments/assets/859d1222-b05b-4b11-9676-bb79981015e0" />
<img width="695" height="142" alt="Screenshot_2026-04-09_15-28-39" src="https://github.com/user-attachments/assets/9b834c51-5a78-467c-a02f-f811108f0dbb" />

## Changes

- `ClaudeSettings.ts`: Add `refreshInterval` to statusLine interface
- `claude-settings.ts`: Add `getClaudeCodeVersion()`, `isClaudeCodeVersionAtLeast()`, `getRefreshInterval()`, `setRefreshInterval()`, pass version support flag to `installStatusLine()`
- `RefreshIntervalMenu.tsx`: New TUI component with inline numeric input (1-60s range, empty to remove)
- `MainMenu.tsx`: Show "Configure Status Line" + "Uninstall" when installed (was single toggle)
- `App.tsx`: Wire up new screen, state, error handling with rollback
- `isKnownCommand()`: Use path-boundary regex for local dev command matching

## Test plan

- [x] 762 tests pass (`bun test`)
- [x] Lint clean (`bun run lint`)
- [ ] Manual test: Install via TUI, verify refreshInterval=10 in `~/.claude/settings.json`
- [ ] Manual test: Configure Status Line → change interval → verify saved
- [ ] Manual test: Configure Status Line → leave empty → verify refreshInterval removed
- [ ] Manual test: With Claude Code <2.1.97, verify option shows disabled with version message