### PR TITLE
feat: add CacheTimer widget for prompt cache TTL countdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccstatusline",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "A customizable status line formatter for Claude Code CLI",
   "module": "src/ccstatusline.ts",
   "type": "module",

--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -75,7 +75,8 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'worktree-mode', create: () => new widgets.GitWorktreeModeWidget() },
     { type: 'worktree-name', create: () => new widgets.GitWorktreeNameWidget() },
     { type: 'worktree-branch', create: () => new widgets.GitWorktreeBranchWidget() },
-    { type: 'worktree-original-branch', create: () => new widgets.GitWorktreeOriginalBranchWidget() }
+    { type: 'worktree-original-branch', create: () => new widgets.GitWorktreeOriginalBranchWidget() },
+    { type: 'cache-timer', create: () => new widgets.CacheTimerWidget() }
 ];
 
 export const LAYOUT_WIDGET_MANIFEST: LayoutWidgetManifestEntry[] = [

--- a/src/widgets/CacheTimer.ts
+++ b/src/widgets/CacheTimer.ts
@@ -13,11 +13,16 @@ import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
 const TTL_SECONDS = 300;
 const SAFETY_MARGIN = 5; // display as COLD 5s before actual expiry
 
+interface TranscriptEntry {
+    type?: string;
+    timestamp?: string;
+}
+
 /**
  * Read the last N bytes of a file and return as string.
  * Avoids loading large transcript files entirely.
  */
-function readFileTail(filePath: string, bytes: number = 32768): string {
+function readFileTail(filePath: string, bytes = 32768): string {
     try {
         const fd = fs.openSync(filePath, 'r');
         const stat = fs.fstatSync(fd);
@@ -34,27 +39,35 @@ function readFileTail(filePath: string, bytes: number = 32768): string {
 }
 
 /**
- * Find the timestamp of the last assistant message in the transcript.
- * Returns null if not found.
+ * Find the last user/assistant entry in the transcript.
+ * Returns { isWorking: true } when the last entry is a user message (Claude is processing).
+ * Returns { isWorking: false, lastAssistant: Date } when the last entry is an assistant message.
  */
-function getLastAssistantTimestamp(transcriptPath: string): Date | null {
+function getTranscriptState(transcriptPath: string): { isWorking: true } | { isWorking: false; lastAssistant: Date | null } {
     const tail = readFileTail(transcriptPath);
-    if (!tail) return null;
+    if (!tail) {
+        return { isWorking: false, lastAssistant: null };
+    }
 
     const lines = tail.split('\n').reverse();
     for (const line of lines) {
         const trimmed = line.trim();
-        if (!trimmed) continue;
+        if (!trimmed) {
+            continue;
+        }
         try {
-            const entry = JSON.parse(trimmed);
+            const entry = JSON.parse(trimmed) as TranscriptEntry;
+            if (entry.type === 'user') {
+                return { isWorking: true };
+            }
             if (entry.type === 'assistant' && entry.timestamp) {
-                return new Date(entry.timestamp);
+                return { isWorking: false, lastAssistant: new Date(entry.timestamp) };
             }
         } catch {
             continue;
         }
     }
-    return null;
+    return { isWorking: false, lastAssistant: null };
 }
 
 function getRemainingSeconds(lastAssistant: Date): number {
@@ -63,17 +76,25 @@ function getRemainingSeconds(lastAssistant: Date): number {
 }
 
 function formatCountdown(remaining: number): string {
-    if (remaining <= 0) return 'COLD';
+    if (remaining <= 0) {
+        return 'COLD';
+    }
     const m = Math.floor(remaining / 60);
     const s = Math.floor(remaining % 60);
     return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
 function getIcon(remaining: number): string {
-    if (remaining <= 0) return '❄️';
+    if (remaining <= 0) {
+        return '❄️';
+    }
     const pct = remaining / (TTL_SECONDS - SAFETY_MARGIN);
-    if (pct > 0.5) return '🟢';
-    if (pct > 0.2) return '🟡';
+    if (pct > 0.5) {
+        return '🟢';
+    }
+    if (pct > 0.2) {
+        return '🟡';
+    }
     return '🔴';
 }
 
@@ -93,10 +114,20 @@ export class CacheTimerWidget implements Widget {
         }
 
         const transcriptPath = context.data?.transcript_path;
-        if (!transcriptPath) return null;
+        if (!transcriptPath) {
+            return null;
+        }
 
-        const lastAssistant = getLastAssistantTimestamp(transcriptPath);
-        if (!lastAssistant) return null;
+        const state = getTranscriptState(transcriptPath);
+
+        if (state.isWorking) {
+            return formatRawOrLabeledValue(item, 'Cache: ', '🔥 HOT');
+        }
+
+        const { lastAssistant } = state;
+        if (!lastAssistant) {
+            return null;
+        }
 
         const remaining = getRemainingSeconds(lastAssistant);
         const icon = getIcon(remaining);

--- a/src/widgets/CacheTimer.ts
+++ b/src/widgets/CacheTimer.ts
@@ -1,6 +1,4 @@
 import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
 
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
@@ -12,30 +10,56 @@ import type {
 
 import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
 
-const TTL_SECONDS = 295; // 5 min minus 5s safety margin
-const STATE_DIR = path.join(os.homedir(), '.claude', 'state');
+const TTL_SECONDS = 300;
+const SAFETY_MARGIN = 5; // display as COLD 5s before actual expiry
 
-interface TimerFile {
-    timestamp: string;
-    session_id: string;
-    stopped: boolean | null;
-}
-
-function readTimerFile(sessionId: string): TimerFile | null {
-    const filePath = path.join(STATE_DIR, `cache-timer-${sessionId}.json`);
+/**
+ * Read the last N bytes of a file and return as string.
+ * Avoids loading large transcript files entirely.
+ */
+function readFileTail(filePath: string, bytes: number = 32768): string {
     try {
-        const raw = fs.readFileSync(filePath, 'utf-8');
-        return JSON.parse(raw) as TimerFile;
+        const fd = fs.openSync(filePath, 'r');
+        const stat = fs.fstatSync(fd);
+        const size = stat.size;
+        const readSize = Math.min(bytes, size);
+        const offset = size - readSize;
+        const buf = Buffer.alloc(readSize);
+        fs.readSync(fd, buf, 0, readSize, offset);
+        fs.closeSync(fd);
+        return buf.toString('utf-8');
     } catch {
-        return null;
+        return '';
     }
 }
 
-function getRemainingSeconds(timestamp: string): number {
-    const ts = new Date(timestamp).getTime();
-    const now = Date.now();
-    const elapsedSeconds = (now - ts) / 1000;
-    return TTL_SECONDS - elapsedSeconds;
+/**
+ * Find the timestamp of the last assistant message in the transcript.
+ * Returns null if not found.
+ */
+function getLastAssistantTimestamp(transcriptPath: string): Date | null {
+    const tail = readFileTail(transcriptPath);
+    if (!tail) return null;
+
+    const lines = tail.split('\n').reverse();
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+            const entry = JSON.parse(trimmed);
+            if (entry.type === 'assistant' && entry.timestamp) {
+                return new Date(entry.timestamp);
+            }
+        } catch {
+            continue;
+        }
+    }
+    return null;
+}
+
+function getRemainingSeconds(lastAssistant: Date): number {
+    const elapsedSeconds = (Date.now() - lastAssistant.getTime()) / 1000;
+    return TTL_SECONDS - SAFETY_MARGIN - elapsedSeconds;
 }
 
 function formatCountdown(remaining: number): string {
@@ -47,7 +71,7 @@ function formatCountdown(remaining: number): string {
 
 function getIcon(remaining: number): string {
     if (remaining <= 0) return '❄️';
-    const pct = remaining / TTL_SECONDS;
+    const pct = remaining / (TTL_SECONDS - SAFETY_MARGIN);
     if (pct > 0.5) return '🟢';
     if (pct > 0.2) return '🟡';
     return '🔴';
@@ -68,19 +92,13 @@ export class CacheTimerWidget implements Widget {
             return formatRawOrLabeledValue(item, 'Cache: ', '🟢 4:52');
         }
 
-        const sessionId = context.data?.session_id;
-        if (!sessionId) return null;
+        const transcriptPath = context.data?.transcript_path;
+        if (!transcriptPath) return null;
 
-        const timer = readTimerFile(sessionId);
-        if (!timer) return null;
+        const lastAssistant = getLastAssistantTimestamp(transcriptPath);
+        if (!lastAssistant) return null;
 
-        if (timer.stopped === false) {
-            return formatRawOrLabeledValue(item, 'Cache: ', '🔥 HOT');
-        }
-
-        if (!timer.timestamp) return null;
-
-        const remaining = getRemainingSeconds(timer.timestamp);
+        const remaining = getRemainingSeconds(lastAssistant);
         const icon = getIcon(remaining);
         const countdown = formatCountdown(remaining);
 

--- a/src/widgets/CacheTimer.ts
+++ b/src/widgets/CacheTimer.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+
+import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
+
+const TTL_SECONDS = 295; // 5 min minus 5s safety margin
+const STATE_DIR = path.join(os.homedir(), '.claude', 'state');
+
+interface TimerFile {
+    timestamp: string;
+    session_id: string;
+    stopped: boolean | null;
+}
+
+function readTimerFile(sessionId: string): TimerFile | null {
+    const filePath = path.join(STATE_DIR, `cache-timer-${sessionId}.json`);
+    try {
+        const raw = fs.readFileSync(filePath, 'utf-8');
+        return JSON.parse(raw) as TimerFile;
+    } catch {
+        return null;
+    }
+}
+
+function getRemainingSeconds(timestamp: string): number {
+    const ts = new Date(timestamp).getTime();
+    const now = Date.now();
+    const elapsedSeconds = (now - ts) / 1000;
+    return TTL_SECONDS - elapsedSeconds;
+}
+
+function formatCountdown(remaining: number): string {
+    if (remaining <= 0) return 'COLD';
+    const m = Math.floor(remaining / 60);
+    const s = Math.floor(remaining % 60);
+    return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function getIcon(remaining: number): string {
+    if (remaining <= 0) return '❄️';
+    const pct = remaining / TTL_SECONDS;
+    if (pct > 0.5) return '🟢';
+    if (pct > 0.2) return '🟡';
+    return '🔴';
+}
+
+export class CacheTimerWidget implements Widget {
+    getDefaultColor(): string { return 'brightCyan'; }
+    getDescription(): string { return 'Shows time remaining on the 5-minute prompt cache TTL'; }
+    getDisplayName(): string { return 'Cache Timer'; }
+    getCategory(): string { return 'Session'; }
+
+    getEditorDisplay(_item: WidgetItem): WidgetEditorDisplay {
+        return { displayText: this.getDisplayName() };
+    }
+
+    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+        if (context.isPreview) {
+            return formatRawOrLabeledValue(item, 'Cache: ', '🟢 4:52');
+        }
+
+        const sessionId = context.data?.session_id;
+        if (!sessionId) return null;
+
+        const timer = readTimerFile(sessionId);
+        if (!timer) return null;
+
+        if (timer.stopped === false) {
+            return formatRawOrLabeledValue(item, 'Cache: ', '🔥 HOT');
+        }
+
+        if (!timer.timestamp) return null;
+
+        const remaining = getRemainingSeconds(timer.timestamp);
+        const icon = getIcon(remaining);
+        const countdown = formatCountdown(remaining);
+
+        return formatRawOrLabeledValue(item, 'Cache: ', `${icon} ${countdown}`);
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(_item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -57,3 +57,4 @@ export { GitWorktreeModeWidget } from './GitWorktreeMode';
 export { GitWorktreeNameWidget } from './GitWorktreeName';
 export { GitWorktreeBranchWidget } from './GitWorktreeBranch';
 export { GitWorktreeOriginalBranchWidget } from './GitWorktreeOriginalBranch';
+export { CacheTimerWidget } from './CacheTimer';


### PR DESCRIPTION
## Summary

Adds a new `cache-timer` widget that displays the remaining time on Anthropic's 5-minute prompt cache TTL directly in the status line.

**No external dependencies.** The widget reads the last assistant message timestamp directly from the `transcript_path` that Claude Code already passes to ccstatusline — no hooks, no additional tools required.

## How it works

On each status line refresh, the widget:
1. Reads the last few bytes of the transcript JSONL file
2. Finds the most recent `type: "assistant"` entry
3. Computes `remaining = 300s − elapsed` from that timestamp

**Display states:**

| Output | Meaning |
|--------|---------|
| 🟢 4:52 | Cache warm, >50% remaining |
| 🟡 1:30 | Draining, 20–50% remaining |
| 🔴 0:15 | Almost cold, <20% remaining |
| ❄️ COLD | Cache expired |

## Usage

Add `cache-timer` to your layout via the TUI or directly in `~/.config/ccstatusline/settings.json`:

```json
{ "type": "cache-timer" }
```

Pair with `refreshInterval: 1` in your Claude Code `statusLine` config so the countdown ticks in real time when the agent is idle:

```json
"statusLine": {
  "type": "command",
  "command": "npx -y ccstatusline@latest",
  "refreshInterval": 1
}
```

## Files changed
- `src/widgets/CacheTimer.ts` — new widget
- `src/widgets/index.ts` — export
- `src/utils/widget-manifest.ts` — registration
