### PR TITLE
feat: replace hardcoded 80% usable context ratio with autocompact formula

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,10 @@ The project has dual runtime compatibility - works with both Bun and Node.js:
   - Detects installation status and manages settings.json updates
   - Validates config directory paths with proper error handling
 - **colors.ts**: Color definitions and ANSI code mapping
-- **model-context.ts**: Model-to-context-window mapping
+- **model-context.ts**: Model-to-context-window mapping and autocompact threshold computation
   - Maps model IDs to their context window sizes based on [1m] suffix
-  - Sonnet 4.5 WITH [1m] suffix: 1M tokens (800k usable at 80%) - requires long context beta access
-  - Sonnet 4.5 WITHOUT [1m] suffix: 200k tokens (160k usable at 80%)
-  - Legacy models: 200k tokens (160k usable at 80%)
+  - Usable tokens are computed using Claude Code's autocompact formula (effectiveWindow - buffer), not a flat percentage: 1M context yields 967k usable, 200k context yields 167k usable
+  - Supports `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` to lower the usable threshold via a percentage of the effective window
 
 ### Widgets (src/widgets/)
 Custom widgets implementing the Widget interface defined in src/types/Widget.ts:

--- a/src/utils/__tests__/autocompact.test.ts
+++ b/src/utils/__tests__/autocompact.test.ts
@@ -1,0 +1,101 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import { loadClaudeSettingsSync } from '../claude-settings';
+
+vi.mock('../claude-settings', () => ({ loadClaudeSettingsSync: vi.fn(() => ({})) }));
+
+const mockLoadClaudeSettingsSync = loadClaudeSettingsSync as unknown as ReturnType<typeof vi.fn>;
+
+// Import after mock setup
+const { resolveAutocompactPercent } = await import('../autocompact');
+
+describe('resolveAutocompactPercent', () => {
+    beforeEach(() => {
+        delete process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE;
+        mockLoadClaudeSettingsSync.mockReturnValue({});
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns null when no source provides a value', () => {
+        expect(resolveAutocompactPercent()).toBeNull();
+    });
+
+    describe('process.env priority', () => {
+        it('returns value from process.env when set', () => {
+            process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = '75';
+            expect(resolveAutocompactPercent()).toBe(75);
+        });
+
+        it('takes priority over Claude settings', () => {
+            process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = '60';
+            mockLoadClaudeSettingsSync.mockReturnValue({ env: { CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: '80' } });
+            expect(resolveAutocompactPercent()).toBe(60);
+        });
+    });
+
+    describe('Claude settings.json env fallback', () => {
+        it('returns value from Claude settings env when process.env is not set', () => {
+            mockLoadClaudeSettingsSync.mockReturnValue({ env: { CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: '83' } });
+            expect(resolveAutocompactPercent()).toBe(83);
+        });
+
+        it('handles numeric value in Claude settings', () => {
+            mockLoadClaudeSettingsSync.mockReturnValue({ env: { CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: 42 } });
+            expect(resolveAutocompactPercent()).toBe(42);
+        });
+    });
+
+    describe('invalid values are skipped', () => {
+        it('skips process.env value of 0 and falls through', () => {
+            process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = '0';
+            mockLoadClaudeSettingsSync.mockReturnValue({ env: { CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: '50' } });
+            expect(resolveAutocompactPercent()).toBe(50);
+        });
+
+        it('skips process.env value over 100 and falls through', () => {
+            process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = '150';
+            mockLoadClaudeSettingsSync.mockReturnValue({ env: { CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: '50' } });
+            expect(resolveAutocompactPercent()).toBe(50);
+        });
+
+        it('skips non-numeric process.env value and falls through', () => {
+            process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = 'abc';
+            mockLoadClaudeSettingsSync.mockReturnValue({ env: { CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: '70' } });
+            expect(resolveAutocompactPercent()).toBe(70);
+        });
+
+        it('skips invalid Claude settings value and returns null', () => {
+            mockLoadClaudeSettingsSync.mockReturnValue({ env: { CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: 'not-a-number' } });
+            expect(resolveAutocompactPercent()).toBeNull();
+        });
+
+        it('returns null when Claude settings env is missing', () => {
+            mockLoadClaudeSettingsSync.mockReturnValue({ env: {} });
+            expect(resolveAutocompactPercent()).toBeNull();
+        });
+
+        it('returns null when Claude settings has no env key', () => {
+            mockLoadClaudeSettingsSync.mockReturnValue({});
+            expect(resolveAutocompactPercent()).toBeNull();
+        });
+    });
+
+    describe('error handling', () => {
+        it('returns null when loadClaudeSettingsSync throws', () => {
+            mockLoadClaudeSettingsSync.mockImplementation(() => {
+                throw new Error('File not found');
+            });
+            expect(resolveAutocompactPercent()).toBeNull();
+        });
+    });
+});

--- a/src/utils/__tests__/model-context.test.ts
+++ b/src/utils/__tests__/model-context.test.ts
@@ -15,14 +15,14 @@ describe('getContextConfig', () => {
             const config = getContextConfig('claude-3-5-sonnet-20241022', 1000000);
 
             expect(config.maxTokens).toBe(1000000);
-            expect(config.usableTokens).toBe(800000);
+            expect(config.usableTokens).toBe(967000);
         });
 
         it('should prioritize context_window_size over [1m] model suffix', () => {
             const config = getContextConfig('claude-sonnet-4-5-20250929[1m]', 200000);
 
             expect(config.maxTokens).toBe(200000);
-            expect(config.usableTokens).toBe(160000);
+            expect(config.usableTokens).toBe(167000);
         });
     });
 
@@ -31,14 +31,14 @@ describe('getContextConfig', () => {
             const config = getContextConfig('claude-sonnet-4-5-20250929[1m]');
 
             expect(config.maxTokens).toBe(1000000);
-            expect(config.usableTokens).toBe(800000);
+            expect(config.usableTokens).toBe(967000);
         });
 
         it('should return 1M context window for claude-opus-4-6 with [1m] suffix', () => {
             const config = getContextConfig('claude-opus-4-6[1m]');
 
             expect(config.maxTokens).toBe(1000000);
-            expect(config.usableTokens).toBe(800000);
+            expect(config.usableTokens).toBe(967000);
         });
 
         it('should return 1M context window for AWS Bedrock format with [1m] suffix', () => {
@@ -47,42 +47,42 @@ describe('getContextConfig', () => {
             );
 
             expect(config.maxTokens).toBe(1000000);
-            expect(config.usableTokens).toBe(800000);
+            expect(config.usableTokens).toBe(967000);
         });
 
         it('should return 1M context window with uppercase [1M] suffix', () => {
             const config = getContextConfig('claude-sonnet-4-5-20250929[1M]');
 
             expect(config.maxTokens).toBe(1000000);
-            expect(config.usableTokens).toBe(800000);
+            expect(config.usableTokens).toBe(967000);
         });
 
         it('should return 1M context window for model IDs with 1M context label', () => {
             const config = getContextConfig('Opus 4.6 (1M context)');
 
             expect(config.maxTokens).toBe(1000000);
-            expect(config.usableTokens).toBe(800000);
+            expect(config.usableTokens).toBe(967000);
         });
 
         it('should return 1M context window for model IDs with 1M token context label', () => {
             const config = getContextConfig('Claude Opus 4.6 - 1M token context');
 
             expect(config.maxTokens).toBe(1000000);
-            expect(config.usableTokens).toBe(800000);
+            expect(config.usableTokens).toBe(967000);
         });
 
         it('should return 1M context window for model IDs with 1M in parentheses', () => {
             const config = getContextConfig('Opus 4.6 (1M)');
 
             expect(config.maxTokens).toBe(1000000);
-            expect(config.usableTokens).toBe(800000);
+            expect(config.usableTokens).toBe(967000);
         });
 
         it('should return 1M context window for model IDs with 1M in square brackets', () => {
             const config = getContextConfig('Opus 4.5 [1M]');
 
             expect(config.maxTokens).toBe(1000000);
-            expect(config.usableTokens).toBe(800000);
+            expect(config.usableTokens).toBe(967000);
         });
     });
 
@@ -91,7 +91,7 @@ describe('getContextConfig', () => {
             const config = getContextConfig('claude-sonnet-4-5-20250929');
 
             expect(config.maxTokens).toBe(200000);
-            expect(config.usableTokens).toBe(160000);
+            expect(config.usableTokens).toBe(167000);
         });
 
         it('should return 200k context window for AWS Bedrock format without [1m] suffix', () => {
@@ -100,7 +100,7 @@ describe('getContextConfig', () => {
             );
 
             expect(config.maxTokens).toBe(200000);
-            expect(config.usableTokens).toBe(160000);
+            expect(config.usableTokens).toBe(167000);
         });
     });
 
@@ -109,21 +109,86 @@ describe('getContextConfig', () => {
             const config = getContextConfig('claude-3-5-sonnet-20241022');
 
             expect(config.maxTokens).toBe(200000);
-            expect(config.usableTokens).toBe(160000);
+            expect(config.usableTokens).toBe(167000);
         });
 
         it('should return 200k context window when model ID is undefined', () => {
             const config = getContextConfig(undefined);
 
             expect(config.maxTokens).toBe(200000);
-            expect(config.usableTokens).toBe(160000);
+            expect(config.usableTokens).toBe(167000);
         });
 
         it('should return 200k context window for unknown model ID', () => {
             const config = getContextConfig('claude-unknown-model');
 
             expect(config.maxTokens).toBe(200000);
-            expect(config.usableTokens).toBe(160000);
+            expect(config.usableTokens).toBe(167000);
+        });
+    });
+
+    describe('autocompactPercent override', () => {
+        it('should lower usable tokens when override is below default threshold', () => {
+            // 200k window: effectiveWindow = 180,000
+            // default threshold = 167,000
+            // 50% of effectiveWindow = 90,000 < 167,000 -> use 90,000
+            const config = getContextConfig('claude-3-5-sonnet-20241022', null, 50);
+
+            expect(config.maxTokens).toBe(200000);
+            expect(config.usableTokens).toBe(90000);
+        });
+
+        it('should clamp to default threshold when override would raise above it', () => {
+            // 200k window: effectiveWindow = 180,000
+            // default threshold = 167,000
+            // 99% of effectiveWindow = 178,200 > 167,000 -> clamp to 167,000
+            const config = getContextConfig('claude-3-5-sonnet-20241022', null, 99);
+
+            expect(config.maxTokens).toBe(200000);
+            expect(config.usableTokens).toBe(167000);
+        });
+
+        it('should apply override to 1M context window', () => {
+            // 1M window: effectiveWindow = 980,000
+            // default threshold = 967,000
+            // 50% of effectiveWindow = 490,000 < 967,000 -> use 490,000
+            const config = getContextConfig('claude-sonnet-4-5-20250929[1m]', null, 50);
+
+            expect(config.maxTokens).toBe(1000000);
+            expect(config.usableTokens).toBe(490000);
+        });
+
+        it('should apply override when context_window_size is provided', () => {
+            // 200k from status JSON, 50% override
+            // effectiveWindow = 180,000, 50% = 90,000
+            const config = getContextConfig('claude-3-5-sonnet-20241022', 200000, 50);
+
+            expect(config.maxTokens).toBe(200000);
+            expect(config.usableTokens).toBe(90000);
+        });
+
+        it('should ignore null autocompact percent', () => {
+            const config = getContextConfig('claude-3-5-sonnet-20241022', null, null);
+
+            expect(config.usableTokens).toBe(167000);
+        });
+
+        it('should ignore invalid autocompact percent values', () => {
+            expect(getContextConfig(undefined, null, 0).usableTokens).toBe(167000);
+            expect(getContextConfig(undefined, null, 101).usableTokens).toBe(167000);
+            expect(getContextConfig(undefined, null, -5).usableTokens).toBe(167000);
+        });
+    });
+
+    describe('Small context windows', () => {
+        it('should floor usable tokens at 1 to prevent zero or negative values', () => {
+            // contextWindow = 30,000
+            // effectiveWindow = 30,000 - 20,000 = 10,000
+            // defaultThreshold = 10,000 - 13,000 = -3,000 -> clamped to 1
+            const config = getContextConfig(undefined, 30000);
+
+            expect(config.maxTokens).toBe(30000);
+            expect(config.usableTokens).toBe(1);
         });
     });
 });

--- a/src/utils/autocompact.ts
+++ b/src/utils/autocompact.ts
@@ -1,0 +1,56 @@
+import { loadClaudeSettingsSync } from './claude-settings';
+
+/**
+ * Parse and validate an autocompact percentage value.
+ * Must be a finite number between 1 and 100 inclusive.
+ */
+function parseAutocompactPercent(value: unknown): number | null {
+    if (value === undefined || value === null || value === '') {
+        return null;
+    }
+
+    const num = typeof value === 'number' ? value : Number(value);
+
+    if (!Number.isFinite(num) || num < 1 || num > 100) {
+        return null;
+    }
+
+    return num;
+}
+
+/**
+ * Resolve the CLAUDE_AUTOCOMPACT_PCT_OVERRIDE value from available sources.
+ *
+ * Priority cascade:
+ * 1. process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE (shell environment)
+ * 2. Claude Code settings.json env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+ * 3. null (no override found)
+ *
+ * The value must be a number between 1 and 100. Invalid values are skipped.
+ */
+export function resolveAutocompactPercent(): number | null {
+    // 1. Shell environment variable
+    const envValue = parseAutocompactPercent(process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE);
+    if (envValue !== null) {
+        return envValue;
+    }
+
+    // 2. Claude Code settings.json -> env -> CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+    try {
+        const claudeSettings = loadClaudeSettingsSync({ logErrors: false });
+        const envRecord = claudeSettings.env;
+
+        if (envRecord && typeof envRecord === 'object') {
+            const claudeEnvValue = parseAutocompactPercent(
+                (envRecord as Record<string, unknown>).CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+            );
+            if (claudeEnvValue !== null) {
+                return claudeEnvValue;
+            }
+        }
+    } catch {
+        // Claude settings unreadable, skip
+    }
+
+    return null;
+}

--- a/src/utils/model-context.ts
+++ b/src/utils/model-context.ts
@@ -9,7 +9,19 @@ interface ModelIdentifier {
 }
 
 const DEFAULT_CONTEXT_WINDOW_SIZE = 200000;
-const USABLE_CONTEXT_RATIO = 0.8;
+
+/**
+ * Tokens reserved for the autocompact summary output.
+ * Claude Code reserves min(modelMaxOutputTokens, 20000) tokens;
+ * all current models have max_output >= 20k so this is always 20,000.
+ */
+const RESERVED_TOKENS_FOR_SUMMARY = 20_000;
+
+/**
+ * Fixed buffer subtracted from the effective window to arrive at the
+ * default autocompact threshold.
+ */
+const AUTOCOMPACT_BUFFER_TOKENS = 13_000;
 
 function toValidWindowSize(value: number | null | undefined): number | null {
     if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
@@ -73,19 +85,51 @@ export function getModelContextIdentifier(model?: string | ModelIdentifier): str
     return id ?? displayName;
 }
 
-export function getContextConfig(modelIdentifier?: string, contextWindowSize?: number | null): ModelContextConfig {
+/**
+ * Compute the usable-token threshold for a given context window.
+ *
+ * Default formula (matches Claude Code autocompact):
+ *   effectiveWindow = contextWindow - RESERVED_TOKENS_FOR_SUMMARY
+ *   threshold       = effectiveWindow - AUTOCOMPACT_BUFFER_TOKENS
+ *
+ * With an optional percentage override (1-100):
+ *   pctThreshold    = floor(effectiveWindow * pct / 100)
+ *   threshold       = min(pctThreshold, defaultThreshold)   // can only lower
+ */
+function computeUsableTokens(contextWindow: number, autocompactPercent?: number | null): number {
+    const effectiveWindow = contextWindow - RESERVED_TOKENS_FOR_SUMMARY;
+    const defaultThreshold = effectiveWindow - AUTOCOMPACT_BUFFER_TOKENS;
+
+    if (
+        typeof autocompactPercent === 'number'
+        && Number.isFinite(autocompactPercent)
+        && autocompactPercent >= 1
+        && autocompactPercent <= 100
+    ) {
+        const pctThreshold = Math.floor(effectiveWindow * autocompactPercent / 100);
+        return Math.max(1, Math.min(pctThreshold, defaultThreshold));
+    }
+
+    return Math.max(1, defaultThreshold);
+}
+
+export function getContextConfig(
+    modelIdentifier?: string,
+    contextWindowSize?: number | null,
+    autocompactPercent?: number | null
+): ModelContextConfig {
     const statusWindowSize = toValidWindowSize(contextWindowSize);
     if (statusWindowSize !== null) {
         return {
             maxTokens: statusWindowSize,
-            usableTokens: Math.floor(statusWindowSize * USABLE_CONTEXT_RATIO)
+            usableTokens: computeUsableTokens(statusWindowSize, autocompactPercent)
         };
     }
 
     // Default to 200k for older models
     const defaultConfig = {
         maxTokens: DEFAULT_CONTEXT_WINDOW_SIZE,
-        usableTokens: Math.floor(DEFAULT_CONTEXT_WINDOW_SIZE * USABLE_CONTEXT_RATIO)
+        usableTokens: computeUsableTokens(DEFAULT_CONTEXT_WINDOW_SIZE, autocompactPercent)
     };
 
     if (!modelIdentifier) {
@@ -96,7 +140,7 @@ export function getContextConfig(modelIdentifier?: string, contextWindowSize?: n
     if (inferredWindowSize !== null) {
         return {
             maxTokens: inferredWindowSize,
-            usableTokens: Math.floor(inferredWindowSize * USABLE_CONTEXT_RATIO)
+            usableTokens: computeUsableTokens(inferredWindowSize, autocompactPercent)
         };
     }
 

--- a/src/widgets/ContextPercentageUsable.ts
+++ b/src/widgets/ContextPercentageUsable.ts
@@ -6,6 +6,7 @@ import type {
     WidgetEditorDisplay,
     WidgetItem
 } from '../types/Widget';
+import { resolveAutocompactPercent } from '../utils/autocompact';
 import { getContextWindowMetrics } from '../utils/context-window';
 import {
     getContextConfig,
@@ -21,7 +22,7 @@ import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
 
 export class ContextPercentageUsableWidget implements Widget {
     getDefaultColor(): string { return 'green'; }
-    getDescription(): string { return 'Shows percentage of usable context window used or remaining (80% of max before auto-compact)'; }
+    getDescription(): string { return 'Shows percentage of usable context window used or remaining (auto-compact threshold)'; }
     getDisplayName(): string { return 'Context % (usable)'; }
     getCategory(): string { return 'Context'; }
     getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
@@ -39,10 +40,11 @@ export class ContextPercentageUsableWidget implements Widget {
         const isInverse = isContextInverse(item);
         const modelIdentifier = getModelContextIdentifier(context.data?.model);
         const contextWindowMetrics = getContextWindowMetrics(context.data);
-        const contextConfig = getContextConfig(modelIdentifier, contextWindowMetrics.windowSize);
+        const autocompactPercent = resolveAutocompactPercent();
+        const contextConfig = getContextConfig(modelIdentifier, contextWindowMetrics.windowSize, autocompactPercent);
 
         if (context.isPreview) {
-            const previewValue = isInverse ? '88.4%' : '11.6%';
+            const previewValue = isInverse ? '88.0%' : '12.0%';
             return formatRawOrLabeledValue(item, 'Ctx(u): ', previewValue);
         }
 

--- a/src/widgets/__tests__/ContextPercentageUsable.test.ts
+++ b/src/widgets/__tests__/ContextPercentageUsable.test.ts
@@ -1,7 +1,8 @@
 import {
     describe,
     expect,
-    it
+    it,
+    vi
 } from 'vitest';
 
 import type {
@@ -10,6 +11,8 @@ import type {
 } from '../../types';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import { ContextPercentageUsableWidget } from '../ContextPercentageUsable';
+
+vi.mock('../../utils/autocompact', () => ({ resolveAutocompactPercent: vi.fn(() => null) }));
 
 function render(modelId: string | undefined, contextLength: number, rawValue = false, inverse = false) {
     const widget = new ContextPercentageUsableWidget();
@@ -80,7 +83,7 @@ describe('ContextPercentageUsableWidget', () => {
             }
         };
 
-        expect(widget.render(item, context, DEFAULT_SETTINGS)).toBe('Ctx(u): 5.0%');
+        expect(widget.render(item, context, DEFAULT_SETTINGS)).toBe('Ctx(u): 4.1%');
     });
 
     it('uses context_window_size for usable denominator even without [1m] model suffix', () => {
@@ -103,50 +106,50 @@ describe('ContextPercentageUsableWidget', () => {
             }
         };
 
-        expect(widget.render(item, context, DEFAULT_SETTINGS)).toBe('Ctx(u): 5.3%');
+        expect(widget.render(item, context, DEFAULT_SETTINGS)).toBe('Ctx(u): 4.3%');
     });
 
-    describe('Sonnet 4.5 with 800k usable tokens', () => {
-        it('should calculate percentage using 800k denominator for Sonnet 4.5 with [1m] suffix', () => {
+    describe('1M models with 967k usable tokens', () => {
+        it('should calculate percentage using 967k denominator for Sonnet 4.5 with [1m] suffix', () => {
             const result = render('claude-sonnet-4-5-20250929[1m]', 42000);
-            expect(result).toBe('Ctx(u): 5.3%');
+            expect(result).toBe('Ctx(u): 4.3%');
         });
 
-        it('should calculate percentage using 800k denominator for Sonnet 4.5 (raw value) with [1m] suffix', () => {
+        it('should calculate percentage using 967k denominator for Sonnet 4.5 (raw value) with [1m] suffix', () => {
             const result = render('claude-sonnet-4-5-20250929[1m]', 42000, true);
-            expect(result).toBe('5.3%');
+            expect(result).toBe('4.3%');
         });
 
         it('should treat [1M] suffix case-insensitively in fallback mode', () => {
             const result = render('claude-sonnet-4-5-20250929[1M]', 42000);
-            expect(result).toBe('Ctx(u): 5.3%');
+            expect(result).toBe('Ctx(u): 4.3%');
         });
 
         it('uses 1M context labels in model id for fallback denominator', () => {
             const result = render('Opus 4.6 (1M context)', 42000);
-            expect(result).toBe('Ctx(u): 5.3%');
+            expect(result).toBe('Ctx(u): 4.3%');
         });
 
         it('uses 1M in parentheses in model id for fallback denominator', () => {
             const result = render('Opus 4.6 (1M)', 42000);
-            expect(result).toBe('Ctx(u): 5.3%');
+            expect(result).toBe('Ctx(u): 4.3%');
         });
     });
 
-    describe('Older models with 160k usable tokens', () => {
-        it('should calculate percentage using 160k denominator for older Sonnet 3.5', () => {
+    describe('Older models with 167k usable tokens', () => {
+        it('should calculate percentage using 167k denominator for older Sonnet 3.5', () => {
             const result = render('claude-3-5-sonnet-20241022', 42000);
-            expect(result).toBe('Ctx(u): 26.3%');
+            expect(result).toBe('Ctx(u): 25.1%');
         });
 
-        it('should calculate percentage using 160k denominator when model ID is undefined', () => {
+        it('should calculate percentage using 167k denominator when model ID is undefined', () => {
             const result = render(undefined, 42000);
-            expect(result).toBe('Ctx(u): 26.3%');
+            expect(result).toBe('Ctx(u): 25.1%');
         });
 
-        it('should calculate percentage using 160k denominator for unknown model', () => {
+        it('should calculate percentage using 167k denominator for unknown model', () => {
             const result = render('claude-unknown-model', 42000);
-            expect(result).toBe('Ctx(u): 26.3%');
+            expect(result).toBe('Ctx(u): 25.1%');
         });
     });
 });


### PR DESCRIPTION
## Summary

- Replace the flat 0.8 (80%) usable context ratio with Claude Code's actual autocompact threshold formula: `effectiveWindow - bufferTokens`
- This changes usable tokens from 160k → 167k (200k windows) and 800k → 967k (1M windows), matching when Claude Code actually triggers compaction
- Add support for `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` resolved from shell env → Claude Code `settings.json` env block → null

## Test plan

- [x] All 750 tests pass (`bun test`)
- [x] Lint and type check clean (`bun run lint`)
- [ ] Verify usable context percentage display with piped input
- [ ] Verify with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` set in environment
- [ ] Verify with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` set in `~/.claude/settings.json` env block

🤖 Generated with [Claude Code](https://claude.com/claude-code)