### PR TITLE
fix: support xhigh thinking effort level

### DIFF
--- a/src/types/ClaudeSettings.ts
+++ b/src/types/ClaudeSettings.ts
@@ -1,5 +1,7 @@
+import type { TranscriptThinkingEffort } from '../utils/jsonl-metadata';
+
 export interface ClaudeSettings {
-    effortLevel?: 'low' | 'medium' | 'high' | 'max';
+    effortLevel?: TranscriptThinkingEffort;
     permissions?: {
         allow?: string[];
         deny?: string[];

--- a/src/utils/jsonl-metadata.ts
+++ b/src/utils/jsonl-metadata.ts
@@ -4,27 +4,39 @@ import {
     readJsonlLinesSync
 } from './jsonl-lines';
 
-export type TranscriptThinkingEffort = 'low' | 'medium' | 'high' | 'max';
+const KNOWN_THINKING_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+const KNOWN_THINKING_EFFORTS_SET: ReadonlySet<string> = new Set(KNOWN_THINKING_EFFORTS);
+export type TranscriptThinkingEffort = typeof KNOWN_THINKING_EFFORTS[number];
+
+export interface ResolvedThinkingEffort {
+    value: string;
+    known: boolean;
+}
 
 const MODEL_STDOUT_PREFIX = '<local-command-stdout>Set model to ';
-const MODEL_STDOUT_EFFORT_REGEX = /^<local-command-stdout>Set model to[\s\S]*? with (low|medium|high|max) effort<\/local-command-stdout>$/i;
+const MODEL_STDOUT_EFFORT_REGEX = /^<local-command-stdout>Set model to[\s\S]*? with ([a-zA-Z0-9-]+) effort<\/local-command-stdout>$/i;
+const UNKNOWN_EFFORT_PATTERN = /^(?=.*[a-z0-9])[a-z0-9-]{2,20}$/;
 
 interface TranscriptEntry { message?: { content?: string } }
 
-function normalizeThinkingEffort(value: string | undefined): TranscriptThinkingEffort | undefined {
+export function normalizeThinkingEffort(value: string | undefined): ResolvedThinkingEffort | undefined {
     if (!value) {
         return undefined;
     }
 
     const normalized = value.toLowerCase();
-    if (normalized === 'low' || normalized === 'medium' || normalized === 'high' || normalized === 'max') {
-        return normalized;
+    if (KNOWN_THINKING_EFFORTS_SET.has(normalized)) {
+        return { value: normalized, known: true };
+    }
+
+    if (UNKNOWN_EFFORT_PATTERN.test(normalized)) {
+        return { value: normalized, known: false };
     }
 
     return undefined;
 }
 
-export function getTranscriptThinkingEffort(transcriptPath: string | undefined): TranscriptThinkingEffort | undefined {
+export function getTranscriptThinkingEffort(transcriptPath: string | undefined): ResolvedThinkingEffort | undefined {
     if (!transcriptPath) {
         return undefined;
     }

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -11,4 +11,11 @@ export {
     getSpeedMetricsCollection,
     getTokenMetrics
 } from './jsonl-metrics';
-export { getTranscriptThinkingEffort } from './jsonl-metadata';
+export {
+    getTranscriptThinkingEffort,
+    normalizeThinkingEffort
+} from './jsonl-metadata';
+export type {
+    ResolvedThinkingEffort,
+    TranscriptThinkingEffort
+} from './jsonl-metadata';

--- a/src/widgets/ThinkingEffort.ts
+++ b/src/widgets/ThinkingEffort.ts
@@ -6,27 +6,16 @@ import type {
     WidgetItem
 } from '../types/Widget';
 import { loadClaudeSettingsSync } from '../utils/claude-settings';
-import { getTranscriptThinkingEffort } from '../utils/jsonl';
+import {
+    getTranscriptThinkingEffort,
+    normalizeThinkingEffort,
+    type ResolvedThinkingEffort,
+    type TranscriptThinkingEffort
+} from '../utils/jsonl';
 
-export type ThinkingEffortLevel = 'low' | 'medium' | 'high' | 'max';
+export type ThinkingEffortLevel = TranscriptThinkingEffort;
 
-/**
- * Resolve thinking effort from transcript and settings.
- */
-function normalizeThinkingEffort(value: string | undefined): ThinkingEffortLevel | undefined {
-    if (!value) {
-        return undefined;
-    }
-
-    const normalized = value.toLowerCase();
-    if (normalized === 'low' || normalized === 'medium' || normalized === 'high' || normalized === 'max') {
-        return normalized;
-    }
-
-    return undefined;
-}
-
-function resolveThinkingEffortFromSettings(): ThinkingEffortLevel | undefined {
+function resolveThinkingEffortFromSettings(): ResolvedThinkingEffort | undefined {
     try {
         const settings = loadClaudeSettingsSync({ logErrors: false });
         return normalizeThinkingEffort(settings.effortLevel);
@@ -37,15 +26,22 @@ function resolveThinkingEffortFromSettings(): ThinkingEffortLevel | undefined {
     return undefined;
 }
 
-function resolveThinkingEffort(context: RenderContext): ThinkingEffortLevel {
+function resolveThinkingEffort(context: RenderContext): ResolvedThinkingEffort | null {
     return getTranscriptThinkingEffort(context.data?.transcript_path)
         ?? resolveThinkingEffortFromSettings()
-        ?? 'medium';
+        ?? null;
+}
+
+function formatEffort(resolved: ResolvedThinkingEffort | null): string {
+    if (!resolved) {
+        return 'default';
+    }
+    return resolved.known ? resolved.value : `${resolved.value}?`;
 }
 
 export class ThinkingEffortWidget implements Widget {
     getDefaultColor(): string { return 'magenta'; }
-    getDescription(): string { return 'Displays the current thinking effort level (low, medium, high, max).\nMay be incorrect when multiple Claude Code sessions are running due to current Claude Code limitations.'; }
+    getDescription(): string { return 'Displays the current thinking effort level (low, medium, high, xhigh, max).\nUnknown levels are shown with a trailing "?" (e.g. "super-max?").\nMay be incorrect when multiple Claude Code sessions are running due to current Claude Code limitations.'; }
     getDisplayName(): string { return 'Thinking Effort'; }
     getCategory(): string { return 'Core'; }
     getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
@@ -57,7 +53,7 @@ export class ThinkingEffortWidget implements Widget {
             return item.rawValue ? 'high' : 'Thinking: high';
         }
 
-        const effort = resolveThinkingEffort(context);
+        const effort = formatEffort(resolveThinkingEffort(context));
         return item.rawValue ? effort : `Thinking: ${effort}`;
     }
 

--- a/src/widgets/__tests__/ThinkingEffort.test.ts
+++ b/src/widgets/__tests__/ThinkingEffort.test.ts
@@ -26,6 +26,10 @@ const mockedLoadSettings = loadClaudeSettingsSync as Mock;
 const MODEL_WITH_HIGH_EFFORT = '<local-command-stdout>Set model to \u001b[1mopus (claude-opus-4-6)\u001b[22m with \u001b[1mhigh\u001b[22m effort</local-command-stdout>';
 const MODEL_WITH_LOW_EFFORT = '<local-command-stdout>Set model to \u001b[1msonnet (claude-sonnet-4-5)\u001b[22m with \u001b[1mlow\u001b[22m effort</local-command-stdout>';
 const MODEL_WITH_MAX_EFFORT = '<local-command-stdout>Set model to \u001b[1mopus (claude-opus-4-6)\u001b[22m with \u001b[1mmax\u001b[22m effort</local-command-stdout>';
+const MODEL_WITH_XHIGH_EFFORT = '<local-command-stdout>Set model to \u001b[1mopus (claude-opus-4-7)\u001b[22m with \u001b[1mxhigh\u001b[22m effort</local-command-stdout>';
+const MODEL_WITH_XHIGH_MIXED_CASE_EFFORT = '<local-command-stdout>Set model to \u001b[1mopus (claude-opus-4-7)\u001b[22m with \u001b[1mxHigh\u001b[22m effort</local-command-stdout>';
+const MODEL_WITH_SUPER_MAX_EFFORT = '<local-command-stdout>Set model to \u001b[1mopus (claude-opus-4-8)\u001b[22m with \u001b[1msuper-max\u001b[22m effort</local-command-stdout>';
+const MODEL_WITH_SUPER_MAX_MIXED_CASE_EFFORT = '<local-command-stdout>Set model to \u001b[1mopus (claude-opus-4-8)\u001b[22m with \u001b[1mSuper-Max\u001b[22m effort</local-command-stdout>';
 const MODEL_WITHOUT_EFFORT = '<local-command-stdout>Set model to \u001b[1msonnet (claude-sonnet-4-5)\u001b[22m</local-command-stdout>';
 
 let tempDir: string;
@@ -142,6 +146,26 @@ describe('ThinkingEffortWidget', () => {
             expect(result).toBe('Thinking: max');
         });
 
+        it('supports xhigh effort from transcript output', () => {
+            const result = render({ fileContent: makeTranscriptEntry(MODEL_WITH_XHIGH_EFFORT) });
+            expect(result).toBe('Thinking: xhigh');
+        });
+
+        it('supports mixed-case xHigh effort from transcript output', () => {
+            const result = render({ fileContent: makeTranscriptEntry(MODEL_WITH_XHIGH_MIXED_CASE_EFFORT) });
+            expect(result).toBe('Thinking: xhigh');
+        });
+
+        it('shows unknown-but-valid effort with trailing "?" marker', () => {
+            const result = render({ fileContent: makeTranscriptEntry(MODEL_WITH_SUPER_MAX_EFFORT) });
+            expect(result).toBe('Thinking: super-max?');
+        });
+
+        it('lowercases and marks mixed-case unknown effort', () => {
+            const result = render({ fileContent: makeTranscriptEntry(MODEL_WITH_SUPER_MAX_MIXED_CASE_EFFORT) });
+            expect(result).toBe('Thinking: super-max?');
+        });
+
         it('does not keep stale transcript effort when a newer /model output has no effort', () => {
             const result = render({
                 fileContent: [
@@ -183,27 +207,62 @@ describe('ThinkingEffortWidget', () => {
             expect(result).toBe('Thinking: max');
         });
 
-        it('defaults to medium when effortLevel is not set', () => {
+        it('supports xhigh effortLevel', () => {
+            const result = render({ settingsValue: { effortLevel: 'xhigh' } });
+            expect(result).toBe('Thinking: xhigh');
+        });
+
+        it('supports mixed-case xHigh effortLevel', () => {
+            const result = render({ settingsValue: { effortLevel: 'xHigh' } });
+            expect(result).toBe('Thinking: xhigh');
+        });
+
+        it('shows unknown-but-valid effortLevel with trailing "?" marker', () => {
+            const result = render({ settingsValue: { effortLevel: 'super-max' } });
+            expect(result).toBe('Thinking: super-max?');
+        });
+
+        it('marks unknown effortLevel still passes through case-insensitive match', () => {
+            const result = render({ settingsValue: { effortLevel: 'Ultra' } });
+            expect(result).toBe('Thinking: ultra?');
+        });
+
+        it('displays default when effortLevel is not set', () => {
             const result = render();
-            expect(result).toBe('Thinking: medium');
+            expect(result).toBe('Thinking: default');
         });
 
-        it('defaults to medium when effortLevel is invalid', () => {
-            const result = render({ settingsValue: { effortLevel: 'ultra' } });
-            expect(result).toBe('Thinking: medium');
+        it('displays default when effortLevel fails the shape check', () => {
+            const result = render({ settingsValue: { effortLevel: 'has space' } });
+            expect(result).toBe('Thinking: default');
         });
 
-        it('defaults to medium when settings read fails', () => {
+        it('displays default when effortLevel is too long', () => {
+            const result = render({ settingsValue: { effortLevel: 'thisisaveryverylongeffortname' } });
+            expect(result).toBe('Thinking: default');
+        });
+
+        it('displays default when effortLevel is a single character', () => {
+            const result = render({ settingsValue: { effortLevel: 'x' } });
+            expect(result).toBe('Thinking: default');
+        });
+
+        it('displays default when settings read fails', () => {
             mockedLoadSettings.mockImplementation(() => {
                 throw new Error('settings unavailable');
             });
             const result = render();
-            expect(result).toBe('Thinking: medium');
+            expect(result).toBe('Thinking: default');
         });
 
-        it('defaults to medium when the latest /model output has no effort and settings are missing', () => {
+        it('displays default when the latest /model output has no effort and settings are missing', () => {
             const result = render({ fileContent: makeTranscriptEntry(MODEL_WITHOUT_EFFORT) });
-            expect(result).toBe('Thinking: medium');
+            expect(result).toBe('Thinking: default');
+        });
+
+        it('displays raw default when fallback hits', () => {
+            const result = render({ rawValue: true });
+            expect(result).toBe('default');
         });
     });
 });


### PR DESCRIPTION
## Summary
- Adds support for Claude Code's new `xhigh` thinking effort level. Accepts both `xhigh` and `xHigh` casings from `/model` transcript output and from `effortLevel` in `settings.json`.
- Opens the `ThinkingEffort` widget up to future effort levels: any unknown but word-shaped effort name (2–20 chars, `[a-z0-9-]`, case-insensitive) is rendered verbatim with a trailing `?` (e.g. `super-max?`) instead of being silently dropped.
- Changes the `ThinkingEffort` widget's fallback display from a silent `medium` assumption to an explicit `default` when no effort signal is available from either the transcript or Claude Code settings. This avoids showing a misleading effort label when ccstatusline genuinely can't determine the current value (fresh session, no `effortLevel` set, no `/model` command run yet).

## Test plan
- [x] `bun test` — all 742 tests pass, including 11 new cases covering `xhigh`/`xHigh`, `super-max`/`Super-Max` unknown-but-valid values, and rejected shapes (oversized, single char, contains whitespace).
- [x] `bun run lint` — clean.
- [x] Manual verification with piped payloads for each level, the unknown-with-marker path, and the `default` fallback.
- [x] Live verification in a sandboxed Claude Code session with the locally built `dist/ccstatusline.js`.
