### PR TITLE
feat: add tool-count widget tracking tool invocations per session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# graphify knowledge graph outputs
+graphify-out/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # graphify knowledge graph outputs
 graphify-out/
+
+# superpowers planning docs (local only)
+docs/superpowers/

--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -8,9 +8,14 @@ import type {
     TokenMetrics,
     ToolCountMetrics
 } from './types';
+import type { AgentActivityMetrics } from './types/AgentActivityMetrics';
 import type { RenderContext } from './types/RenderContext';
 import type { StatusJSON } from './types/StatusJSON';
 import { StatusJSONSchema } from './types/StatusJSON';
+import {
+    getAgentActivityFilePath,
+    getAgentActivityMetrics
+} from './utils/agent-activity';
 import { getVisibleText } from './utils/ansi';
 import { updateColorMap } from './utils/colors';
 import {
@@ -153,6 +158,12 @@ async function renderMultipleLines(data: StatusJSON) {
         toolCountMetrics = getToolCountMetrics(data.session_id);
     }
 
+    const hasAgentActivity = lines.some(line => line.some(item => item.type === 'agent-activity'));
+    let agentActivityMetrics: AgentActivityMetrics | null = null;
+    if (hasAgentActivity && data.session_id) {
+        agentActivityMetrics = getAgentActivityMetrics(data.session_id);
+    }
+
     // Create render context
     const context: RenderContext = {
         data,
@@ -163,6 +174,7 @@ async function renderMultipleLines(data: StatusJSON) {
         sessionDuration,
         skillsMetrics,
         toolCountMetrics,
+        agentActivityMetrics,
         isPreview: false,
         minimalist: settings.minimalistMode
     };
@@ -252,7 +264,13 @@ interface HookInput {
     session_id?: string;
     hook_event_name?: string;
     tool_name?: string;
-    tool_input?: { skill?: string };
+    tool_use_id?: string;
+    tool_input?: {
+        skill?: string;
+        subagent_type?: string;
+        model?: string;
+        description?: string;
+    };
     prompt?: string;
 }
 
@@ -308,6 +326,43 @@ async function handleHook(): Promise<void> {
                 category: classifyTool(data.tool_name)
             });
             fs.appendFileSync(toolCountPath, entry + '\n');
+        }
+
+        // Agent Activity — start event (Task subagent began)
+        if (data.hook_event_name === 'PreToolUse'
+            && data.tool_name === 'Task'
+            && typeof data.tool_use_id === 'string'
+            && data.tool_use_id.length > 0) {
+            const agentPath = getAgentActivityFilePath(sessionId);
+            fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+            const entry = JSON.stringify({
+                timestamp: new Date().toISOString(),
+                session_id: sessionId,
+                event: 'start',
+                id: data.tool_use_id,
+                type: typeof data.tool_input?.subagent_type === 'string'
+                    ? data.tool_input.subagent_type
+                    : 'unknown',
+                model: typeof data.tool_input?.model === 'string' ? data.tool_input.model : undefined,
+                description: typeof data.tool_input?.description === 'string' ? data.tool_input.description : undefined
+            });
+            fs.appendFileSync(agentPath, entry + '\n');
+        }
+
+        // Agent Activity — end event (Task subagent finished)
+        if (data.hook_event_name === 'PostToolUse'
+            && data.tool_name === 'Task'
+            && typeof data.tool_use_id === 'string'
+            && data.tool_use_id.length > 0) {
+            const agentPath = getAgentActivityFilePath(sessionId);
+            fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+            const entry = JSON.stringify({
+                timestamp: new Date().toISOString(),
+                session_id: sessionId,
+                event: 'end',
+                id: data.tool_use_id
+            });
+            fs.appendFileSync(agentPath, entry + '\n');
         }
     } catch { /* ignore parse errors */ }
     console.log('{}');

--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -12,6 +12,7 @@ import type { AgentActivityMetrics } from './types/AgentActivityMetrics';
 import type { RenderContext } from './types/RenderContext';
 import type { StatusJSON } from './types/StatusJSON';
 import { StatusJSONSchema } from './types/StatusJSON';
+import type { TodoProgressMetrics } from './types/TodoProgressMetrics';
 import {
     getAgentActivityFilePath,
     getAgentActivityMetrics
@@ -44,7 +45,12 @@ import {
     isWidgetSpeedWindowEnabled
 } from './utils/speed-window';
 import {
+    getTodoProgressFilePath,
+    getTodoProgressMetrics
+} from './utils/todo-progress';
+import {
     classifyTool,
+    extractTarget,
     getToolCountFilePath,
     getToolCountMetrics
 } from './utils/tool-count';
@@ -164,6 +170,12 @@ async function renderMultipleLines(data: StatusJSON) {
         agentActivityMetrics = getAgentActivityMetrics(data.session_id);
     }
 
+    const hasTodoProgress = lines.some(line => line.some(item => item.type === 'todo-progress'));
+    let todoProgressMetrics: TodoProgressMetrics | null = null;
+    if (hasTodoProgress && data.session_id) {
+        todoProgressMetrics = getTodoProgressMetrics(data.session_id);
+    }
+
     // Create render context
     const context: RenderContext = {
         data,
@@ -175,6 +187,7 @@ async function renderMultipleLines(data: StatusJSON) {
         skillsMetrics,
         toolCountMetrics,
         agentActivityMetrics,
+        todoProgressMetrics,
         isPreview: false,
         minimalist: settings.minimalistMode
     };
@@ -270,6 +283,12 @@ interface HookInput {
         subagent_type?: string;
         model?: string;
         description?: string;
+        todos?: unknown;
+        file_path?: string;
+        path?: string;
+        pattern?: string;
+        url?: string;
+        command?: string;
     };
     prompt?: string;
 }
@@ -319,11 +338,38 @@ async function handleHook(): Promise<void> {
             && data.tool_name !== 'Skill') {
             const toolCountPath = getToolCountFilePath(sessionId);
             fs.mkdirSync(path.dirname(toolCountPath), { recursive: true });
+            const target = extractTarget(data.tool_name, data.tool_input);
+            const record: Record<string, unknown> = {
+                timestamp: new Date().toISOString(),
+                session_id: sessionId,
+                tool_name: data.tool_name,
+                category: classifyTool(data.tool_name),
+                event: 'start'
+            };
+            if (typeof data.tool_use_id === 'string' && data.tool_use_id.length > 0) {
+                record.tool_use_id = data.tool_use_id;
+            }
+            if (target) {
+                record.target = target;
+            }
+            fs.appendFileSync(toolCountPath, JSON.stringify(record) + '\n');
+        }
+
+        // Tool Count — end event (paired with PreToolUse start; enables `activity` mode)
+        if (data.hook_event_name === 'PostToolUse'
+            && data.tool_name
+            && data.tool_name !== 'Skill'
+            && typeof data.tool_use_id === 'string'
+            && data.tool_use_id.length > 0) {
+            const toolCountPath = getToolCountFilePath(sessionId);
+            fs.mkdirSync(path.dirname(toolCountPath), { recursive: true });
             const entry = JSON.stringify({
                 timestamp: new Date().toISOString(),
                 session_id: sessionId,
                 tool_name: data.tool_name,
-                category: classifyTool(data.tool_name)
+                category: classifyTool(data.tool_name),
+                event: 'end',
+                tool_use_id: data.tool_use_id
             });
             fs.appendFileSync(toolCountPath, entry + '\n');
         }
@@ -363,6 +409,36 @@ async function handleHook(): Promise<void> {
                 id: data.tool_use_id
             });
             fs.appendFileSync(agentPath, entry + '\n');
+        }
+
+        // Todo Progress — snapshot on TodoWrite
+        if (data.hook_event_name === 'PostToolUse'
+            && data.tool_name === 'TodoWrite'
+            && Array.isArray(data.tool_input?.todos)) {
+            const todos: { content: string; status: string; activeForm?: string }[] = [];
+            for (const raw of data.tool_input.todos) {
+                if (typeof raw !== 'object' || raw === null)
+                    continue;
+                const rec = raw as Record<string, unknown>;
+                if (typeof rec.content !== 'string' || typeof rec.status !== 'string')
+                    continue;
+                const entry: { content: string; status: string; activeForm?: string } = {
+                    content: rec.content,
+                    status: rec.status
+                };
+                if (typeof rec.activeForm === 'string') {
+                    entry.activeForm = rec.activeForm;
+                }
+                todos.push(entry);
+            }
+            const todoPath = getTodoProgressFilePath(sessionId);
+            fs.mkdirSync(path.dirname(todoPath), { recursive: true });
+            const entry = JSON.stringify({
+                timestamp: new Date().toISOString(),
+                session_id: sessionId,
+                todos
+            });
+            fs.appendFileSync(todoPath, entry + '\n');
         }
     } catch { /* ignore parse errors */ }
     console.log('{}');

--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -328,9 +328,9 @@ async function handleHook(): Promise<void> {
             fs.appendFileSync(toolCountPath, entry + '\n');
         }
 
-        // Agent Activity — start event (Task subagent began)
+        // Agent Activity — start event (Agent subagent began)
         if (data.hook_event_name === 'PreToolUse'
-            && data.tool_name === 'Task'
+            && data.tool_name === 'Agent'
             && typeof data.tool_use_id === 'string'
             && data.tool_use_id.length > 0) {
             const agentPath = getAgentActivityFilePath(sessionId);
@@ -349,9 +349,9 @@ async function handleHook(): Promise<void> {
             fs.appendFileSync(agentPath, entry + '\n');
         }
 
-        // Agent Activity — end event (Task subagent finished)
+        // Agent Activity — end event (Agent subagent finished)
         if (data.hook_event_name === 'PostToolUse'
-            && data.tool_name === 'Task'
+            && data.tool_name === 'Agent'
             && typeof data.tool_use_id === 'string'
             && data.tool_use_id.length > 0) {
             const agentPath = getAgentActivityFilePath(sessionId);

--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -332,6 +332,27 @@ async function handleHook(): Promise<void> {
             fs.appendFileSync(skillsPath, entry + '\n');
         }
 
+        // Turn boundary marker — appended to agent-activity and todo-progress
+        // jsonls on every new user prompt. getAgentActivityMetrics /
+        // getTodoProgressMetrics read the last turn timestamp and purge
+        // completed agents / stale todo snapshots that predate it. Running
+        // agents are always kept; they span turns by definition.
+        if (data.hook_event_name === 'UserPromptSubmit') {
+            const turnMarker = JSON.stringify({
+                timestamp: new Date().toISOString(),
+                session_id: sessionId,
+                event: 'turn'
+            });
+            const agentPath = getAgentActivityFilePath(sessionId);
+            if (fs.existsSync(agentPath)) {
+                fs.appendFileSync(agentPath, turnMarker + '\n');
+            }
+            const todoPath = getTodoProgressFilePath(sessionId);
+            if (fs.existsSync(todoPath)) {
+                fs.appendFileSync(todoPath, turnMarker + '\n');
+            }
+        }
+
         // Skill is logged above; don't double-count it here.
         if (data.hook_event_name === 'PreToolUse'
             && data.tool_name

--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -5,7 +5,8 @@ import { runTUI } from './tui';
 import type {
     SkillsMetrics,
     SpeedMetrics,
-    TokenMetrics
+    TokenMetrics,
+    ToolCountMetrics
 } from './types';
 import type { RenderContext } from './types/RenderContext';
 import type { StatusJSON } from './types/StatusJSON';
@@ -37,6 +38,11 @@ import {
     getWidgetSpeedWindowSeconds,
     isWidgetSpeedWindowEnabled
 } from './utils/speed-window';
+import {
+    classifyTool,
+    getToolCountFilePath,
+    getToolCountMetrics
+} from './utils/tool-count';
 import { prefetchUsageDataIfNeeded } from './utils/usage-prefetch';
 
 function hasSessionDurationInStatusJson(data: StatusJSON): boolean {
@@ -141,6 +147,12 @@ async function renderMultipleLines(data: StatusJSON) {
         skillsMetrics = getSkillsMetrics(data.session_id);
     }
 
+    const hasToolCount = lines.some(line => line.some(item => item.type === 'tool-count'));
+    let toolCountMetrics: ToolCountMetrics | null = null;
+    if (hasToolCount && data.session_id) {
+        toolCountMetrics = getToolCountMetrics(data.session_id);
+    }
+
     // Create render context
     const context: RenderContext = {
         data,
@@ -150,6 +162,7 @@ async function renderMultipleLines(data: StatusJSON) {
         usageData,
         sessionDuration,
         skillsMetrics,
+        toolCountMetrics,
         isPreview: false,
         minimalist: settings.minimalistMode
     };
@@ -257,6 +270,9 @@ async function handleHook(): Promise<void> {
             return;
         }
 
+        const fs = await import('fs');
+        const path = await import('path');
+
         let skillName = '';
         if (data.hook_event_name === 'PreToolUse' && data.tool_name === 'Skill') {
             skillName = data.tool_input?.skill ?? '';
@@ -266,22 +282,33 @@ async function handleHook(): Promise<void> {
                 skillName = match[1] ?? '';
             }
         }
-        if (!skillName) {
-            console.log('{}');
-            return;
+
+        if (skillName) {
+            const skillsPath = getSkillsFilePath(sessionId);
+            fs.mkdirSync(path.dirname(skillsPath), { recursive: true });
+            const entry = JSON.stringify({
+                timestamp: new Date().toISOString(),
+                session_id: sessionId,
+                skill: skillName,
+                source: data.hook_event_name
+            });
+            fs.appendFileSync(skillsPath, entry + '\n');
         }
 
-        const filePath = getSkillsFilePath(sessionId);
-        const fs = await import('fs');
-        const path = await import('path');
-        fs.mkdirSync(path.dirname(filePath), { recursive: true });
-        const entry = JSON.stringify({
-            timestamp: new Date().toISOString(),
-            session_id: sessionId,
-            skill: skillName,
-            source: data.hook_event_name
-        });
-        fs.appendFileSync(filePath, entry + '\n');
+        // Skill is logged above; don't double-count it here.
+        if (data.hook_event_name === 'PreToolUse'
+            && data.tool_name
+            && data.tool_name !== 'Skill') {
+            const toolCountPath = getToolCountFilePath(sessionId);
+            fs.mkdirSync(path.dirname(toolCountPath), { recursive: true });
+            const entry = JSON.stringify({
+                timestamp: new Date().toISOString(),
+                session_id: sessionId,
+                tool_name: data.tool_name,
+                category: classifyTool(data.tool_name)
+            });
+            fs.appendFileSync(toolCountPath, entry + '\n');
+        }
     } catch { /* ignore parse errors */ }
     console.log('{}');
 }

--- a/src/types/AgentActivityMetrics.ts
+++ b/src/types/AgentActivityMetrics.ts
@@ -1,0 +1,23 @@
+export type AgentStatus = 'running' | 'completed';
+
+export interface AgentEntry {
+    id: string;
+    type: string;
+    model?: string;
+    description?: string;
+    status: AgentStatus;
+    startTime: Date;
+    endTime?: Date;
+}
+
+export interface AgentActivityMetrics { agents: AgentEntry[] }
+
+export interface AgentActivityEvent {
+    timestamp: string;
+    session_id: string;
+    event: 'start' | 'end';
+    id: string;
+    type?: string;
+    model?: string;
+    description?: string;
+}

--- a/src/types/RenderContext.ts
+++ b/src/types/RenderContext.ts
@@ -7,6 +7,7 @@ import type {
 import type { AgentActivityMetrics } from './AgentActivityMetrics';
 import type { SpeedMetrics } from './SpeedMetrics';
 import type { StatusJSON } from './StatusJSON';
+import type { TodoProgressMetrics } from './TodoProgressMetrics';
 import type { TokenMetrics } from './TokenMetrics';
 
 export interface RenderUsageData {
@@ -32,6 +33,7 @@ export interface RenderContext {
     skillsMetrics?: SkillsMetrics | null;
     toolCountMetrics?: ToolCountMetrics | null;
     agentActivityMetrics?: AgentActivityMetrics | null;
+    todoProgressMetrics?: TodoProgressMetrics | null;
     terminalWidth?: number | null;
     isPreview?: boolean;
     minimalist?: boolean;

--- a/src/types/RenderContext.ts
+++ b/src/types/RenderContext.ts
@@ -1,6 +1,7 @@
 import type {
     BlockMetrics,
-    SkillsMetrics
+    SkillsMetrics,
+    ToolCountMetrics
 } from '../types';
 
 import type { SpeedMetrics } from './SpeedMetrics';
@@ -28,6 +29,7 @@ export interface RenderContext {
     sessionDuration?: string | null;
     blockMetrics?: BlockMetrics | null;
     skillsMetrics?: SkillsMetrics | null;
+    toolCountMetrics?: ToolCountMetrics | null;
     terminalWidth?: number | null;
     isPreview?: boolean;
     minimalist?: boolean;

--- a/src/types/RenderContext.ts
+++ b/src/types/RenderContext.ts
@@ -4,6 +4,7 @@ import type {
     ToolCountMetrics
 } from '../types';
 
+import type { AgentActivityMetrics } from './AgentActivityMetrics';
 import type { SpeedMetrics } from './SpeedMetrics';
 import type { StatusJSON } from './StatusJSON';
 import type { TokenMetrics } from './TokenMetrics';
@@ -30,6 +31,7 @@ export interface RenderContext {
     blockMetrics?: BlockMetrics | null;
     skillsMetrics?: SkillsMetrics | null;
     toolCountMetrics?: ToolCountMetrics | null;
+    agentActivityMetrics?: AgentActivityMetrics | null;
     terminalWidth?: number | null;
     isPreview?: boolean;
     minimalist?: boolean;

--- a/src/types/SkillsMetrics.ts
+++ b/src/types/SkillsMetrics.ts
@@ -9,4 +9,5 @@ export interface SkillsMetrics {
     totalInvocations: number;
     uniqueSkills: string[];
     lastSkill: string | null;
+    recent: string[];
 }

--- a/src/types/TodoProgressMetrics.ts
+++ b/src/types/TodoProgressMetrics.ts
@@ -1,0 +1,18 @@
+export type TodoStatus = 'pending' | 'in_progress' | 'completed';
+
+export interface TodoItem {
+    content: string;
+    activeForm?: string;
+    status: TodoStatus;
+}
+
+export interface TodoProgressSnapshot {
+    timestamp: string;
+    session_id: string;
+    todos: TodoItem[];
+}
+
+export interface TodoProgressMetrics {
+    todos: TodoItem[];
+    timestamp: string | null;
+}

--- a/src/types/ToolCountMetrics.ts
+++ b/src/types/ToolCountMetrics.ts
@@ -1,10 +1,25 @@
 export type ToolCategory = 'builtin' | 'mcp';
 
+export type ToolActivityStatus = 'running' | 'completed';
+
 export interface ToolInvocation {
     timestamp: string;
     session_id: string;
     tool_name: string;
     category: ToolCategory;
+    event?: 'start' | 'end';
+    tool_use_id?: string;
+    target?: string;
+}
+
+export interface ToolActivityEntry {
+    tool_name: string;
+    category: ToolCategory;
+    status: ToolActivityStatus;
+    target?: string;
+    startTime: Date;
+    endTime?: Date;
+    id: string;
 }
 
 export interface ToolCountMetrics {
@@ -12,4 +27,5 @@ export interface ToolCountMetrics {
     byCategory: Record<ToolCategory, number>;
     byTool: Record<string, number>;
     lastTool: string | null;
+    activity: ToolActivityEntry[];
 }

--- a/src/types/ToolCountMetrics.ts
+++ b/src/types/ToolCountMetrics.ts
@@ -1,0 +1,15 @@
+export type ToolCategory = 'builtin' | 'mcp';
+
+export interface ToolInvocation {
+    timestamp: string;
+    session_id: string;
+    tool_name: string;
+    category: ToolCategory;
+}
+
+export interface ToolCountMetrics {
+    totalInvocations: number;
+    byCategory: Record<ToolCategory, number>;
+    byTool: Record<string, number>;
+    lastTool: string | null;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,3 +21,9 @@ export type { BlockMetrics } from './BlockMetrics';
 export type { SpeedMetrics } from './SpeedMetrics';
 export type { SkillInvocation, SkillsMetrics } from './SkillsMetrics';
 export type { ToolCategory, ToolCountMetrics, ToolInvocation } from './ToolCountMetrics';
+export type {
+    AgentActivityEvent,
+    AgentActivityMetrics,
+    AgentEntry,
+    AgentStatus
+} from './AgentActivityMetrics';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,10 +20,22 @@ export type { ColorEntry } from './ColorEntry';
 export type { BlockMetrics } from './BlockMetrics';
 export type { SpeedMetrics } from './SpeedMetrics';
 export type { SkillInvocation, SkillsMetrics } from './SkillsMetrics';
-export type { ToolCategory, ToolCountMetrics, ToolInvocation } from './ToolCountMetrics';
+export type {
+    ToolActivityEntry,
+    ToolActivityStatus,
+    ToolCategory,
+    ToolCountMetrics,
+    ToolInvocation
+} from './ToolCountMetrics';
 export type {
     AgentActivityEvent,
     AgentActivityMetrics,
     AgentEntry,
     AgentStatus
 } from './AgentActivityMetrics';
+export type {
+    TodoItem,
+    TodoProgressMetrics,
+    TodoProgressSnapshot,
+    TodoStatus
+} from './TodoProgressMetrics';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,3 +20,4 @@ export type { ColorEntry } from './ColorEntry';
 export type { BlockMetrics } from './BlockMetrics';
 export type { SpeedMetrics } from './SpeedMetrics';
 export type { SkillInvocation, SkillsMetrics } from './SkillsMetrics';
+export type { ToolCategory, ToolCountMetrics, ToolInvocation } from './ToolCountMetrics';

--- a/src/utils/__tests__/agent-activity.test.ts
+++ b/src/utils/__tests__/agent-activity.test.ts
@@ -1,0 +1,275 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import {
+    getAgentActivityFilePath,
+    getAgentActivityMetrics
+} from '../agent-activity';
+
+let testHomeDir = '';
+
+describe('agent-activity', () => {
+    beforeEach(() => {
+        testHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-home-'));
+        vi.spyOn(os, 'homedir').mockReturnValue(testHomeDir);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        if (testHomeDir) {
+            fs.rmSync(testHomeDir, { recursive: true, force: true });
+        }
+    });
+
+    describe('getAgentActivityFilePath', () => {
+        it('uses ~/.cache/ccstatusline/agent-activity path', () => {
+            expect(getAgentActivityFilePath('session-1')).toBe(
+                path.join(testHomeDir, '.cache', 'ccstatusline', 'agent-activity', 'agent-activity-session-1.jsonl')
+            );
+        });
+    });
+
+    function writeEvents(sessionId: string, events: unknown[]): void {
+        const filePath = getAgentActivityFilePath(sessionId);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, events.map(e => JSON.stringify(e)).join('\n'), 'utf-8');
+    }
+
+    describe('getAgentActivityMetrics — basic merging', () => {
+        it('returns empty agents when file does not exist', () => {
+            expect(getAgentActivityMetrics('session-unknown')).toEqual({ agents: [] });
+        });
+
+        it('keeps status=running when only start event exists', () => {
+            writeEvents('s-start-only', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-start-only',
+                    event: 'start',
+                    id: 'tool-1',
+                    type: 'explore',
+                    model: 'haiku',
+                    description: 'Finding auth code'
+                }
+            ]);
+
+            const result = getAgentActivityMetrics('s-start-only');
+            expect(result.agents).toHaveLength(1);
+            expect(result.agents[0]).toMatchObject({
+                id: 'tool-1',
+                type: 'explore',
+                model: 'haiku',
+                description: 'Finding auth code',
+                status: 'running'
+            });
+            expect(result.agents[0]?.startTime.toISOString()).toBe('2026-04-19T10:00:00.000Z');
+            expect(result.agents[0]?.endTime).toBeUndefined();
+        });
+
+        it('marks agent completed when matching end event exists', () => {
+            writeEvents('s-pair', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-pair',
+                    event: 'start',
+                    id: 'tool-1',
+                    type: 'code-reviewer',
+                    model: 'opus'
+                },
+                {
+                    timestamp: '2026-04-19T10:02:30.000Z',
+                    session_id: 's-pair',
+                    event: 'end',
+                    id: 'tool-1'
+                }
+            ]);
+
+            const result = getAgentActivityMetrics('s-pair');
+            expect(result.agents).toHaveLength(1);
+            expect(result.agents[0]?.status).toBe('completed');
+            expect(result.agents[0]?.endTime?.toISOString()).toBe('2026-04-19T10:02:30.000Z');
+        });
+    });
+
+    describe('getAgentActivityMetrics — resilience', () => {
+        it('ignores orphan end events (no matching start)', () => {
+            writeEvents('s-orphan', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-orphan',
+                    event: 'end',
+                    id: 'tool-1'
+                }
+            ]);
+
+            expect(getAgentActivityMetrics('s-orphan').agents).toEqual([]);
+        });
+
+        it('keeps first start when same id starts twice', () => {
+            writeEvents('s-dup', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-dup',
+                    event: 'start',
+                    id: 'tool-1',
+                    type: 'first',
+                    model: 'haiku'
+                },
+                {
+                    timestamp: '2026-04-19T10:01:00.000Z',
+                    session_id: 's-dup',
+                    event: 'start',
+                    id: 'tool-1',
+                    type: 'second',
+                    model: 'opus'
+                }
+            ]);
+
+            const agents = getAgentActivityMetrics('s-dup').agents;
+            expect(agents).toHaveLength(1);
+            expect(agents[0]?.type).toBe('first');
+            expect(agents[0]?.model).toBe('haiku');
+        });
+
+        it('falls back type to "unknown" when missing', () => {
+            writeEvents('s-no-type', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-no-type',
+                    event: 'start',
+                    id: 'tool-1'
+                }
+            ]);
+
+            expect(getAgentActivityMetrics('s-no-type').agents[0]?.type).toBe('unknown');
+        });
+
+        it('leaves model and description undefined when missing', () => {
+            writeEvents('s-minimal', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-minimal',
+                    event: 'start',
+                    id: 'tool-1',
+                    type: 'explore'
+                }
+            ]);
+
+            const agent = getAgentActivityMetrics('s-minimal').agents[0];
+            expect(agent?.model).toBeUndefined();
+            expect(agent?.description).toBeUndefined();
+        });
+
+        it('skips malformed JSON lines', () => {
+            const filePath = getAgentActivityFilePath('s-bad');
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
+            const valid = JSON.stringify({
+                timestamp: '2026-04-19T10:00:00.000Z',
+                session_id: 's-bad',
+                event: 'start',
+                id: 'tool-1',
+                type: 'explore'
+            });
+            fs.writeFileSync(filePath, `${valid}\n{not-json\n${valid}\n`, 'utf-8');
+
+            expect(getAgentActivityMetrics('s-bad').agents).toHaveLength(1);
+        });
+
+        it('filters out events with different session_id', () => {
+            writeEvents('s-a', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-b',
+                    event: 'start',
+                    id: 'tool-1',
+                    type: 'explore'
+                },
+                {
+                    timestamp: '2026-04-19T10:01:00.000Z',
+                    session_id: 's-a',
+                    event: 'start',
+                    id: 'tool-2',
+                    type: 'code-reviewer'
+                }
+            ]);
+
+            const agents = getAgentActivityMetrics('s-a').agents;
+            expect(agents).toHaveLength(1);
+            expect(agents[0]?.id).toBe('tool-2');
+        });
+    });
+
+    describe('getAgentActivityMetrics — ordering and capacity', () => {
+        it('sorts agents by startTime ascending', () => {
+            writeEvents('s-order', [
+                {
+                    timestamp: '2026-04-19T10:02:00.000Z',
+                    session_id: 's-order',
+                    event: 'start',
+                    id: 'late',
+                    type: 'b'
+                },
+                {
+                    timestamp: '2026-04-19T10:01:00.000Z',
+                    session_id: 's-order',
+                    event: 'start',
+                    id: 'early',
+                    type: 'a'
+                }
+            ]);
+
+            const agents = getAgentActivityMetrics('s-order').agents;
+            expect(agents.map(a => a.id)).toEqual(['early', 'late']);
+        });
+
+        it('breaks ties by id ascending when startTime equal', () => {
+            writeEvents('s-tie', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-tie',
+                    event: 'start',
+                    id: 'z-agent',
+                    type: 'a'
+                },
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-tie',
+                    event: 'start',
+                    id: 'a-agent',
+                    type: 'b'
+                }
+            ]);
+
+            const agents = getAgentActivityMetrics('s-tie').agents;
+            expect(agents.map(a => a.id)).toEqual(['a-agent', 'z-agent']);
+        });
+
+        it('keeps only the most recent 10 agents', () => {
+            const events = [];
+            for (let i = 0; i < 15; i += 1) {
+                events.push({
+                    timestamp: new Date(Date.UTC(2026, 3, 19, 10, i, 0)).toISOString(),
+                    session_id: 's-cap',
+                    event: 'start',
+                    id: `tool-${i}`,
+                    type: `t${i}`
+                });
+            }
+            writeEvents('s-cap', events);
+
+            const agents = getAgentActivityMetrics('s-cap').agents;
+            expect(agents).toHaveLength(10);
+            expect(agents[0]?.id).toBe('tool-5');
+            expect(agents[9]?.id).toBe('tool-14');
+        });
+    });
+});

--- a/src/utils/__tests__/agent-activity.test.ts
+++ b/src/utils/__tests__/agent-activity.test.ts
@@ -272,4 +272,64 @@ describe('agent-activity', () => {
             expect(agents[9]?.id).toBe('tool-14');
         });
     });
+
+    describe('getAgentActivityMetrics — turn boundary purge', () => {
+        it('drops completed agents that ended before the last turn marker', () => {
+            writeEvents('s-turn', [
+                { timestamp: '2026-04-19T10:00:00.000Z', session_id: 's-turn', event: 'start', id: 'old', type: 'explore' },
+                { timestamp: '2026-04-19T10:00:10.000Z', session_id: 's-turn', event: 'end', id: 'old' },
+                { timestamp: '2026-04-19T10:05:00.000Z', session_id: 's-turn', event: 'turn' },
+                { timestamp: '2026-04-19T10:06:00.000Z', session_id: 's-turn', event: 'start', id: 'new', type: 'reviewer' },
+                { timestamp: '2026-04-19T10:06:30.000Z', session_id: 's-turn', event: 'end', id: 'new' }
+            ]);
+
+            const agents = getAgentActivityMetrics('s-turn').agents;
+            expect(agents.map(a => a.id)).toEqual(['new']);
+        });
+
+        it('keeps running agents across turn boundaries', () => {
+            writeEvents('s-running-spans-turn', [
+                { timestamp: '2026-04-19T10:00:00.000Z', session_id: 's-running-spans-turn', event: 'start', id: 'long', type: 'explore' },
+                { timestamp: '2026-04-19T10:05:00.000Z', session_id: 's-running-spans-turn', event: 'turn' }
+            ]);
+
+            const agents = getAgentActivityMetrics('s-running-spans-turn').agents;
+            expect(agents).toHaveLength(1);
+            expect(agents[0]?.status).toBe('running');
+        });
+
+        it('no purge when no turn marker present (legacy files)', () => {
+            writeEvents('s-no-turn', [
+                { timestamp: '2026-04-19T10:00:00.000Z', session_id: 's-no-turn', event: 'start', id: 'a', type: 'explore' },
+                { timestamp: '2026-04-19T10:00:10.000Z', session_id: 's-no-turn', event: 'end', id: 'a' }
+            ]);
+
+            expect(getAgentActivityMetrics('s-no-turn').agents).toHaveLength(1);
+        });
+
+        it('uses the most recent of multiple turn markers', () => {
+            writeEvents('s-multi-turn', [
+                { timestamp: '2026-04-19T10:00:00.000Z', session_id: 's-multi-turn', event: 'start', id: 'mid', type: 'x' },
+                { timestamp: '2026-04-19T10:00:10.000Z', session_id: 's-multi-turn', event: 'end', id: 'mid' },
+                { timestamp: '2026-04-19T10:01:00.000Z', session_id: 's-multi-turn', event: 'turn' },
+                { timestamp: '2026-04-19T10:02:00.000Z', session_id: 's-multi-turn', event: 'start', id: 'between', type: 'y' },
+                { timestamp: '2026-04-19T10:02:10.000Z', session_id: 's-multi-turn', event: 'end', id: 'between' },
+                { timestamp: '2026-04-19T10:03:00.000Z', session_id: 's-multi-turn', event: 'turn' }
+            ]);
+
+            // Both completed agents ended before the latest turn → purged.
+            expect(getAgentActivityMetrics('s-multi-turn').agents).toEqual([]);
+        });
+
+        it('ignores turn markers from other sessions', () => {
+            writeEvents('s-cross', [
+                { timestamp: '2026-04-19T10:00:00.000Z', session_id: 's-cross', event: 'start', id: 'a', type: 'x' },
+                { timestamp: '2026-04-19T10:00:10.000Z', session_id: 's-cross', event: 'end', id: 'a' },
+                { timestamp: '2026-04-19T10:05:00.000Z', session_id: 'other-session', event: 'turn' }
+            ]);
+
+            // Foreign-session turn marker should not purge our agents.
+            expect(getAgentActivityMetrics('s-cross').agents).toHaveLength(1);
+        });
+    });
 });

--- a/src/utils/__tests__/claude-settings.test.ts
+++ b/src/utils/__tests__/claude-settings.test.ts
@@ -183,7 +183,6 @@ describe('buildCommand via installStatusLine', () => {
         expect(hooks.PreToolUse).toEqual([
             {
                 _tag: 'ccstatusline-managed',
-                matcher: 'Skill',
                 hooks: [{ type: 'command', command: `${installedCommand} --hook` }]
             }
         ]);

--- a/src/utils/__tests__/skills.test.ts
+++ b/src/utils/__tests__/skills.test.ts
@@ -53,7 +53,8 @@ describe('skills metrics', () => {
         expect(getSkillsMetrics('session-1')).toEqual({
             totalInvocations: 4,
             uniqueSkills: ['commit', 'lint', 'review-pr'],
-            lastSkill: 'commit'
+            lastSkill: 'commit',
+            recent: ['commit', 'review-pr', 'lint', 'commit']
         });
     });
 });

--- a/src/utils/__tests__/todo-progress.test.ts
+++ b/src/utils/__tests__/todo-progress.test.ts
@@ -186,4 +186,61 @@ describe('todo-progress', () => {
             expect(getTodoProgressMetrics('s-nonarr')).toEqual({ todos: [], timestamp: null });
         });
     });
+
+    describe('getTodoProgressMetrics — turn boundary purge', () => {
+        it('returns empty todos when latest snapshot predates the last turn marker', () => {
+            writeLines('s-stale', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-stale',
+                    todos: [{ content: 'Old task', status: 'in_progress' }]
+                },
+                { timestamp: '2026-04-19T10:05:00.000Z', session_id: 's-stale', event: 'turn' }
+            ]);
+
+            const metrics = getTodoProgressMetrics('s-stale');
+            expect(metrics.todos).toEqual([]);
+            // timestamp is still preserved so callers can tell "had data once"
+            expect(metrics.timestamp).toBe('2026-04-19T10:00:00.000Z');
+        });
+
+        it('keeps snapshot when it is newer than the last turn marker', () => {
+            writeLines('s-fresh', [
+                { timestamp: '2026-04-19T10:00:00.000Z', session_id: 's-fresh', event: 'turn' },
+                {
+                    timestamp: '2026-04-19T10:01:00.000Z',
+                    session_id: 's-fresh',
+                    todos: [{ content: 'Current task', status: 'in_progress' }]
+                }
+            ]);
+
+            const metrics = getTodoProgressMetrics('s-fresh');
+            expect(metrics.todos.map(t => t.content)).toEqual(['Current task']);
+        });
+
+        it('no purge when no turn marker present (legacy files)', () => {
+            writeLines('s-no-turn', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-no-turn',
+                    todos: [{ content: 'Still here', status: 'pending' }]
+                }
+            ]);
+
+            expect(getTodoProgressMetrics('s-no-turn').todos).toHaveLength(1);
+        });
+
+        it('ignores turn markers from other sessions', () => {
+            writeLines('s-own', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-own',
+                    todos: [{ content: 'Mine', status: 'pending' }]
+                },
+                { timestamp: '2026-04-19T10:05:00.000Z', session_id: 'other-session', event: 'turn' }
+            ]);
+
+            expect(getTodoProgressMetrics('s-own').todos).toHaveLength(1);
+        });
+    });
 });

--- a/src/utils/__tests__/todo-progress.test.ts
+++ b/src/utils/__tests__/todo-progress.test.ts
@@ -1,0 +1,189 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import {
+    getTodoProgressFilePath,
+    getTodoProgressMetrics
+} from '../todo-progress';
+
+let testHomeDir = '';
+
+describe('todo-progress', () => {
+    beforeEach(() => {
+        testHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-home-'));
+        vi.spyOn(os, 'homedir').mockReturnValue(testHomeDir);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        if (testHomeDir) {
+            fs.rmSync(testHomeDir, { recursive: true, force: true });
+        }
+    });
+
+    function writeLines(sessionId: string, records: unknown[]): void {
+        const filePath = getTodoProgressFilePath(sessionId);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, records.map(r => JSON.stringify(r)).join('\n'), 'utf-8');
+    }
+
+    describe('getTodoProgressFilePath', () => {
+        it('uses ~/.cache/ccstatusline/todo-progress path', () => {
+            expect(getTodoProgressFilePath('session-1')).toBe(
+                path.join(testHomeDir, '.cache', 'ccstatusline', 'todo-progress', 'todo-progress-session-1.jsonl')
+            );
+        });
+    });
+
+    describe('getTodoProgressMetrics', () => {
+        it('returns empty metrics when file does not exist', () => {
+            expect(getTodoProgressMetrics('missing')).toEqual({ todos: [], timestamp: null });
+        });
+
+        it('returns the single snapshot when one line exists', () => {
+            writeLines('s-one', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-one',
+                    todos: [
+                        { content: 'Fix auth', status: 'in_progress' },
+                        { content: 'Ship', status: 'pending' }
+                    ]
+                }
+            ]);
+
+            const metrics = getTodoProgressMetrics('s-one');
+            expect(metrics.timestamp).toBe('2026-04-19T10:00:00.000Z');
+            expect(metrics.todos).toEqual([
+                { content: 'Fix auth', status: 'in_progress' },
+                { content: 'Ship', status: 'pending' }
+            ]);
+        });
+
+        it('returns the latest snapshot when multiple lines exist', () => {
+            writeLines('s-many', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-many',
+                    todos: [{ content: 'A', status: 'pending' }]
+                },
+                {
+                    timestamp: '2026-04-19T10:05:00.000Z',
+                    session_id: 's-many',
+                    todos: [
+                        { content: 'A', status: 'completed' },
+                        { content: 'B', status: 'in_progress' }
+                    ]
+                }
+            ]);
+
+            const metrics = getTodoProgressMetrics('s-many');
+            expect(metrics.timestamp).toBe('2026-04-19T10:05:00.000Z');
+            expect(metrics.todos).toHaveLength(2);
+            expect(metrics.todos[1]).toEqual({ content: 'B', status: 'in_progress' });
+        });
+
+        it('preserves activeForm when present', () => {
+            writeLines('s-active', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-active',
+                    todos: [
+                        { content: 'Fix auth', activeForm: 'Fixing auth', status: 'in_progress' }
+                    ]
+                }
+            ]);
+
+            expect(getTodoProgressMetrics('s-active').todos[0]).toEqual({
+                content: 'Fix auth',
+                activeForm: 'Fixing auth',
+                status: 'in_progress'
+            });
+        });
+
+        it('skips malformed JSON and returns the latest valid line', () => {
+            const filePath = getTodoProgressFilePath('s-bad');
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
+            const valid = JSON.stringify({
+                timestamp: '2026-04-19T10:00:00.000Z',
+                session_id: 's-bad',
+                todos: [{ content: 'A', status: 'pending' }]
+            });
+            fs.writeFileSync(filePath, `${valid}\nnot-json\n`, 'utf-8');
+
+            const metrics = getTodoProgressMetrics('s-bad');
+            expect(metrics.todos).toHaveLength(1);
+            expect(metrics.todos[0]?.content).toBe('A');
+        });
+
+        it('falls back to an earlier valid snapshot when the last line is malformed', () => {
+            const filePath = getTodoProgressFilePath('s-fallback');
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
+            const valid = JSON.stringify({
+                timestamp: '2026-04-19T09:00:00.000Z',
+                session_id: 's-fallback',
+                todos: [{ content: 'A', status: 'pending' }]
+            });
+            fs.writeFileSync(filePath, `${valid}\n{broken\n`, 'utf-8');
+
+            expect(getTodoProgressMetrics('s-fallback').todos[0]?.content).toBe('A');
+        });
+
+        it('filters out snapshots with a different session_id', () => {
+            writeLines('s-want', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-other',
+                    todos: [{ content: 'Leaked', status: 'in_progress' }]
+                },
+                {
+                    timestamp: '2026-04-19T10:01:00.000Z',
+                    session_id: 's-want',
+                    todos: [{ content: 'Mine', status: 'pending' }]
+                }
+            ]);
+
+            expect(getTodoProgressMetrics('s-want').todos[0]?.content).toBe('Mine');
+        });
+
+        it('drops individual todos that are missing content or status', () => {
+            writeLines('s-drop', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-drop',
+                    todos: [
+                        { content: 'Good', status: 'pending' },
+                        { status: 'pending' },
+                        { content: 'No status' },
+                        { content: 'Weird status', status: 'blocked' },
+                        { content: 'Also good', status: 'completed' }
+                    ]
+                }
+            ]);
+
+            const metrics = getTodoProgressMetrics('s-drop');
+            expect(metrics.todos.map(t => t.content)).toEqual(['Good', 'Also good']);
+        });
+
+        it('returns empty metrics when todos is not an array', () => {
+            writeLines('s-nonarr', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-nonarr',
+                    todos: 'oops'
+                }
+            ]);
+
+            expect(getTodoProgressMetrics('s-nonarr')).toEqual({ todos: [], timestamp: null });
+        });
+    });
+});

--- a/src/utils/__tests__/tool-count.test.ts
+++ b/src/utils/__tests__/tool-count.test.ts
@@ -1,0 +1,250 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import {
+    basename,
+    extractTarget,
+    getToolCountFilePath,
+    getToolCountMetrics
+} from '../tool-count';
+
+let testHomeDir = '';
+
+function writeLines(sessionId: string, records: unknown[]): void {
+    const filePath = getToolCountFilePath(sessionId);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, records.map(r => JSON.stringify(r)).join('\n'), 'utf-8');
+}
+
+describe('tool-count', () => {
+    beforeEach(() => {
+        testHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-home-'));
+        vi.spyOn(os, 'homedir').mockReturnValue(testHomeDir);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        if (testHomeDir) {
+            fs.rmSync(testHomeDir, { recursive: true, force: true });
+        }
+    });
+
+    describe('getToolCountMetrics — legacy schema (no event field)', () => {
+        it('returns empty metrics when no file exists', () => {
+            expect(getToolCountMetrics('missing')).toEqual({
+                totalInvocations: 0,
+                byCategory: { builtin: 0, mcp: 0 },
+                byTool: {},
+                lastTool: null,
+                activity: []
+            });
+        });
+
+        it('counts invocations and tracks lastTool for legacy rows', () => {
+            writeLines('s-legacy', [
+                { timestamp: 't1', session_id: 's-legacy', tool_name: 'Read', category: 'builtin' },
+                { timestamp: 't2', session_id: 's-legacy', tool_name: 'Edit', category: 'builtin' },
+                { timestamp: 't3', session_id: 's-legacy', tool_name: 'mcp__foo__bar', category: 'mcp' }
+            ]);
+
+            const metrics = getToolCountMetrics('s-legacy');
+            expect(metrics.totalInvocations).toBe(3);
+            expect(metrics.byCategory).toEqual({ builtin: 2, mcp: 1 });
+            expect(metrics.byTool).toEqual({ Read: 1, Edit: 1, mcp__foo__bar: 1 });
+            expect(metrics.lastTool).toBe('mcp__foo__bar');
+            expect(metrics.activity).toEqual([]);
+        });
+
+        it('filters rows from a different session_id', () => {
+            writeLines('s-a', [
+                { timestamp: 't1', session_id: 's-b', tool_name: 'Read', category: 'builtin' },
+                { timestamp: 't2', session_id: 's-a', tool_name: 'Edit', category: 'builtin' }
+            ]);
+
+            const metrics = getToolCountMetrics('s-a');
+            expect(metrics.totalInvocations).toBe(1);
+            expect(metrics.lastTool).toBe('Edit');
+        });
+    });
+
+    describe('getToolCountMetrics — activity pairing', () => {
+        it('keeps status running when only a start event exists', () => {
+            writeLines('s-run', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-run',
+                    tool_name: 'Edit',
+                    category: 'builtin',
+                    event: 'start',
+                    tool_use_id: 'u1',
+                    target: '/repo/src/auth.ts'
+                }
+            ]);
+
+            const metrics = getToolCountMetrics('s-run');
+            expect(metrics.totalInvocations).toBe(1);
+            expect(metrics.activity).toHaveLength(1);
+            expect(metrics.activity[0]).toMatchObject({
+                id: 'u1',
+                tool_name: 'Edit',
+                status: 'running',
+                target: '/repo/src/auth.ts'
+            });
+            expect(metrics.activity[0]?.startTime.toISOString()).toBe('2026-04-19T10:00:00.000Z');
+        });
+
+        it('marks paired start/end rows as completed', () => {
+            writeLines('s-pair', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-pair',
+                    tool_name: 'Read',
+                    category: 'builtin',
+                    event: 'start',
+                    tool_use_id: 'u1'
+                },
+                {
+                    timestamp: '2026-04-19T10:00:05.000Z',
+                    session_id: 's-pair',
+                    tool_name: 'Read',
+                    category: 'builtin',
+                    event: 'end',
+                    tool_use_id: 'u1'
+                }
+            ]);
+
+            const metrics = getToolCountMetrics('s-pair');
+            expect(metrics.totalInvocations).toBe(1);  // end event does not recount
+            expect(metrics.activity).toHaveLength(1);
+            expect(metrics.activity[0]?.status).toBe('completed');
+            expect(metrics.activity[0]?.endTime?.toISOString()).toBe('2026-04-19T10:00:05.000Z');
+        });
+
+        it('ignores orphan end events and skips rows without tool_use_id', () => {
+            writeLines('s-sparse', [
+                {
+                    timestamp: 't1',
+                    session_id: 's-sparse',
+                    tool_name: 'Bash',
+                    category: 'builtin'
+                },
+                {
+                    timestamp: 't2',
+                    session_id: 's-sparse',
+                    tool_name: 'Read',
+                    category: 'builtin',
+                    event: 'end',
+                    tool_use_id: 'orphan'
+                }
+            ]);
+
+            const metrics = getToolCountMetrics('s-sparse');
+            expect(metrics.totalInvocations).toBe(1);  // Bash row counts; orphan end does not
+            expect(metrics.activity).toEqual([]);
+        });
+
+        it('includes Agent tool in activity (render layer filters it)', () => {
+            writeLines('s-agent', [
+                {
+                    timestamp: '2026-04-19T10:00:00.000Z',
+                    session_id: 's-agent',
+                    tool_name: 'Agent',
+                    category: 'builtin',
+                    event: 'start',
+                    tool_use_id: 'u1',
+                    target: 'explore'
+                }
+            ]);
+
+            const metrics = getToolCountMetrics('s-agent');
+            expect(metrics.activity).toHaveLength(1);
+            expect(metrics.activity[0]?.tool_name).toBe('Agent');
+        });
+
+        it('sorts activity by startTime ascending and caps at 20', () => {
+            const records: unknown[] = [];
+            for (let i = 0; i < 25; i += 1) {
+                records.push({
+                    timestamp: new Date(Date.UTC(2026, 3, 19, 10, i, 0)).toISOString(),
+                    session_id: 's-cap',
+                    tool_name: 'Read',
+                    category: 'builtin',
+                    event: 'start',
+                    tool_use_id: `u${i}`
+                });
+            }
+            writeLines('s-cap', records);
+
+            const metrics = getToolCountMetrics('s-cap');
+            expect(metrics.activity).toHaveLength(20);
+            expect(metrics.activity[0]?.id).toBe('u5');
+            expect(metrics.activity[19]?.id).toBe('u24');
+        });
+
+        it('skips malformed JSON lines', () => {
+            const filePath = getToolCountFilePath('s-bad');
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
+            const valid = JSON.stringify({ timestamp: 't1', session_id: 's-bad', tool_name: 'Edit', category: 'builtin' });
+            fs.writeFileSync(filePath, `${valid}\nnot-json\n`, 'utf-8');
+
+            expect(getToolCountMetrics('s-bad').totalInvocations).toBe(1);
+        });
+    });
+
+    describe('extractTarget', () => {
+        it('extracts file_path for editor tools', () => {
+            expect(extractTarget('Edit', { file_path: '/a.ts' })).toBe('/a.ts');
+            expect(extractTarget('Write', { file_path: '/a.ts' })).toBe('/a.ts');
+            expect(extractTarget('Read', { file_path: '/a.ts' })).toBe('/a.ts');
+        });
+
+        it('extracts path then pattern for Grep/Glob', () => {
+            expect(extractTarget('Grep', { path: '/src', pattern: 'foo' })).toBe('/src');
+            expect(extractTarget('Grep', { pattern: 'foo' })).toBe('foo');
+        });
+
+        it('extracts url for WebFetch', () => {
+            expect(extractTarget('WebFetch', { url: 'https://example.com' })).toBe('https://example.com');
+        });
+
+        it('returns undefined for Bash (no stable target)', () => {
+            expect(extractTarget('Bash', { command: 'ls -la' })).toBeUndefined();
+        });
+
+        it('returns undefined for unknown tools', () => {
+            expect(extractTarget('mcp__foo__bar', { some: 'thing' })).toBeUndefined();
+        });
+
+        it('is defensive against non-object input', () => {
+            expect(extractTarget('Edit', null)).toBeUndefined();
+            expect(extractTarget('Edit', 'string')).toBeUndefined();
+        });
+    });
+
+    describe('basename', () => {
+        it('returns last path segment for unix paths', () => {
+            expect(basename('/repo/src/auth.ts')).toBe('auth.ts');
+        });
+
+        it('normalizes windows backslashes', () => {
+            expect(basename('C:\\repo\\src\\auth.ts')).toBe('auth.ts');
+        });
+
+        it('returns url host for http(s) urls', () => {
+            expect(basename('https://example.com/path?x=1')).toBe('example.com');
+        });
+
+        it('falls back to the original string for bare names', () => {
+            expect(basename('README.md')).toBe('README.md');
+        });
+    });
+});

--- a/src/utils/agent-activity.ts
+++ b/src/utils/agent-activity.ts
@@ -1,0 +1,108 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type {
+    AgentActivityEvent,
+    AgentActivityMetrics,
+    AgentEntry
+} from '../types/AgentActivityMetrics';
+
+function getAgentActivityDir(): string {
+    return path.join(os.homedir(), '.cache', 'ccstatusline', 'agent-activity');
+}
+
+export function getAgentActivityFilePath(sessionId: string): string {
+    return path.join(getAgentActivityDir(), `agent-activity-${sessionId}.jsonl`);
+}
+
+function parseEvent(line: string, sessionId: string): AgentActivityEvent | null {
+    try {
+        const parsed: unknown = JSON.parse(line);
+        if (typeof parsed !== 'object' || parsed === null) {
+            return null;
+        }
+        const record = parsed as Record<string, unknown>;
+        if (record.event !== 'start' && record.event !== 'end') {
+            return null;
+        }
+        if (typeof record.id !== 'string' || record.id.length === 0) {
+            return null;
+        }
+        if (typeof record.timestamp !== 'string') {
+            return null;
+        }
+        if (typeof record.session_id !== 'string' || record.session_id !== sessionId) {
+            return null;
+        }
+        return {
+            event: record.event,
+            id: record.id,
+            timestamp: record.timestamp,
+            session_id: record.session_id,
+            type: typeof record.type === 'string' ? record.type : undefined,
+            model: typeof record.model === 'string' ? record.model : undefined,
+            description: typeof record.description === 'string' ? record.description : undefined
+        };
+    } catch {
+        return null;
+    }
+}
+
+function buildAgentEntry(event: AgentActivityEvent): AgentEntry {
+    return {
+        id: event.id,
+        type: typeof event.type === 'string' && event.type.length > 0 ? event.type : 'unknown',
+        model: typeof event.model === 'string' ? event.model : undefined,
+        description: typeof event.description === 'string' ? event.description : undefined,
+        status: 'running',
+        startTime: new Date(event.timestamp)
+    };
+}
+
+export function getAgentActivityMetrics(sessionId: string): AgentActivityMetrics {
+    const filePath = getAgentActivityFilePath(sessionId);
+    if (!fs.existsSync(filePath)) {
+        return { agents: [] };
+    }
+
+    try {
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const lines = content.split('\n').filter(line => line.trim().length > 0);
+
+        const agentMap = new Map<string, AgentEntry>();
+
+        for (const line of lines) {
+            const event = parseEvent(line, sessionId);
+            if (!event) {
+                continue;
+            }
+
+            if (event.event === 'start') {
+                if (!agentMap.has(event.id)) {
+                    agentMap.set(event.id, buildAgentEntry(event));
+                }
+            } else {
+                const existing = agentMap.get(event.id);
+                if (existing) {
+                    existing.status = 'completed';
+                    existing.endTime = new Date(event.timestamp);
+                }
+            }
+        }
+
+        const agents = Array.from(agentMap.values())
+            .sort((a, b) => {
+                const delta = a.startTime.getTime() - b.startTime.getTime();
+                if (delta !== 0) {
+                    return delta;
+                }
+                return a.id.localeCompare(b.id);
+            })
+            .slice(-10);
+
+        return { agents };
+    } catch {
+        return { agents: [] };
+    }
+}

--- a/src/utils/agent-activity.ts
+++ b/src/utils/agent-activity.ts
@@ -49,6 +49,25 @@ function parseEvent(line: string, sessionId: string): AgentActivityEvent | null 
     }
 }
 
+function extractTurnTimestamp(line: string, sessionId: string): string | null {
+    try {
+        const parsed: unknown = JSON.parse(line);
+        if (typeof parsed !== 'object' || parsed === null) {
+            return null;
+        }
+        const record = parsed as Record<string, unknown>;
+        if (record.event !== 'turn')
+            return null;
+        if (record.session_id !== sessionId)
+            return null;
+        if (typeof record.timestamp !== 'string')
+            return null;
+        return record.timestamp;
+    } catch {
+        return null;
+    }
+}
+
 function buildAgentEntry(event: AgentActivityEvent): AgentEntry {
     return {
         id: event.id,
@@ -71,8 +90,17 @@ export function getAgentActivityMetrics(sessionId: string): AgentActivityMetrics
         const lines = content.split('\n').filter(line => line.trim().length > 0);
 
         const agentMap = new Map<string, AgentEntry>();
+        let lastTurnMs = 0;
 
         for (const line of lines) {
+            const turnTs = extractTurnTimestamp(line, sessionId);
+            if (turnTs !== null) {
+                const ms = new Date(turnTs).getTime();
+                if (!Number.isNaN(ms) && ms > lastTurnMs) {
+                    lastTurnMs = ms;
+                }
+                continue;
+            }
             const event = parseEvent(line, sessionId);
             if (!event) {
                 continue;
@@ -91,7 +119,18 @@ export function getAgentActivityMetrics(sessionId: string): AgentActivityMetrics
             }
         }
 
+        // Turn-boundary purge: drop completed agents that finished before the
+        // last UserPromptSubmit turn marker. Running agents are always kept —
+        // they span turns by definition.
         const agents = Array.from(agentMap.values())
+            .filter((a) => {
+                if (a.status === 'running')
+                    return true;
+                if (lastTurnMs === 0)
+                    return true;
+                const endMs = a.endTime?.getTime() ?? a.startTime.getTime();
+                return endMs >= lastTurnMs;
+            })
             .sort((a, b) => {
                 const delta = a.startTime.getTime() - b.startTime.getTime();
                 if (delta !== 0) {

--- a/src/utils/skills.ts
+++ b/src/utils/skills.ts
@@ -7,7 +7,8 @@ import type {
     SkillsMetrics
 } from '../types/SkillsMetrics';
 
-const EMPTY: SkillsMetrics = { totalInvocations: 0, uniqueSkills: [], lastSkill: null };
+const RECENT_CAP = 20;
+const EMPTY: SkillsMetrics = { totalInvocations: 0, uniqueSkills: [], lastSkill: null, recent: [] };
 
 function getSkillsDir(): string {
     return path.join(os.homedir(), '.cache', 'ccstatusline', 'skills');
@@ -47,10 +48,15 @@ export function getSkillsMetrics(sessionId: string): SkillsMetrics {
             }
         }
 
+        const recent = invocations
+            .slice(-RECENT_CAP)
+            .map(inv => inv.skill);
+
         return {
             totalInvocations: invocations.length,
             uniqueSkills,
-            lastSkill: invocations[invocations.length - 1]?.skill ?? null
+            lastSkill: invocations[invocations.length - 1]?.skill ?? null,
+            recent
         };
     } catch {
         return EMPTY;

--- a/src/utils/todo-progress.ts
+++ b/src/utils/todo-progress.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type {
+    TodoItem,
+    TodoProgressMetrics,
+    TodoStatus
+} from '../types/TodoProgressMetrics';
+
+function getTodoProgressDir(): string {
+    return path.join(os.homedir(), '.cache', 'ccstatusline', 'todo-progress');
+}
+
+export function getTodoProgressFilePath(sessionId: string): string {
+    return path.join(getTodoProgressDir(), `todo-progress-${sessionId}.jsonl`);
+}
+
+function isTodoStatus(value: unknown): value is TodoStatus {
+    return value === 'pending' || value === 'in_progress' || value === 'completed';
+}
+
+function normalizeTodo(entry: unknown): TodoItem | null {
+    if (typeof entry !== 'object' || entry === null) {
+        return null;
+    }
+    const record = entry as Record<string, unknown>;
+    if (typeof record.content !== 'string') {
+        return null;
+    }
+    if (!isTodoStatus(record.status)) {
+        return null;
+    }
+    const item: TodoItem = {
+        content: record.content,
+        status: record.status
+    };
+    if (typeof record.activeForm === 'string') {
+        item.activeForm = record.activeForm;
+    }
+    return item;
+}
+
+function parseSnapshot(line: string, sessionId: string): TodoProgressMetrics | null {
+    try {
+        const parsed: unknown = JSON.parse(line);
+        if (typeof parsed !== 'object' || parsed === null) {
+            return null;
+        }
+        const record = parsed as Record<string, unknown>;
+        if (typeof record.timestamp !== 'string') {
+            return null;
+        }
+        if (record.session_id !== sessionId) {
+            return null;
+        }
+        if (!Array.isArray(record.todos)) {
+            return null;
+        }
+        const todos: TodoItem[] = [];
+        for (const raw of record.todos) {
+            const normalized = normalizeTodo(raw);
+            if (normalized !== null) {
+                todos.push(normalized);
+            }
+        }
+        return { todos, timestamp: record.timestamp };
+    } catch {
+        return null;
+    }
+}
+
+export function getTodoProgressMetrics(sessionId: string): TodoProgressMetrics {
+    const filePath = getTodoProgressFilePath(sessionId);
+    if (!fs.existsSync(filePath)) {
+        return { todos: [], timestamp: null };
+    }
+
+    try {
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const lines = content.split('\n').filter(line => line.trim().length > 0);
+
+        for (let i = lines.length - 1; i >= 0; i -= 1) {
+            const line = lines[i];
+            if (line === undefined) {
+                continue;
+            }
+            const snapshot = parseSnapshot(line, sessionId);
+            if (snapshot !== null) {
+                return snapshot;
+            }
+        }
+        return { todos: [], timestamp: null };
+    } catch {
+        return { todos: [], timestamp: null };
+    }
+}

--- a/src/utils/todo-progress.ts
+++ b/src/utils/todo-progress.ts
@@ -41,6 +41,24 @@ function normalizeTodo(entry: unknown): TodoItem | null {
     return item;
 }
 
+function extractTurnTimestamp(line: string, sessionId: string): string | null {
+    try {
+        const parsed: unknown = JSON.parse(line);
+        if (typeof parsed !== 'object' || parsed === null)
+            return null;
+        const record = parsed as Record<string, unknown>;
+        if (record.event !== 'turn')
+            return null;
+        if (record.session_id !== sessionId)
+            return null;
+        if (typeof record.timestamp !== 'string')
+            return null;
+        return record.timestamp;
+    } catch {
+        return null;
+    }
+}
+
 function parseSnapshot(line: string, sessionId: string): TodoProgressMetrics | null {
     try {
         const parsed: unknown = JSON.parse(line);
@@ -80,17 +98,39 @@ export function getTodoProgressMetrics(sessionId: string): TodoProgressMetrics {
         const content = fs.readFileSync(filePath, 'utf-8');
         const lines = content.split('\n').filter(line => line.trim().length > 0);
 
-        for (let i = lines.length - 1; i >= 0; i -= 1) {
-            const line = lines[i];
-            if (line === undefined) {
+        let lastTurnMs = 0;
+        let lastSnapshot: TodoProgressMetrics | null = null;
+
+        for (const line of lines) {
+            const turnTs = extractTurnTimestamp(line, sessionId);
+            if (turnTs !== null) {
+                const ms = new Date(turnTs).getTime();
+                if (!Number.isNaN(ms) && ms > lastTurnMs) {
+                    lastTurnMs = ms;
+                }
                 continue;
             }
             const snapshot = parseSnapshot(line, sessionId);
             if (snapshot !== null) {
-                return snapshot;
+                lastSnapshot = snapshot;
             }
         }
-        return { todos: [], timestamp: null };
+
+        if (lastSnapshot === null) {
+            return { todos: [], timestamp: null };
+        }
+
+        // Turn-boundary purge: if the last snapshot predates the most recent
+        // UserPromptSubmit turn marker, treat it as empty — the user has moved
+        // on to a new conversation turn and the old todos are stale.
+        if (lastTurnMs > 0 && lastSnapshot.timestamp !== null) {
+            const snapshotMs = new Date(lastSnapshot.timestamp).getTime();
+            if (!Number.isNaN(snapshotMs) && snapshotMs < lastTurnMs) {
+                return { todos: [], timestamp: lastSnapshot.timestamp };
+            }
+        }
+
+        return lastSnapshot;
     } catch {
         return { todos: [], timestamp: null };
     }

--- a/src/utils/tool-count.ts
+++ b/src/utils/tool-count.ts
@@ -1,0 +1,75 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type {
+    ToolCategory,
+    ToolCountMetrics,
+    ToolInvocation
+} from '../types/ToolCountMetrics';
+
+const EMPTY: ToolCountMetrics = {
+    totalInvocations: 0,
+    byCategory: { builtin: 0, mcp: 0 },
+    byTool: {},
+    lastTool: null
+};
+
+function getToolCountDir(): string {
+    return path.join(os.homedir(), '.cache', 'ccstatusline', 'tool-count');
+}
+
+export function getToolCountFilePath(sessionId: string): string {
+    return path.join(getToolCountDir(), `tool-count-${sessionId}.jsonl`);
+}
+
+export function classifyTool(toolName: string): ToolCategory {
+    if (toolName.startsWith('mcp__')) {
+        return 'mcp';
+    }
+    return 'builtin';
+}
+
+export function getToolCountMetrics(sessionId: string): ToolCountMetrics {
+    const filePath = getToolCountFilePath(sessionId);
+    if (!fs.existsSync(filePath)) {
+        return EMPTY;
+    }
+
+    try {
+        const invocations: ToolInvocation[] = fs.readFileSync(filePath, 'utf-8')
+            .trim().split('\n')
+            .filter(line => line.trim())
+            .map((line) => {
+                try { return JSON.parse(line) as ToolInvocation; } catch {
+                    return null;
+                }
+            })
+            .filter((e): e is ToolInvocation => e !== null
+                && typeof e.tool_name === 'string'
+                && typeof e.session_id === 'string'
+                && e.session_id === sessionId);
+        if (invocations.length === 0) {
+            return EMPTY;
+        }
+
+        const byCategory: Record<ToolCategory, number> = { builtin: 0, mcp: 0 };
+        const byTool: Record<string, number> = {};
+        for (const inv of invocations) {
+            const cat: ToolCategory = inv.category === 'mcp'
+                ? 'mcp'
+                : classifyTool(inv.tool_name);
+            byCategory[cat] += 1;
+            byTool[inv.tool_name] = (byTool[inv.tool_name] ?? 0) + 1;
+        }
+
+        return {
+            totalInvocations: invocations.length,
+            byCategory,
+            byTool,
+            lastTool: invocations[invocations.length - 1]?.tool_name ?? null
+        };
+    } catch {
+        return EMPTY;
+    }
+}

--- a/src/utils/tool-count.ts
+++ b/src/utils/tool-count.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 import type {
+    ToolActivityEntry,
     ToolCategory,
     ToolCountMetrics,
     ToolInvocation
@@ -12,8 +13,12 @@ const EMPTY: ToolCountMetrics = {
     totalInvocations: 0,
     byCategory: { builtin: 0, mcp: 0 },
     byTool: {},
-    lastTool: null
+    lastTool: null,
+    activity: []
 };
+
+const ACTIVITY_CAP = 20;
+const TARGET_MAX_LEN = 60;
 
 function getToolCountDir(): string {
     return path.join(os.homedir(), '.cache', 'ccstatusline', 'tool-count');
@@ -30,46 +35,151 @@ export function classifyTool(toolName: string): ToolCategory {
     return 'builtin';
 }
 
+function trimTarget(value: string): string | undefined {
+    const trimmed = value.trim();
+    if (trimmed.length === 0)
+        return undefined;
+    return trimmed.length > TARGET_MAX_LEN ? `${trimmed.slice(0, TARGET_MAX_LEN - 1)}…` : trimmed;
+}
+
+export function extractTarget(toolName: string, toolInput: unknown): string | undefined {
+    if (typeof toolInput !== 'object' || toolInput === null)
+        return undefined;
+    const input = toolInput as Record<string, unknown>;
+
+    if (toolName === 'Edit' || toolName === 'Write' || toolName === 'Read'
+        || toolName === 'MultiEdit' || toolName === 'NotebookEdit') {
+        if (typeof input.file_path === 'string')
+            return trimTarget(input.file_path);
+    }
+    if (toolName === 'Grep' || toolName === 'Glob') {
+        if (typeof input.path === 'string')
+            return trimTarget(input.path);
+        if (typeof input.pattern === 'string')
+            return trimTarget(input.pattern);
+    }
+    if (toolName === 'WebFetch' || toolName === 'WebSearch') {
+        if (typeof input.url === 'string')
+            return trimTarget(input.url);
+    }
+    return undefined;
+}
+
+export function basename(target: string): string {
+    if (target.includes('://')) {
+        try {
+            return new URL(target).host || target;
+        } catch {
+            // fall through
+        }
+    }
+    const normalized = target.replace(/\\/g, '/');
+    const parts = normalized.split('/');
+    const last = parts[parts.length - 1];
+    return last !== undefined && last.length > 0 ? last : target;
+}
+
+function parseInvocation(line: string, sessionId: string): ToolInvocation | null {
+    try {
+        const parsed: unknown = JSON.parse(line);
+        if (typeof parsed !== 'object' || parsed === null)
+            return null;
+        const record = parsed as Record<string, unknown>;
+        if (typeof record.tool_name !== 'string')
+            return null;
+        if (typeof record.session_id !== 'string' || record.session_id !== sessionId)
+            return null;
+        const category: ToolCategory = record.category === 'mcp'
+            ? 'mcp'
+            : classifyTool(record.tool_name);
+        const inv: ToolInvocation = {
+            timestamp: typeof record.timestamp === 'string' ? record.timestamp : new Date().toISOString(),
+            session_id: record.session_id,
+            tool_name: record.tool_name,
+            category
+        };
+        if (record.event === 'start' || record.event === 'end') {
+            inv.event = record.event;
+        }
+        if (typeof record.tool_use_id === 'string' && record.tool_use_id.length > 0) {
+            inv.tool_use_id = record.tool_use_id;
+        }
+        if (typeof record.target === 'string' && record.target.length > 0) {
+            inv.target = record.target;
+        }
+        return inv;
+    } catch {
+        return null;
+    }
+}
+
 export function getToolCountMetrics(sessionId: string): ToolCountMetrics {
     const filePath = getToolCountFilePath(sessionId);
     if (!fs.existsSync(filePath)) {
-        return EMPTY;
+        return { ...EMPTY, byCategory: { builtin: 0, mcp: 0 }, byTool: {}, activity: [] };
     }
 
     try {
-        const invocations: ToolInvocation[] = fs.readFileSync(filePath, 'utf-8')
-            .trim().split('\n')
-            .filter(line => line.trim())
-            .map((line) => {
-                try { return JSON.parse(line) as ToolInvocation; } catch {
-                    return null;
-                }
-            })
-            .filter((e): e is ToolInvocation => e !== null
-                && typeof e.tool_name === 'string'
-                && typeof e.session_id === 'string'
-                && e.session_id === sessionId);
-        if (invocations.length === 0) {
-            return EMPTY;
-        }
+        const lines = fs.readFileSync(filePath, 'utf-8')
+            .split('\n')
+            .filter(line => line.trim().length > 0);
 
         const byCategory: Record<ToolCategory, number> = { builtin: 0, mcp: 0 };
         const byTool: Record<string, number> = {};
-        for (const inv of invocations) {
-            const cat: ToolCategory = inv.category === 'mcp'
-                ? 'mcp'
-                : classifyTool(inv.tool_name);
-            byCategory[cat] += 1;
-            byTool[inv.tool_name] = (byTool[inv.tool_name] ?? 0) + 1;
+        const activityMap = new Map<string, ToolActivityEntry>();
+        let lastTool: string | null = null;
+        let totalInvocations = 0;
+
+        for (const line of lines) {
+            const inv = parseInvocation(line, sessionId);
+            if (!inv)
+                continue;
+
+            if (inv.event !== 'end') {
+                byCategory[inv.category] += 1;
+                byTool[inv.tool_name] = (byTool[inv.tool_name] ?? 0) + 1;
+                lastTool = inv.tool_name;
+                totalInvocations += 1;
+            }
+
+            if (!inv.tool_use_id)
+                continue;
+
+            if (inv.event === 'end') {
+                const existing = activityMap.get(inv.tool_use_id);
+                if (existing) {
+                    existing.status = 'completed';
+                    existing.endTime = new Date(inv.timestamp);
+                }
+            } else if (!activityMap.has(inv.tool_use_id)) {
+                activityMap.set(inv.tool_use_id, {
+                    id: inv.tool_use_id,
+                    tool_name: inv.tool_name,
+                    category: inv.category,
+                    status: 'running',
+                    target: inv.target,
+                    startTime: new Date(inv.timestamp)
+                });
+            }
         }
 
+        const activity = Array.from(activityMap.values())
+            .sort((a, b) => {
+                const delta = a.startTime.getTime() - b.startTime.getTime();
+                if (delta !== 0)
+                    return delta;
+                return a.id.localeCompare(b.id);
+            })
+            .slice(-ACTIVITY_CAP);
+
         return {
-            totalInvocations: invocations.length,
+            totalInvocations,
             byCategory,
             byTool,
-            lastTool: invocations[invocations.length - 1]?.tool_name ?? null
+            lastTool,
+            activity
         };
     } catch {
-        return EMPTY;
+        return { ...EMPTY, byCategory: { builtin: 0, mcp: 0 }, byTool: {}, activity: [] };
     }
 }

--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -72,6 +72,7 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'skills', create: () => new widgets.SkillsWidget() },
     { type: 'tool-count', create: () => new widgets.ToolCountWidget() },
     { type: 'agent-activity', create: () => new widgets.AgentActivityWidget() },
+    { type: 'todo-progress', create: () => new widgets.TodoProgressWidget() },
     { type: 'thinking-effort', create: () => new widgets.ThinkingEffortWidget() },
     { type: 'vim-mode', create: () => new widgets.VimModeWidget() },
     { type: 'worktree-mode', create: () => new widgets.GitWorktreeModeWidget() },

--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -70,6 +70,7 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'weekly-reset-timer', create: () => new widgets.WeeklyResetTimerWidget() },
     { type: 'context-bar', create: () => new widgets.ContextBarWidget() },
     { type: 'skills', create: () => new widgets.SkillsWidget() },
+    { type: 'tool-count', create: () => new widgets.ToolCountWidget() },
     { type: 'thinking-effort', create: () => new widgets.ThinkingEffortWidget() },
     { type: 'vim-mode', create: () => new widgets.VimModeWidget() },
     { type: 'worktree-mode', create: () => new widgets.GitWorktreeModeWidget() },

--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -71,6 +71,7 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'context-bar', create: () => new widgets.ContextBarWidget() },
     { type: 'skills', create: () => new widgets.SkillsWidget() },
     { type: 'tool-count', create: () => new widgets.ToolCountWidget() },
+    { type: 'agent-activity', create: () => new widgets.AgentActivityWidget() },
     { type: 'thinking-effort', create: () => new widgets.ThinkingEffortWidget() },
     { type: 'vim-mode', create: () => new widgets.VimModeWidget() },
     { type: 'worktree-mode', create: () => new widgets.GitWorktreeModeWidget() },

--- a/src/widgets/AgentActivity.tsx
+++ b/src/widgets/AgentActivity.tsx
@@ -176,11 +176,14 @@ export class AgentActivityWidget implements Widget {
         };
     }
 
+    // ItemsEditor reserves a/i/d/c/r/m/space for built-in actions
+    // (add/insert/delete/clear/rawValue/merge/separator-cycle). Use
+    // second-letter keys with parenthesized highlights to avoid collision.
     getCustomKeybinds(item?: WidgetItem): CustomKeybind[] {
         const keybinds: CustomKeybind[] = [
             { key: 'v', label: '(v)iew: current/count/list/activity', action: CYCLE_MODE_ACTION },
-            { key: 'm', label: '(m)odel', action: TOGGLE_HIDE_MODEL_ACTION },
-            { key: 'd', label: '(d)escription', action: TOGGLE_HIDE_DESCRIPTION_ACTION },
+            { key: 'o', label: 'm(o)del', action: TOGGLE_HIDE_MODEL_ACTION },
+            { key: 't', label: '(t)ext', action: TOGGLE_HIDE_DESCRIPTION_ACTION },
             { key: 'e', label: '(e)lapsed', action: TOGGLE_HIDE_ELAPSED_ACTION },
             { key: 'h', label: '(h)ide when empty', action: TOGGLE_HIDE_EMPTY_ACTION }
         ];
@@ -191,7 +194,7 @@ export class AgentActivityWidget implements Widget {
                 keybinds.push({ key: 'l', label: '(l)imit', action: EDIT_LIMIT_ACTION });
             }
             if (mode === 'activity') {
-                keybinds.push({ key: 'r', label: '(r)unning only', action: TOGGLE_HIDE_COMPLETED_ACTION });
+                keybinds.push({ key: 'u', label: 'r(u)nning only', action: TOGGLE_HIDE_COMPLETED_ACTION });
             }
         }
 

--- a/src/widgets/AgentActivity.tsx
+++ b/src/widgets/AgentActivity.tsx
@@ -1,0 +1,341 @@
+import {
+    Box,
+    Text,
+    useInput
+} from 'ink';
+import React, { useState } from 'react';
+
+import type { AgentEntry } from '../types/AgentActivityMetrics';
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    CustomKeybind,
+    Widget,
+    WidgetEditorDisplay,
+    WidgetEditorProps,
+    WidgetItem
+} from '../types/Widget';
+import type { WidgetHookDef } from '../utils/hooks';
+import { shouldInsertInput } from '../utils/input-guards';
+
+import { makeModifierText } from './shared/editor-display';
+import {
+    isMetadataFlagEnabled,
+    toggleMetadataFlag
+} from './shared/metadata';
+
+type Mode = 'mixed' | 'active' | 'last';
+const MODES: Mode[] = ['mixed', 'active', 'last'];
+
+const LIMIT_DEFAULT = 3;
+
+const HIDE_MODEL_KEY = 'hideModel';
+const HIDE_DESCRIPTION_KEY = 'hideDescription';
+const HIDE_ELAPSED_KEY = 'hideElapsed';
+const HIDE_WHEN_EMPTY_KEY = 'hideWhenEmpty';
+const LIMIT_KEY = 'limit';
+
+const CYCLE_MODE_ACTION = 'cycle-mode';
+const TOGGLE_HIDE_MODEL_ACTION = 'toggle-hide-model';
+const TOGGLE_HIDE_DESCRIPTION_ACTION = 'toggle-hide-description';
+const TOGGLE_HIDE_ELAPSED_ACTION = 'toggle-hide-elapsed';
+const TOGGLE_HIDE_EMPTY_ACTION = 'toggle-hide-empty';
+const EDIT_LIMIT_ACTION = 'edit-limit';
+
+export function formatElapsed(startTime: Date, endTime: Date | undefined, now: Date = new Date()): string {
+    const endMs = (endTime ?? now).getTime();
+    const ms = Math.max(0, endMs - startTime.getTime());
+
+    if (ms < 1000)
+        return '<1s';
+    if (ms < 60_000)
+        return `${Math.round(ms / 1000)}s`;
+
+    const totalSecs = Math.floor(ms / 1000);
+    const totalMins = Math.floor(totalSecs / 60);
+
+    if (totalMins < 60) {
+        const secs = totalSecs % 60;
+        return `${totalMins}m ${secs}s`;
+    }
+
+    const hours = Math.floor(totalMins / 60);
+    const mins = totalMins % 60;
+    return `${hours}h ${mins}m`;
+}
+
+function truncate(text: string, maxLen: number): string {
+    if (text.length <= maxLen)
+        return text;
+    return `${text.slice(0, maxLen - 3)}...`;
+}
+
+export interface AgentDisplayFlags {
+    hideModel: boolean;
+    hideDescription: boolean;
+    hideElapsed: boolean;
+}
+
+export function formatAgent(
+    agent: AgentEntry,
+    flags: AgentDisplayFlags,
+    rawValue: boolean,
+    now: Date = new Date()
+): string {
+    const icon = agent.status === 'running' ? '◐' : '✓';
+    const type = agent.type;
+    const model = !flags.hideModel && agent.model
+        ? ` [${agent.model}]`
+        : '';
+    const desc = !flags.hideDescription && agent.description
+        ? `: ${truncate(agent.description, 40)}`
+        : '';
+    const elapsed = !flags.hideElapsed
+        ? ` (${formatElapsed(agent.startTime, agent.endTime, now)})`
+        : '';
+    const body = `${type}${model}${desc}${elapsed}`;
+    return rawValue ? body : `${icon} ${body}`;
+}
+
+export function filterByMode(agents: AgentEntry[], mode: Mode): AgentEntry[] {
+    if (mode === 'active') {
+        return agents.filter(a => a.status === 'running');
+    }
+    if (mode === 'last') {
+        const last = agents[agents.length - 1];
+        return last === undefined ? [] : [last];
+    }
+    return agents;
+}
+
+export function applyLimit(agents: AgentEntry[], limit: number): AgentEntry[] {
+    if (limit === 0)
+        return agents;
+    return agents.slice(-limit);
+}
+
+export class AgentActivityWidget implements Widget {
+    getDefaultColor(): string { return 'magenta'; }
+    getDescription(): string {
+        return 'Shows Task subagents: running + recent completed, with model and elapsed time';
+    }
+
+    getDisplayName(): string { return 'Agent Activity'; }
+    getCategory(): string { return 'Session'; }
+    supportsRawValue(): boolean { return true; }
+    supportsColors(_item: WidgetItem): boolean { return true; }
+
+    getHooks(): WidgetHookDef[] {
+        return [
+            { event: 'PreToolUse', matcher: 'Task' },
+            { event: 'PostToolUse', matcher: 'Task' }
+        ];
+    }
+
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
+        const modifiers: string[] = [this.getMode(item)];
+
+        const rawLimit = item.metadata?.[LIMIT_KEY];
+        if (rawLimit !== undefined) {
+            const parsed = parseInt(rawLimit, 10);
+            if (!Number.isNaN(parsed) && parsed >= 0 && parsed !== LIMIT_DEFAULT) {
+                modifiers.push(`limit: ${parsed === 0 ? '∞' : parsed}`);
+            }
+        }
+
+        if (this.shouldHideModel(item)) {
+            modifiers.push('no model');
+        }
+        if (this.shouldHideDescription(item)) {
+            modifiers.push('no desc');
+        }
+        if (this.shouldHideElapsed(item)) {
+            modifiers.push('no elapsed');
+        }
+
+        if (this.isHideWhenEmptyEnabled(item)) {
+            modifiers.push('hide when empty');
+        }
+
+        return {
+            displayText: 'Agent Activity',
+            modifierText: makeModifierText(modifiers)
+        };
+    }
+
+    getCustomKeybinds(item?: WidgetItem): CustomKeybind[] {
+        const keybinds: CustomKeybind[] = [
+            { key: 'v', label: '(v)iew: mixed/active/last', action: CYCLE_MODE_ACTION },
+            { key: 'm', label: '(m)odel', action: TOGGLE_HIDE_MODEL_ACTION },
+            { key: 'd', label: '(d)escription', action: TOGGLE_HIDE_DESCRIPTION_ACTION },
+            { key: 'e', label: '(e)lapsed', action: TOGGLE_HIDE_ELAPSED_ACTION },
+            { key: 'h', label: '(h)ide when empty', action: TOGGLE_HIDE_EMPTY_ACTION }
+        ];
+
+        if (item && this.getMode(item) !== 'last') {
+            keybinds.push({ key: 'l', label: '(l)imit', action: EDIT_LIMIT_ACTION });
+        }
+
+        return keybinds;
+    }
+
+    handleEditorAction(action: string, item: WidgetItem): WidgetItem | null {
+        if (action === CYCLE_MODE_ACTION) {
+            const currentMode = this.getMode(item);
+            const nextIndex = (MODES.indexOf(currentMode) + 1) % MODES.length;
+            const nextMode = MODES[nextIndex] ?? 'mixed';
+            return { ...item, metadata: { ...item.metadata, mode: nextMode } };
+        }
+        if (action === TOGGLE_HIDE_MODEL_ACTION) {
+            return toggleMetadataFlag(item, HIDE_MODEL_KEY);
+        }
+        if (action === TOGGLE_HIDE_DESCRIPTION_ACTION) {
+            return toggleMetadataFlag(item, HIDE_DESCRIPTION_KEY);
+        }
+        if (action === TOGGLE_HIDE_ELAPSED_ACTION) {
+            return toggleMetadataFlag(item, HIDE_ELAPSED_KEY);
+        }
+        if (action === TOGGLE_HIDE_EMPTY_ACTION) {
+            return toggleMetadataFlag(item, HIDE_WHEN_EMPTY_KEY);
+        }
+        return null;
+    }
+
+    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+        const mode = this.getMode(item);
+        const rawValue = item.rawValue === true;
+        const hideWhenEmpty = this.isHideWhenEmptyEnabled(item);
+
+        if (context.isPreview) {
+            return this.renderPreview(mode, rawValue);
+        }
+
+        const allAgents = context.agentActivityMetrics?.agents ?? [];
+        const filtered = filterByMode(allAgents, mode);
+
+        if (filtered.length === 0) {
+            if (hideWhenEmpty)
+                return null;
+            return rawValue ? '' : 'Agents: none';
+        }
+
+        const limit = mode === 'last' ? 1 : this.parseLimit(item);
+        const limited = applyLimit(filtered, limit);
+        const now = new Date();
+        const flags: AgentDisplayFlags = {
+            hideModel: this.shouldHideModel(item),
+            hideDescription: this.shouldHideDescription(item),
+            hideElapsed: this.shouldHideElapsed(item)
+        };
+        const parts = limited.map(agent => formatAgent(agent, flags, rawValue, now));
+        const separator = mode === 'active' ? ', ' : ' | ';
+        const joined = parts.join(separator);
+
+        return rawValue ? joined : `Agents: ${joined}`;
+    }
+
+    private renderPreview(mode: Mode, rawValue: boolean): string {
+        if (mode === 'active') {
+            return rawValue
+                ? 'explore [haiku]: Finding auth code (12s)'
+                : 'Agents: ◐ explore [haiku]: Finding auth code (12s)';
+        }
+        if (mode === 'last') {
+            return rawValue
+                ? 'code-reviewer [opus]: Review complete (2m 34s)'
+                : 'Agents: ✓ code-reviewer [opus]: Review complete (2m 34s)';
+        }
+        return rawValue
+            ? 'explore [haiku]: Finding auth code (12s) | code-reviewer [opus]: Review complete (2m 34s)'
+            : 'Agents: ◐ explore [haiku]: Finding auth code (12s) | ✓ code-reviewer [opus]: Review complete (2m 34s)';
+    }
+
+    renderEditor(props: WidgetEditorProps): React.ReactElement {
+        return <AgentActivityEditor {...props} />;
+    }
+
+    private getMode(item: WidgetItem): Mode {
+        const raw = item.metadata?.mode;
+        return raw !== undefined && (MODES as string[]).includes(raw) ? raw as Mode : 'mixed';
+    }
+
+    private parseLimit(item: WidgetItem): number {
+        const raw = item.metadata?.[LIMIT_KEY];
+        if (raw === undefined)
+            return LIMIT_DEFAULT;
+        const parsed = parseInt(raw, 10);
+        if (Number.isNaN(parsed) || parsed < 0)
+            return LIMIT_DEFAULT;
+        return parsed;
+    }
+
+    private shouldHideModel(item: WidgetItem): boolean {
+        return isMetadataFlagEnabled(item, HIDE_MODEL_KEY);
+    }
+
+    private shouldHideDescription(item: WidgetItem): boolean {
+        return isMetadataFlagEnabled(item, HIDE_DESCRIPTION_KEY);
+    }
+
+    private shouldHideElapsed(item: WidgetItem): boolean {
+        return isMetadataFlagEnabled(item, HIDE_ELAPSED_KEY);
+    }
+
+    private isHideWhenEmptyEnabled(item: WidgetItem): boolean {
+        return isMetadataFlagEnabled(item, HIDE_WHEN_EMPTY_KEY);
+    }
+}
+
+const AgentActivityEditor: React.FC<WidgetEditorProps> = ({ widget, onComplete, onCancel, action }) => {
+    const currentLimit = (() => {
+        const raw = widget.metadata?.[LIMIT_KEY];
+        if (raw === undefined) {
+            return LIMIT_DEFAULT;
+        }
+        const parsed = parseInt(raw, 10);
+        return Number.isNaN(parsed) || parsed < 0 ? LIMIT_DEFAULT : parsed;
+    })();
+    const [limitInput, setLimitInput] = useState(currentLimit.toString());
+
+    useInput((input, key) => {
+        if (action !== EDIT_LIMIT_ACTION) {
+            return;
+        }
+
+        if (key.return) {
+            const parsed = parseInt(limitInput, 10);
+            if (Number.isNaN(parsed) || parsed < 0) {
+                onCancel();
+                return;
+            }
+            onComplete({
+                ...widget,
+                metadata: {
+                    ...widget.metadata,
+                    [LIMIT_KEY]: parsed.toString()
+                }
+            });
+        } else if (key.escape) {
+            onCancel();
+        } else if (key.backspace) {
+            setLimitInput(limitInput.slice(0, -1));
+        } else if (shouldInsertInput(input, key) && /\d/.test(input)) {
+            setLimitInput(limitInput + input);
+        }
+    });
+
+    if (action === EDIT_LIMIT_ACTION) {
+        return (
+            <Box flexDirection='column'>
+                <Box>
+                    <Text>Enter max agents to show (0 for unlimited): </Text>
+                    <Text>{limitInput}</Text>
+                    <Text backgroundColor='gray' color='black'>{' '}</Text>
+                </Box>
+                <Text dimColor>Press Enter to save, ESC to cancel</Text>
+            </Box>
+        );
+    }
+
+    return <Text>Unknown editor mode</Text>;
+};

--- a/src/widgets/AgentActivity.tsx
+++ b/src/widgets/AgentActivity.tsx
@@ -24,14 +24,21 @@ import {
     toggleMetadataFlag
 } from './shared/metadata';
 
-type Mode = 'mixed' | 'active' | 'last';
-const MODES: Mode[] = ['mixed', 'active', 'last'];
+type Mode = 'current' | 'count' | 'list' | 'activity';
+const MODES: Mode[] = ['current', 'count', 'list', 'activity'];
+const MODE_LABELS: Record<Mode, string> = {
+    current: 'current',
+    count: 'count',
+    list: 'list',
+    activity: 'activity'
+};
 
 const LIMIT_DEFAULT = 3;
 
 const HIDE_MODEL_KEY = 'hideModel';
 const HIDE_DESCRIPTION_KEY = 'hideDescription';
 const HIDE_ELAPSED_KEY = 'hideElapsed';
+const HIDE_COMPLETED_KEY = 'hideCompleted';
 const HIDE_WHEN_EMPTY_KEY = 'hideWhenEmpty';
 const LIMIT_KEY = 'limit';
 
@@ -39,6 +46,7 @@ const CYCLE_MODE_ACTION = 'cycle-mode';
 const TOGGLE_HIDE_MODEL_ACTION = 'toggle-hide-model';
 const TOGGLE_HIDE_DESCRIPTION_ACTION = 'toggle-hide-description';
 const TOGGLE_HIDE_ELAPSED_ACTION = 'toggle-hide-elapsed';
+const TOGGLE_HIDE_COMPLETED_ACTION = 'toggle-hide-completed';
 const TOGGLE_HIDE_EMPTY_ACTION = 'toggle-hide-empty';
 const EDIT_LIMIT_ACTION = 'edit-limit';
 
@@ -97,13 +105,13 @@ export function formatAgent(
     return rawValue ? body : `${icon} ${body}`;
 }
 
-export function filterByMode(agents: AgentEntry[], mode: Mode): AgentEntry[] {
-    if (mode === 'active') {
-        return agents.filter(a => a.status === 'running');
-    }
-    if (mode === 'last') {
+export function filterByMode(agents: AgentEntry[], mode: Mode, hideCompleted = false): AgentEntry[] {
+    if (mode === 'current') {
         const last = agents[agents.length - 1];
         return last === undefined ? [] : [last];
+    }
+    if (mode === 'activity' && hideCompleted) {
+        return agents.filter(a => a.status === 'running');
     }
     return agents;
 }
@@ -133,14 +141,19 @@ export class AgentActivityWidget implements Widget {
     }
 
     getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
-        const modifiers: string[] = [this.getMode(item)];
+        const mode = this.getMode(item);
+        const modifiers: string[] = [MODE_LABELS[mode]];
 
         const rawLimit = item.metadata?.[LIMIT_KEY];
-        if (rawLimit !== undefined) {
+        if (rawLimit !== undefined && (mode === 'list' || mode === 'activity')) {
             const parsed = parseInt(rawLimit, 10);
             if (!Number.isNaN(parsed) && parsed >= 0 && parsed !== LIMIT_DEFAULT) {
                 modifiers.push(`limit: ${parsed === 0 ? '∞' : parsed}`);
             }
+        }
+
+        if (mode === 'activity' && this.shouldHideCompleted(item)) {
+            modifiers.push('running only');
         }
 
         if (this.shouldHideModel(item)) {
@@ -165,15 +178,21 @@ export class AgentActivityWidget implements Widget {
 
     getCustomKeybinds(item?: WidgetItem): CustomKeybind[] {
         const keybinds: CustomKeybind[] = [
-            { key: 'v', label: '(v)iew: mixed/active/last', action: CYCLE_MODE_ACTION },
+            { key: 'v', label: '(v)iew: current/count/list/activity', action: CYCLE_MODE_ACTION },
             { key: 'm', label: '(m)odel', action: TOGGLE_HIDE_MODEL_ACTION },
             { key: 'd', label: '(d)escription', action: TOGGLE_HIDE_DESCRIPTION_ACTION },
             { key: 'e', label: '(e)lapsed', action: TOGGLE_HIDE_ELAPSED_ACTION },
             { key: 'h', label: '(h)ide when empty', action: TOGGLE_HIDE_EMPTY_ACTION }
         ];
 
-        if (item && this.getMode(item) !== 'last') {
-            keybinds.push({ key: 'l', label: '(l)imit', action: EDIT_LIMIT_ACTION });
+        if (item) {
+            const mode = this.getMode(item);
+            if (mode === 'list' || mode === 'activity') {
+                keybinds.push({ key: 'l', label: '(l)imit', action: EDIT_LIMIT_ACTION });
+            }
+            if (mode === 'activity') {
+                keybinds.push({ key: 'r', label: '(r)unning only', action: TOGGLE_HIDE_COMPLETED_ACTION });
+            }
         }
 
         return keybinds;
@@ -183,7 +202,7 @@ export class AgentActivityWidget implements Widget {
         if (action === CYCLE_MODE_ACTION) {
             const currentMode = this.getMode(item);
             const nextIndex = (MODES.indexOf(currentMode) + 1) % MODES.length;
-            const nextMode = MODES[nextIndex] ?? 'mixed';
+            const nextMode = MODES[nextIndex] ?? 'activity';
             return { ...item, metadata: { ...item.metadata, mode: nextMode } };
         }
         if (action === TOGGLE_HIDE_MODEL_ACTION) {
@@ -195,6 +214,9 @@ export class AgentActivityWidget implements Widget {
         if (action === TOGGLE_HIDE_ELAPSED_ACTION) {
             return toggleMetadataFlag(item, HIDE_ELAPSED_KEY);
         }
+        if (action === TOGGLE_HIDE_COMPLETED_ACTION) {
+            return toggleMetadataFlag(item, HIDE_COMPLETED_KEY);
+        }
         if (action === TOGGLE_HIDE_EMPTY_ACTION) {
             return toggleMetadataFlag(item, HIDE_WHEN_EMPTY_KEY);
         }
@@ -205,13 +227,43 @@ export class AgentActivityWidget implements Widget {
         const mode = this.getMode(item);
         const rawValue = item.rawValue === true;
         const hideWhenEmpty = this.isHideWhenEmptyEnabled(item);
+        const hideCompleted = this.shouldHideCompleted(item);
 
         if (context.isPreview) {
-            return this.renderPreview(mode, rawValue);
+            return this.renderPreview(mode, rawValue, hideCompleted);
         }
 
         const allAgents = context.agentActivityMetrics?.agents ?? [];
-        const filtered = filterByMode(allAgents, mode);
+
+        if (mode === 'count') {
+            const total = allAgents.length;
+            if (hideWhenEmpty && total === 0)
+                return null;
+            return rawValue ? String(total) : `Agents: ${total}`;
+        }
+
+        if (mode === 'list') {
+            const byType = new Map<string, number>();
+            for (const a of allAgents) {
+                byType.set(a.type, (byType.get(a.type) ?? 0) + 1);
+            }
+            if (byType.size === 0) {
+                if (hideWhenEmpty)
+                    return null;
+                return rawValue ? '' : 'Agents: none';
+            }
+            const entries = [...byType.entries()].sort((a, b) => {
+                if (b[1] !== a[1])
+                    return b[1] - a[1];
+                return a[0].localeCompare(b[0]);
+            });
+            const limit = this.parseLimit(item);
+            const visible = limit > 0 ? entries.slice(0, limit) : entries;
+            const body = visible.map(([name, count]) => `${name} ×${count}`).join(', ');
+            return rawValue ? body : `Agents: ${body}`;
+        }
+
+        const filtered = filterByMode(allAgents, mode, hideCompleted);
 
         if (filtered.length === 0) {
             if (hideWhenEmpty)
@@ -219,7 +271,7 @@ export class AgentActivityWidget implements Widget {
             return rawValue ? '' : 'Agents: none';
         }
 
-        const limit = mode === 'last' ? 1 : this.parseLimit(item);
+        const limit = mode === 'current' ? 1 : this.parseLimit(item);
         const limited = applyLimit(filtered, limit);
         const now = new Date();
         const flags: AgentDisplayFlags = {
@@ -228,22 +280,29 @@ export class AgentActivityWidget implements Widget {
             hideElapsed: this.shouldHideElapsed(item)
         };
         const parts = limited.map(agent => formatAgent(agent, flags, rawValue, now));
-        const separator = mode === 'active' ? ', ' : ' | ';
+        const separator = mode === 'activity' && hideCompleted ? ', ' : ' | ';
         const joined = parts.join(separator);
 
         return rawValue ? joined : `Agents: ${joined}`;
     }
 
-    private renderPreview(mode: Mode, rawValue: boolean): string {
-        if (mode === 'active') {
-            return rawValue
-                ? 'explore [haiku]: Finding auth code (12s)'
-                : 'Agents: ◐ explore [haiku]: Finding auth code (12s)';
+    private renderPreview(mode: Mode, rawValue: boolean, hideCompleted: boolean): string {
+        if (mode === 'count') {
+            return rawValue ? '3' : 'Agents: 3';
         }
-        if (mode === 'last') {
+        if (mode === 'list') {
+            const body = 'explore ×2, code-reviewer ×1';
+            return rawValue ? body : `Agents: ${body}`;
+        }
+        if (mode === 'current') {
             return rawValue
                 ? 'code-reviewer [opus]: Review complete (2m 34s)'
                 : 'Agents: ✓ code-reviewer [opus]: Review complete (2m 34s)';
+        }
+        if (hideCompleted) {
+            return rawValue
+                ? 'explore [haiku]: Finding auth code (12s)'
+                : 'Agents: ◐ explore [haiku]: Finding auth code (12s)';
         }
         return rawValue
             ? 'explore [haiku]: Finding auth code (12s) | code-reviewer [opus]: Review complete (2m 34s)'
@@ -256,7 +315,11 @@ export class AgentActivityWidget implements Widget {
 
     private getMode(item: WidgetItem): Mode {
         const raw = item.metadata?.mode;
-        return raw !== undefined && (MODES as string[]).includes(raw) ? raw as Mode : 'mixed';
+        if (raw === 'last')
+            return 'current';
+        if (raw === 'mixed' || raw === 'active')
+            return 'activity';
+        return raw !== undefined && (MODES as string[]).includes(raw) ? raw as Mode : 'activity';
     }
 
     private parseLimit(item: WidgetItem): number {
@@ -279,6 +342,12 @@ export class AgentActivityWidget implements Widget {
 
     private shouldHideElapsed(item: WidgetItem): boolean {
         return isMetadataFlagEnabled(item, HIDE_ELAPSED_KEY);
+    }
+
+    private shouldHideCompleted(item: WidgetItem): boolean {
+        if (item.metadata?.mode === 'active')
+            return true;
+        return isMetadataFlagEnabled(item, HIDE_COMPLETED_KEY);
     }
 
     private isHideWhenEmptyEnabled(item: WidgetItem): boolean {

--- a/src/widgets/AgentActivity.tsx
+++ b/src/widgets/AgentActivity.tsx
@@ -127,8 +127,8 @@ export class AgentActivityWidget implements Widget {
 
     getHooks(): WidgetHookDef[] {
         return [
-            { event: 'PreToolUse', matcher: 'Task' },
-            { event: 'PostToolUse', matcher: 'Task' }
+            { event: 'PreToolUse', matcher: 'Agent' },
+            { event: 'PostToolUse', matcher: 'Agent' }
         ];
     }
 

--- a/src/widgets/AgentActivity.tsx
+++ b/src/widgets/AgentActivity.tsx
@@ -41,6 +41,7 @@ const HIDE_ELAPSED_KEY = 'hideElapsed';
 const HIDE_COMPLETED_KEY = 'hideCompleted';
 const HIDE_WHEN_EMPTY_KEY = 'hideWhenEmpty';
 const LIMIT_KEY = 'limit';
+const STALE_MINUTES_KEY = 'staleMinutes';
 
 const CYCLE_MODE_ACTION = 'cycle-mode';
 const TOGGLE_HIDE_MODEL_ACTION = 'toggle-hide-model';
@@ -49,6 +50,7 @@ const TOGGLE_HIDE_ELAPSED_ACTION = 'toggle-hide-elapsed';
 const TOGGLE_HIDE_COMPLETED_ACTION = 'toggle-hide-completed';
 const TOGGLE_HIDE_EMPTY_ACTION = 'toggle-hide-empty';
 const EDIT_LIMIT_ACTION = 'edit-limit';
+const EDIT_STALE_ACTION = 'edit-stale-minutes';
 
 export function formatElapsed(startTime: Date, endTime: Date | undefined, now: Date = new Date()): string {
     const endMs = (endTime ?? now).getTime();
@@ -122,6 +124,21 @@ export function applyLimit(agents: AgentEntry[], limit: number): AgentEntry[] {
     return agents.slice(-limit);
 }
 
+// Staleness pruning (fallback for when D's turn-boundary purge doesn't catch
+// a long-running single-turn session). Running agents always survive; only
+// completed agents with endTime older than `staleMinutes` are dropped.
+export function dropStaleCompleted(agents: AgentEntry[], staleMinutes: number, now: Date = new Date()): AgentEntry[] {
+    if (staleMinutes <= 0)
+        return agents;
+    const cutoff = now.getTime() - staleMinutes * 60_000;
+    return agents.filter((a) => {
+        if (a.status === 'running')
+            return true;
+        const endMs = a.endTime?.getTime() ?? a.startTime.getTime();
+        return endMs >= cutoff;
+    });
+}
+
 export class AgentActivityWidget implements Widget {
     getDefaultColor(): string { return 'magenta'; }
     getDescription(): string {
@@ -136,7 +153,8 @@ export class AgentActivityWidget implements Widget {
     getHooks(): WidgetHookDef[] {
         return [
             { event: 'PreToolUse', matcher: 'Agent' },
-            { event: 'PostToolUse', matcher: 'Agent' }
+            { event: 'PostToolUse', matcher: 'Agent' },
+            { event: 'UserPromptSubmit' }
         ];
     }
 
@@ -154,6 +172,11 @@ export class AgentActivityWidget implements Widget {
 
         if (mode === 'activity' && this.shouldHideCompleted(item)) {
             modifiers.push('running only');
+        }
+
+        const stale = this.parseStaleMinutes(item);
+        if (stale > 0) {
+            modifiers.push(`stale: ${stale}m`);
         }
 
         if (this.shouldHideModel(item)) {
@@ -197,6 +220,7 @@ export class AgentActivityWidget implements Widget {
                 keybinds.push({ key: 'u', label: 'r(u)nning only', action: TOGGLE_HIDE_COMPLETED_ACTION });
             }
         }
+        keybinds.push({ key: 's', label: '(s)tale min', action: EDIT_STALE_ACTION });
 
         return keybinds;
     }
@@ -236,7 +260,8 @@ export class AgentActivityWidget implements Widget {
             return this.renderPreview(mode, rawValue, hideCompleted);
         }
 
-        const allAgents = context.agentActivityMetrics?.agents ?? [];
+        const allAgentsRaw = context.agentActivityMetrics?.agents ?? [];
+        const allAgents = dropStaleCompleted(allAgentsRaw, this.parseStaleMinutes(item));
 
         if (mode === 'count') {
             const total = allAgents.length;
@@ -353,29 +378,45 @@ export class AgentActivityWidget implements Widget {
         return isMetadataFlagEnabled(item, HIDE_COMPLETED_KEY);
     }
 
+    parseStaleMinutes(item: WidgetItem): number {
+        const raw = item.metadata?.[STALE_MINUTES_KEY];
+        if (raw === undefined)
+            return 0;
+        const parsed = parseInt(raw, 10);
+        if (Number.isNaN(parsed) || parsed < 0)
+            return 0;
+        return parsed;
+    }
+
     private isHideWhenEmptyEnabled(item: WidgetItem): boolean {
         return isMetadataFlagEnabled(item, HIDE_WHEN_EMPTY_KEY);
     }
 }
 
 const AgentActivityEditor: React.FC<WidgetEditorProps> = ({ widget, onComplete, onCancel, action }) => {
-    const currentLimit = (() => {
-        const raw = widget.metadata?.[LIMIT_KEY];
+    const editingStale = action === EDIT_STALE_ACTION;
+    const metadataKey = editingStale ? STALE_MINUTES_KEY : LIMIT_KEY;
+
+    const initialValue = (() => {
+        const raw = widget.metadata?.[metadataKey];
         if (raw === undefined) {
-            return LIMIT_DEFAULT;
+            return editingStale ? '0' : LIMIT_DEFAULT.toString();
         }
         const parsed = parseInt(raw, 10);
-        return Number.isNaN(parsed) || parsed < 0 ? LIMIT_DEFAULT : parsed;
+        if (Number.isNaN(parsed) || parsed < 0) {
+            return editingStale ? '0' : LIMIT_DEFAULT.toString();
+        }
+        return parsed.toString();
     })();
-    const [limitInput, setLimitInput] = useState(currentLimit.toString());
+    const [value, setValue] = useState(initialValue);
 
     useInput((input, key) => {
-        if (action !== EDIT_LIMIT_ACTION) {
+        if (action !== EDIT_LIMIT_ACTION && action !== EDIT_STALE_ACTION) {
             return;
         }
 
         if (key.return) {
-            const parsed = parseInt(limitInput, 10);
+            const parsed = parseInt(value, 10);
             if (Number.isNaN(parsed) || parsed < 0) {
                 onCancel();
                 return;
@@ -384,15 +425,15 @@ const AgentActivityEditor: React.FC<WidgetEditorProps> = ({ widget, onComplete, 
                 ...widget,
                 metadata: {
                     ...widget.metadata,
-                    [LIMIT_KEY]: parsed.toString()
+                    [metadataKey]: parsed.toString()
                 }
             });
         } else if (key.escape) {
             onCancel();
         } else if (key.backspace) {
-            setLimitInput(limitInput.slice(0, -1));
+            setValue(value.slice(0, -1));
         } else if (shouldInsertInput(input, key) && /\d/.test(input)) {
-            setLimitInput(limitInput + input);
+            setValue(value + input);
         }
     });
 
@@ -401,7 +442,20 @@ const AgentActivityEditor: React.FC<WidgetEditorProps> = ({ widget, onComplete, 
             <Box flexDirection='column'>
                 <Box>
                     <Text>Enter max agents to show (0 for unlimited): </Text>
-                    <Text>{limitInput}</Text>
+                    <Text>{value}</Text>
+                    <Text backgroundColor='gray' color='black'>{' '}</Text>
+                </Box>
+                <Text dimColor>Press Enter to save, ESC to cancel</Text>
+            </Box>
+        );
+    }
+
+    if (action === EDIT_STALE_ACTION) {
+        return (
+            <Box flexDirection='column'>
+                <Box>
+                    <Text>Stale minutes — drop completed agents this old (0 disables): </Text>
+                    <Text>{value}</Text>
                     <Text backgroundColor='gray' color='black'>{' '}</Text>
                 </Box>
                 <Text dimColor>Press Enter to save, ESC to cancel</Text>

--- a/src/widgets/Skills.tsx
+++ b/src/widgets/Skills.tsx
@@ -24,9 +24,10 @@ import {
     toggleMetadataFlag
 } from './shared/metadata';
 
-type Mode = 'current' | 'count' | 'list';
-const MODES: Mode[] = ['current', 'count', 'list'];
-const MODE_LABELS: Record<Mode, string> = { current: 'last used', count: 'total count', list: 'unique list' };
+type Mode = 'current' | 'count' | 'list' | 'activity';
+const MODES: Mode[] = ['current', 'count', 'list', 'activity'];
+const MODE_LABELS: Record<Mode, string> = { current: 'current', count: 'count', list: 'list', activity: 'activity' };
+const ACTIVITY_DEFAULT_LIMIT = 5;
 const HIDE_WHEN_EMPTY_KEY = 'hideWhenEmpty';
 const LIST_LIMIT_KEY = 'listLimit';
 const TOGGLE_HIDE_EMPTY_ACTION = 'toggle-hide-empty';
@@ -78,20 +79,24 @@ export class SkillsWidget implements Widget {
 
     getCustomKeybinds(item?: WidgetItem): CustomKeybind[] {
         const keybinds: CustomKeybind[] = [
-            { key: 'v', label: '(v)iew: last/count/list', action: 'cycle-mode' },
+            { key: 'v', label: '(v)iew: current/count/list/activity', action: 'cycle-mode' },
             { key: 'h', label: '(h)ide when empty', action: TOGGLE_HIDE_EMPTY_ACTION }
         ];
 
-        if (item && this.getMode(item) === 'list') {
-            keybinds.push({ key: 'l', label: '(l)imit', action: EDIT_LIST_LIMIT_ACTION });
+        if (item) {
+            const mode = this.getMode(item);
+            if (mode === 'list' || mode === 'activity') {
+                keybinds.push({ key: 'l', label: '(l)imit', action: EDIT_LIST_LIMIT_ACTION });
+            }
         }
 
         return keybinds;
     }
 
     getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
-        const modifiers = [MODE_LABELS[this.getMode(item)]];
-        if (this.getMode(item) === 'list') {
+        const mode = this.getMode(item);
+        const modifiers = [MODE_LABELS[mode]];
+        if (mode === 'list' || mode === 'activity') {
             const limit = parseListLimit(item);
             if (limit > 0) {
                 modifiers.push(`limit: ${limit}`);
@@ -106,7 +111,8 @@ export class SkillsWidget implements Widget {
     handleEditorAction(action: string, item: WidgetItem): WidgetItem | null {
         if (action === 'cycle-mode') {
             const next = MODES[(MODES.indexOf(this.getMode(item)) + 1) % MODES.length] ?? 'current';
-            const nextItem = next === 'list' ? item : removeMetadataKeys(item, [LIST_LIMIT_KEY]);
+            const keepsLimit = next === 'list' || next === 'activity';
+            const nextItem = keepsLimit ? item : removeMetadataKeys(item, [LIST_LIMIT_KEY]);
             return { ...nextItem, metadata: { ...nextItem.metadata, mode: next } };
         }
         if (action === TOGGLE_HIDE_EMPTY_ACTION) {
@@ -131,6 +137,10 @@ export class SkillsWidget implements Widget {
             if (mode === 'count') {
                 return raw ? '5' : 'Skills: 5';
             }
+            if (mode === 'activity') {
+                const body = 'commit → review-pr → commit';
+                return raw ? body : `Skills: ${body}`;
+            }
             return raw ? 'commit, review-pr' : 'Skills: commit, review-pr';
         }
 
@@ -150,6 +160,21 @@ export class SkillsWidget implements Widget {
                 return null;
             }
             return raw ? String(total) : `Skills: ${total}`;
+        }
+
+        if (mode === 'activity') {
+            const recent = context.skillsMetrics?.recent ?? [];
+            if (recent.length === 0) {
+                if (hideWhenEmpty) {
+                    return null;
+                }
+                return raw ? '' : 'Skills: none';
+            }
+            const configuredLimit = parseListLimit(item);
+            const limit = configuredLimit > 0 ? configuredLimit : ACTIVITY_DEFAULT_LIMIT;
+            const visible = recent.slice(-limit);
+            const body = visible.join(' → ');
+            return raw ? body : `Skills: ${body}`;
         }
 
         const uniqueSkills = context.skillsMetrics?.uniqueSkills ?? [];

--- a/src/widgets/TodoProgress.tsx
+++ b/src/widgets/TodoProgress.tsx
@@ -97,7 +97,7 @@ export class TodoProgressWidget implements Widget {
     getCustomKeybinds(_item?: WidgetItem): CustomKeybind[] {
         return [
             { key: 'p', label: '(p)rogress', action: TOGGLE_HIDE_PROGRESS_ACTION },
-            { key: 'c', label: '(c)ontent', action: TOGGLE_HIDE_CONTENT_ACTION },
+            { key: 't', label: '(t)ext', action: TOGGLE_HIDE_CONTENT_ACTION },
             { key: 'h', label: '(h)ide when empty', action: TOGGLE_HIDE_EMPTY_ACTION }
         ];
     }

--- a/src/widgets/TodoProgress.tsx
+++ b/src/widgets/TodoProgress.tsx
@@ -1,0 +1,160 @@
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type { TodoItem } from '../types/TodoProgressMetrics';
+import type {
+    CustomKeybind,
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+import type { WidgetHookDef } from '../utils/hooks';
+
+import { makeModifierText } from './shared/editor-display';
+import {
+    isMetadataFlagEnabled,
+    toggleMetadataFlag
+} from './shared/metadata';
+
+const HIDE_WHEN_EMPTY_KEY = 'hideWhenEmpty';
+const HIDE_PROGRESS_KEY = 'hideProgress';
+const HIDE_CONTENT_KEY = 'hideContent';
+
+const TOGGLE_HIDE_EMPTY_ACTION = 'toggle-hide-empty';
+const TOGGLE_HIDE_PROGRESS_ACTION = 'toggle-hide-progress';
+const TOGGLE_HIDE_CONTENT_ACTION = 'toggle-hide-content';
+
+export interface TodoDisplayFlags {
+    hideProgress: boolean;
+    hideContent: boolean;
+}
+
+function truncate(text: string, maxLen: number): string {
+    if (text.length <= maxLen)
+        return text;
+    return `${text.slice(0, maxLen - 3)}...`;
+}
+
+export function formatTodoProgress(
+    todos: TodoItem[],
+    flags: TodoDisplayFlags,
+    rawValue: boolean
+): string {
+    if (todos.length === 0) {
+        return rawValue ? '' : 'Todo: none';
+    }
+
+    const completed = todos.filter(t => t.status === 'completed').length;
+    const total = todos.length;
+    const progress = `${completed}/${total}`;
+    const inProgress = todos.find(t => t.status === 'in_progress');
+
+    if (inProgress) {
+        if (flags.hideContent) {
+            const body = flags.hideProgress ? 'in progress' : `${progress} in progress`;
+            return rawValue ? body : `Todo: ${body}`;
+        }
+        const content = truncate(inProgress.content, 40);
+        const body = flags.hideProgress ? content : `${content} (${progress})`;
+        return rawValue ? body : `▸ ${body}`;
+    }
+
+    const body = flags.hideProgress ? 'done' : `${progress} done`;
+    return rawValue ? body : `Todo: ${body}`;
+}
+
+export class TodoProgressWidget implements Widget {
+    getDefaultColor(): string { return 'yellow'; }
+    getDescription(): string {
+        return 'Shows current in-progress todo and completion ratio from TodoWrite';
+    }
+
+    getDisplayName(): string { return 'Todo Progress'; }
+    getCategory(): string { return 'Session'; }
+    supportsRawValue(): boolean { return true; }
+    supportsColors(_item: WidgetItem): boolean { return true; }
+
+    getHooks(): WidgetHookDef[] {
+        return [{ event: 'PostToolUse', matcher: 'TodoWrite' }];
+    }
+
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
+        const modifiers: string[] = [];
+        if (this.shouldHideContent(item)) {
+            modifiers.push('no content');
+        }
+        if (this.shouldHideProgress(item)) {
+            modifiers.push('no progress');
+        }
+        if (this.isHideWhenEmptyEnabled(item)) {
+            modifiers.push('hide when empty');
+        }
+        return {
+            displayText: 'Todo Progress',
+            modifierText: makeModifierText(modifiers)
+        };
+    }
+
+    getCustomKeybinds(_item?: WidgetItem): CustomKeybind[] {
+        return [
+            { key: 'p', label: '(p)rogress', action: TOGGLE_HIDE_PROGRESS_ACTION },
+            { key: 'c', label: '(c)ontent', action: TOGGLE_HIDE_CONTENT_ACTION },
+            { key: 'h', label: '(h)ide when empty', action: TOGGLE_HIDE_EMPTY_ACTION }
+        ];
+    }
+
+    handleEditorAction(action: string, item: WidgetItem): WidgetItem | null {
+        if (action === TOGGLE_HIDE_PROGRESS_ACTION) {
+            return toggleMetadataFlag(item, HIDE_PROGRESS_KEY);
+        }
+        if (action === TOGGLE_HIDE_CONTENT_ACTION) {
+            return toggleMetadataFlag(item, HIDE_CONTENT_KEY);
+        }
+        if (action === TOGGLE_HIDE_EMPTY_ACTION) {
+            return toggleMetadataFlag(item, HIDE_WHEN_EMPTY_KEY);
+        }
+        return null;
+    }
+
+    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+        const rawValue = item.rawValue === true;
+        const flags: TodoDisplayFlags = {
+            hideProgress: this.shouldHideProgress(item),
+            hideContent: this.shouldHideContent(item)
+        };
+
+        if (context.isPreview) {
+            return formatTodoProgress(
+                [
+                    { content: 'Write tests', status: 'completed' },
+                    { content: 'Fix authentication bug', status: 'in_progress' },
+                    { content: 'Add docs', status: 'pending' },
+                    { content: 'Ship release', status: 'pending' },
+                    { content: 'Cleanup', status: 'pending' }
+                ],
+                flags,
+                rawValue
+            );
+        }
+
+        const todos = context.todoProgressMetrics?.todos ?? [];
+        if (todos.length === 0) {
+            if (this.isHideWhenEmptyEnabled(item))
+                return null;
+            return rawValue ? '' : 'Todo: none';
+        }
+
+        return formatTodoProgress(todos, flags, rawValue);
+    }
+
+    private shouldHideProgress(item: WidgetItem): boolean {
+        return isMetadataFlagEnabled(item, HIDE_PROGRESS_KEY);
+    }
+
+    private shouldHideContent(item: WidgetItem): boolean {
+        return isMetadataFlagEnabled(item, HIDE_CONTENT_KEY);
+    }
+
+    private isHideWhenEmptyEnabled(item: WidgetItem): boolean {
+        return isMetadataFlagEnabled(item, HIDE_WHEN_EMPTY_KEY);
+    }
+}

--- a/src/widgets/TodoProgress.tsx
+++ b/src/widgets/TodoProgress.tsx
@@ -1,3 +1,10 @@
+import {
+    Box,
+    Text,
+    useInput
+} from 'ink';
+import React, { useState } from 'react';
+
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
 import type { TodoItem } from '../types/TodoProgressMetrics';
@@ -5,9 +12,11 @@ import type {
     CustomKeybind,
     Widget,
     WidgetEditorDisplay,
+    WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
 import type { WidgetHookDef } from '../utils/hooks';
+import { shouldInsertInput } from '../utils/input-guards';
 
 import { makeModifierText } from './shared/editor-display';
 import {
@@ -18,10 +27,12 @@ import {
 const HIDE_WHEN_EMPTY_KEY = 'hideWhenEmpty';
 const HIDE_PROGRESS_KEY = 'hideProgress';
 const HIDE_CONTENT_KEY = 'hideContent';
+const STALE_MINUTES_KEY = 'staleMinutes';
 
 const TOGGLE_HIDE_EMPTY_ACTION = 'toggle-hide-empty';
 const TOGGLE_HIDE_PROGRESS_ACTION = 'toggle-hide-progress';
 const TOGGLE_HIDE_CONTENT_ACTION = 'toggle-hide-content';
+const EDIT_STALE_ACTION = 'edit-stale-minutes';
 
 export interface TodoDisplayFlags {
     hideProgress: boolean;
@@ -74,7 +85,10 @@ export class TodoProgressWidget implements Widget {
     supportsColors(_item: WidgetItem): boolean { return true; }
 
     getHooks(): WidgetHookDef[] {
-        return [{ event: 'PostToolUse', matcher: 'TodoWrite' }];
+        return [
+            { event: 'PostToolUse', matcher: 'TodoWrite' },
+            { event: 'UserPromptSubmit' }
+        ];
     }
 
     getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
@@ -84,6 +98,10 @@ export class TodoProgressWidget implements Widget {
         }
         if (this.shouldHideProgress(item)) {
             modifiers.push('no progress');
+        }
+        const stale = this.parseStaleMinutes(item);
+        if (stale > 0) {
+            modifiers.push(`stale: ${stale}m`);
         }
         if (this.isHideWhenEmptyEnabled(item)) {
             modifiers.push('hide when empty');
@@ -98,7 +116,8 @@ export class TodoProgressWidget implements Widget {
         return [
             { key: 'p', label: '(p)rogress', action: TOGGLE_HIDE_PROGRESS_ACTION },
             { key: 't', label: '(t)ext', action: TOGGLE_HIDE_CONTENT_ACTION },
-            { key: 'h', label: '(h)ide when empty', action: TOGGLE_HIDE_EMPTY_ACTION }
+            { key: 'h', label: '(h)ide when empty', action: TOGGLE_HIDE_EMPTY_ACTION },
+            { key: 's', label: '(s)tale min', action: EDIT_STALE_ACTION }
         ];
     }
 
@@ -112,7 +131,12 @@ export class TodoProgressWidget implements Widget {
         if (action === TOGGLE_HIDE_EMPTY_ACTION) {
             return toggleMetadataFlag(item, HIDE_WHEN_EMPTY_KEY);
         }
+        // EDIT_STALE_ACTION returns null to trigger renderEditor below.
         return null;
+    }
+
+    renderEditor(props: WidgetEditorProps): React.ReactElement {
+        return <TodoProgressEditor {...props} />;
     }
 
     render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
@@ -136,8 +160,14 @@ export class TodoProgressWidget implements Widget {
             );
         }
 
-        const todos = context.todoProgressMetrics?.todos ?? [];
-        if (todos.length === 0) {
+        const metrics = context.todoProgressMetrics;
+        const todos = metrics?.todos ?? [];
+        const stale = this.parseStaleMinutes(item);
+        const isStale = stale > 0 && metrics?.timestamp
+            ? (Date.now() - new Date(metrics.timestamp).getTime()) > stale * 60_000
+            : false;
+
+        if (todos.length === 0 || isStale) {
             if (this.isHideWhenEmptyEnabled(item))
                 return null;
             return rawValue ? '' : 'Todo: none';
@@ -157,4 +187,67 @@ export class TodoProgressWidget implements Widget {
     private isHideWhenEmptyEnabled(item: WidgetItem): boolean {
         return isMetadataFlagEnabled(item, HIDE_WHEN_EMPTY_KEY);
     }
+
+    parseStaleMinutes(item: WidgetItem): number {
+        const raw = item.metadata?.[STALE_MINUTES_KEY];
+        if (raw === undefined)
+            return 0;
+        const parsed = parseInt(raw, 10);
+        if (Number.isNaN(parsed) || parsed < 0)
+            return 0;
+        return parsed;
+    }
 }
+
+const TodoProgressEditor: React.FC<WidgetEditorProps> = ({ widget, onComplete, onCancel, action }) => {
+    const initialValue = (() => {
+        const raw = widget.metadata?.[STALE_MINUTES_KEY];
+        if (raw === undefined)
+            return '0';
+        const parsed = parseInt(raw, 10);
+        return Number.isNaN(parsed) || parsed < 0 ? '0' : parsed.toString();
+    })();
+    const [value, setValue] = useState(initialValue);
+
+    useInput((input, key) => {
+        if (action !== EDIT_STALE_ACTION) {
+            return;
+        }
+
+        if (key.return) {
+            const parsed = parseInt(value, 10);
+            if (Number.isNaN(parsed) || parsed < 0) {
+                onCancel();
+                return;
+            }
+            onComplete({
+                ...widget,
+                metadata: {
+                    ...widget.metadata,
+                    [STALE_MINUTES_KEY]: parsed.toString()
+                }
+            });
+        } else if (key.escape) {
+            onCancel();
+        } else if (key.backspace) {
+            setValue(value.slice(0, -1));
+        } else if (shouldInsertInput(input, key) && /\d/.test(input)) {
+            setValue(value + input);
+        }
+    });
+
+    if (action === EDIT_STALE_ACTION) {
+        return (
+            <Box flexDirection='column'>
+                <Box>
+                    <Text>Stale minutes — treat todo snapshot as empty once older than this (0 disables): </Text>
+                    <Text>{value}</Text>
+                    <Text backgroundColor='gray' color='black'>{' '}</Text>
+                </Box>
+                <Text dimColor>Press Enter to save, ESC to cancel</Text>
+            </Box>
+        );
+    }
+
+    return <Text>Unknown editor mode</Text>;
+};

--- a/src/widgets/ToolCount.tsx
+++ b/src/widgets/ToolCount.tsx
@@ -170,7 +170,7 @@ export class ToolCountWidget implements Widget {
                 const preview = '◐ Edit: auth.ts | ✓ Read ×3 | ✓ Bash ×2';
                 return raw ? preview : `Tools: ${preview}`;
             }
-            const preview = 'Bash * 5, Edit * 4, Read * 2, MCP * 1';
+            const preview = 'Bash ×5, Edit ×4, Read ×2, MCP ×1';
             return raw ? preview : `Tools: ${preview}`;
         }
 
@@ -317,7 +317,7 @@ export class ToolCountWidget implements Widget {
             return a.name.localeCompare(b.name);
         });
 
-        return entries.map(e => `${e.name} * ${e.count}`);
+        return entries.map(e => `${e.name} ×${e.count}`);
     }
 
     private getMode(item: WidgetItem): Mode {

--- a/src/widgets/ToolCount.tsx
+++ b/src/widgets/ToolCount.tsx
@@ -108,7 +108,7 @@ export class ToolCountWidget implements Widget {
                 keybinds.push({ key: 'l', label: '(l)imit', action: EDIT_LIST_LIMIT_ACTION });
             }
             if (mode === 'activity') {
-                keybinds.push({ key: 'r', label: '(r)unning only', action: TOGGLE_HIDE_COMPLETED_ACTION });
+                keybinds.push({ key: 'u', label: 'r(u)nning only', action: TOGGLE_HIDE_COMPLETED_ACTION });
             }
         }
 

--- a/src/widgets/ToolCount.tsx
+++ b/src/widgets/ToolCount.tsx
@@ -27,10 +27,17 @@ import {
 type Mode = 'current' | 'count' | 'list';
 const MODES: Mode[] = ['current', 'count', 'list'];
 const MODE_LABELS: Record<Mode, string> = { current: 'last used', count: 'total count', list: 'unique list' };
+
+type Scope = 'all' | 'builtin' | 'mcp';
+const SCOPES: Scope[] = ['all', 'builtin', 'mcp'];
+const SCOPE_LABELS: Record<Scope, string> = { all: 'all', builtin: 'builtin', mcp: 'mcp' };
+
 const HIDE_WHEN_EMPTY_KEY = 'hideWhenEmpty';
 const LIST_LIMIT_KEY = 'listLimit';
+const SCOPE_KEY = 'scope';
 const TOGGLE_HIDE_EMPTY_ACTION = 'toggle-hide-empty';
 const EDIT_LIST_LIMIT_ACTION = 'edit-list-limit';
+const CYCLE_SCOPE_ACTION = 'cycle-scope';
 
 function parseListLimit(item: WidgetItem): number {
     const parsed = parseInt(item.metadata?.[LIST_LIMIT_KEY] ?? '0', 10);
@@ -59,26 +66,24 @@ function setListLimit(item: WidgetItem, limit: number): WidgetItem {
     };
 }
 
-export class SkillsWidget implements Widget {
-    getDefaultColor(): string { return 'magenta'; }
-    getDescription(): string { return 'Shows Claude Code skill invocations from hook data'; }
-    getDisplayName(): string { return 'Skills'; }
+export class ToolCountWidget implements Widget {
+    getDefaultColor(): string { return 'cyan'; }
+    getDescription(): string { return 'Counts Claude Code tool invocations (built-in + MCP) per session'; }
+    getDisplayName(): string { return 'Tool Count'; }
     getCategory(): string { return 'Session'; }
     supportsRawValue(): boolean { return true; }
     supportsColors(): boolean { return true; }
 
-    // No PreToolUse matcher so this hook can be shared with other widgets
-    // (e.g. ToolCount); handleHook routes by tool_name.
+    // PreToolUse (not PostToolUse) so the count updates before the next render.
+    // Shared/deduped with Skills' PreToolUse hook; handleHook routes by tool_name.
     getHooks(): WidgetHookDef[] {
-        return [
-            { event: 'PreToolUse' },
-            { event: 'UserPromptSubmit' }
-        ];
+        return [{ event: 'PreToolUse' }];
     }
 
     getCustomKeybinds(item?: WidgetItem): CustomKeybind[] {
         const keybinds: CustomKeybind[] = [
             { key: 'v', label: '(v)iew: last/count/list', action: 'cycle-mode' },
+            { key: 's', label: '(s)cope: all/builtin/mcp', action: CYCLE_SCOPE_ACTION },
             { key: 'h', label: '(h)ide when empty', action: TOGGLE_HIDE_EMPTY_ACTION }
         ];
 
@@ -91,6 +96,10 @@ export class SkillsWidget implements Widget {
 
     getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
         const modifiers = [MODE_LABELS[this.getMode(item)]];
+        const scope = this.getScope(item);
+        if (scope !== 'all') {
+            modifiers.push(`scope: ${SCOPE_LABELS[scope]}`);
+        }
         if (this.getMode(item) === 'list') {
             const limit = parseListLimit(item);
             if (limit > 0) {
@@ -100,7 +109,7 @@ export class SkillsWidget implements Widget {
         if (this.isHideWhenEmptyEnabled(item)) {
             modifiers.push('hide when empty');
         }
-        return { displayText: 'Skills', modifierText: makeModifierText(modifiers) };
+        return { displayText: 'Tools', modifierText: makeModifierText(modifiers) };
     }
 
     handleEditorAction(action: string, item: WidgetItem): WidgetItem | null {
@@ -109,6 +118,13 @@ export class SkillsWidget implements Widget {
             const nextItem = next === 'list' ? item : removeMetadataKeys(item, [LIST_LIMIT_KEY]);
             return { ...nextItem, metadata: { ...nextItem.metadata, mode: next } };
         }
+        if (action === CYCLE_SCOPE_ACTION) {
+            const next = SCOPES[(SCOPES.indexOf(this.getScope(item)) + 1) % SCOPES.length] ?? 'all';
+            if (next === 'all') {
+                return removeMetadataKeys(item, [SCOPE_KEY]);
+            }
+            return { ...item, metadata: { ...item.metadata, [SCOPE_KEY]: next } };
+        }
         if (action === TOGGLE_HIDE_EMPTY_ACTION) {
             return toggleMetadataFlag(item, HIDE_WHEN_EMPTY_KEY);
         }
@@ -116,54 +132,110 @@ export class SkillsWidget implements Widget {
     }
 
     renderEditor(props: WidgetEditorProps): React.ReactElement {
-        return <SkillsEditor {...props} />;
+        return <ToolCountEditor {...props} />;
     }
 
     render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
         const mode = this.getMode(item);
+        const scope = this.getScope(item);
         const raw = item.rawValue;
         const hideWhenEmpty = this.isHideWhenEmptyEnabled(item);
 
         if (context.isPreview) {
             if (mode === 'current') {
-                return raw ? 'commit' : 'Skill: commit';
+                return raw ? 'Edit' : 'Tool: Edit';
             }
             if (mode === 'count') {
-                return raw ? '5' : 'Skills: 5';
+                return raw ? '42' : 'Tools: 42';
             }
-            return raw ? 'commit, review-pr' : 'Skills: commit, review-pr';
+            const preview = 'Bash * 5, Edit * 4, Read * 2, MCP * 1';
+            return raw ? preview : `Tools: ${preview}`;
         }
 
         if (mode === 'current') {
-            const currentSkill = context.skillsMetrics?.lastSkill;
-            if (!currentSkill) {
+            const lastTool = context.toolCountMetrics?.lastTool;
+            if (!lastTool) {
                 if (hideWhenEmpty) {
                     return null;
                 }
-                return raw ? 'none' : 'Skill: none';
+                return raw ? 'none' : 'Tool: none';
             }
-            return raw ? currentSkill : `Skill: ${currentSkill}`;
+            return raw ? lastTool : `Tool: ${lastTool}`;
         }
+
         if (mode === 'count') {
-            const total = context.skillsMetrics?.totalInvocations ?? 0;
+            const total = this.getScopedTotal(context, scope);
             if (hideWhenEmpty && total === 0) {
                 return null;
             }
-            return raw ? String(total) : `Skills: ${total}`;
+            return raw ? String(total) : `Tools: ${total}`;
         }
 
-        const uniqueSkills = context.skillsMetrics?.uniqueSkills ?? [];
-        if (uniqueSkills.length === 0) {
+        const filtered = this.getScopedUniqueTools(context, scope);
+        if (filtered.length === 0) {
             if (hideWhenEmpty) {
                 return null;
             }
-            return raw ? 'none' : 'Skills: none';
+            return raw ? 'none' : 'Tools: none';
         }
 
         const limit = parseListLimit(item);
-        const visibleSkills = limit > 0 ? uniqueSkills.slice(0, limit) : uniqueSkills;
-        const list = visibleSkills.join(', ');
-        return raw ? list : `Skills: ${list}`;
+        const visibleTools = limit > 0 ? filtered.slice(0, limit) : filtered;
+        const list = visibleTools.join(', ');
+        return raw ? list : `Tools: ${list}`;
+    }
+
+    private getScopedTotal(context: RenderContext, scope: Scope): number {
+        const metrics = context.toolCountMetrics;
+        if (!metrics) {
+            return 0;
+        }
+        if (scope === 'all') {
+            return metrics.totalInvocations;
+        }
+        return metrics.byCategory[scope];
+    }
+
+    private getScopedUniqueTools(context: RenderContext, scope: Scope): string[] {
+        const metrics = context.toolCountMetrics;
+        if (!metrics) {
+            return [];
+        }
+
+        interface Entry {
+            name: string;
+            count: number;
+            isMcp: boolean;
+        }
+        const builtinEntries: Entry[] = Object.entries(metrics.byTool)
+            .filter(([name]) => !name.startsWith('mcp__'))
+            .map(([name, count]) => ({ name, count, isMcp: false }));
+
+        const mcpCount = metrics.byCategory.mcp;
+        const mcpEntry: Entry | null = mcpCount > 0
+            ? { name: 'MCP', count: mcpCount, isMcp: true }
+            : null;
+
+        let entries: Entry[];
+        if (scope === 'builtin') {
+            entries = builtinEntries;
+        } else if (scope === 'mcp') {
+            entries = mcpEntry ? [mcpEntry] : [];
+        } else {
+            entries = mcpEntry ? [...builtinEntries, mcpEntry] : builtinEntries;
+        }
+
+        entries.sort((a, b) => {
+            if (b.count !== a.count) {
+                return b.count - a.count;
+            }
+            if (a.isMcp !== b.isMcp) {
+                return a.isMcp ? 1 : -1;
+            }
+            return a.name.localeCompare(b.name);
+        });
+
+        return entries.map(e => `${e.name} * ${e.count}`);
     }
 
     private getMode(item: WidgetItem): Mode {
@@ -171,12 +243,17 @@ export class SkillsWidget implements Widget {
         return mode && MODES.includes(mode as Mode) ? mode as Mode : 'current';
     }
 
+    private getScope(item: WidgetItem): Scope {
+        const scope = item.metadata?.[SCOPE_KEY];
+        return scope && SCOPES.includes(scope as Scope) ? scope as Scope : 'all';
+    }
+
     private isHideWhenEmptyEnabled(item: WidgetItem): boolean {
         return isMetadataFlagEnabled(item, HIDE_WHEN_EMPTY_KEY);
     }
 }
 
-const SkillsEditor: React.FC<WidgetEditorProps> = ({ widget, onComplete, onCancel, action }) => {
+const ToolCountEditor: React.FC<WidgetEditorProps> = ({ widget, onComplete, onCancel, action }) => {
     const [limitInput, setLimitInput] = useState(() => parseListLimit(widget).toString());
 
     useInput((input, key) => {
@@ -201,7 +278,7 @@ const SkillsEditor: React.FC<WidgetEditorProps> = ({ widget, onComplete, onCance
         return (
             <Box flexDirection='column'>
                 <Box>
-                    <Text>Enter max skills to show (0 for unlimited): </Text>
+                    <Text>Enter max tools to show (0 for unlimited): </Text>
                     <Text>{limitInput}</Text>
                     <Text backgroundColor='gray' color='black'>{' '}</Text>
                 </Box>

--- a/src/widgets/ToolCount.tsx
+++ b/src/widgets/ToolCount.tsx
@@ -29,9 +29,9 @@ import {
 type Mode = 'current' | 'count' | 'list' | 'activity';
 const MODES: Mode[] = ['current', 'count', 'list', 'activity'];
 const MODE_LABELS: Record<Mode, string> = {
-    current: 'last used',
-    count: 'total count',
-    list: 'unique list',
+    current: 'current',
+    count: 'count',
+    list: 'list',
     activity: 'activity'
 };
 
@@ -42,9 +42,11 @@ const SCOPES: Scope[] = ['all', 'builtin', 'mcp'];
 const SCOPE_LABELS: Record<Scope, string> = { all: 'all', builtin: 'builtin', mcp: 'mcp' };
 
 const HIDE_WHEN_EMPTY_KEY = 'hideWhenEmpty';
+const HIDE_COMPLETED_KEY = 'hideCompleted';
 const LIST_LIMIT_KEY = 'listLimit';
 const SCOPE_KEY = 'scope';
 const TOGGLE_HIDE_EMPTY_ACTION = 'toggle-hide-empty';
+const TOGGLE_HIDE_COMPLETED_ACTION = 'toggle-hide-completed';
 const EDIT_LIST_LIMIT_ACTION = 'edit-list-limit';
 const CYCLE_SCOPE_ACTION = 'cycle-scope';
 
@@ -95,7 +97,7 @@ export class ToolCountWidget implements Widget {
 
     getCustomKeybinds(item?: WidgetItem): CustomKeybind[] {
         const keybinds: CustomKeybind[] = [
-            { key: 'v', label: '(v)iew: last/count/list/activity', action: 'cycle-mode' },
+            { key: 'v', label: '(v)iew: current/count/list/activity', action: 'cycle-mode' },
             { key: 's', label: '(s)cope: all/builtin/mcp', action: CYCLE_SCOPE_ACTION },
             { key: 'h', label: '(h)ide when empty', action: TOGGLE_HIDE_EMPTY_ACTION }
         ];
@@ -104,6 +106,9 @@ export class ToolCountWidget implements Widget {
             const mode = this.getMode(item);
             if (mode === 'list' || mode === 'activity') {
                 keybinds.push({ key: 'l', label: '(l)imit', action: EDIT_LIST_LIMIT_ACTION });
+            }
+            if (mode === 'activity') {
+                keybinds.push({ key: 'r', label: '(r)unning only', action: TOGGLE_HIDE_COMPLETED_ACTION });
             }
         }
 
@@ -122,6 +127,9 @@ export class ToolCountWidget implements Widget {
             if (limit > 0) {
                 modifiers.push(`limit: ${limit}`);
             }
+        }
+        if (mode === 'activity' && this.shouldHideCompleted(item)) {
+            modifiers.push('running only');
         }
         if (this.isHideWhenEmptyEnabled(item)) {
             modifiers.push('hide when empty');
@@ -142,6 +150,9 @@ export class ToolCountWidget implements Widget {
                 return removeMetadataKeys(item, [SCOPE_KEY]);
             }
             return { ...item, metadata: { ...item.metadata, [SCOPE_KEY]: next } };
+        }
+        if (action === TOGGLE_HIDE_COMPLETED_ACTION) {
+            return toggleMetadataFlag(item, HIDE_COMPLETED_KEY);
         }
         if (action === TOGGLE_HIDE_EMPTY_ACTION) {
             return toggleMetadataFlag(item, HIDE_WHEN_EMPTY_KEY);
@@ -194,7 +205,7 @@ export class ToolCountWidget implements Widget {
         }
 
         if (mode === 'activity') {
-            const body = this.renderActivity(context, scope, parseListLimit(item));
+            const body = this.renderActivity(context, scope, parseListLimit(item), this.shouldHideCompleted(item));
             if (body === null) {
                 if (hideWhenEmpty)
                     return null;
@@ -219,7 +230,7 @@ export class ToolCountWidget implements Widget {
         return raw ? list : `Tools: ${list}`;
     }
 
-    private renderActivity(context: RenderContext, scope: Scope, configuredLimit: number): string | null {
+    private renderActivity(context: RenderContext, scope: Scope, configuredLimit: number, hideCompleted: boolean): string | null {
         const entries = context.toolCountMetrics?.activity ?? [];
         const filtered = entries.filter((e) => {
             if (e.tool_name === 'Agent')
@@ -239,7 +250,7 @@ export class ToolCountWidget implements Widget {
         for (const entry of filtered) {
             if (entry.status === 'running') {
                 running.push(entry);
-            } else {
+            } else if (!hideCompleted) {
                 completedCounts.set(entry.tool_name, (completedCounts.get(entry.tool_name) ?? 0) + 1);
                 const endMs = entry.endTime?.getTime() ?? entry.startTime.getTime();
                 lastEnd.set(entry.tool_name, Math.max(lastEnd.get(entry.tool_name) ?? 0, endMs));
@@ -332,6 +343,10 @@ export class ToolCountWidget implements Widget {
 
     private isHideWhenEmptyEnabled(item: WidgetItem): boolean {
         return isMetadataFlagEnabled(item, HIDE_WHEN_EMPTY_KEY);
+    }
+
+    private shouldHideCompleted(item: WidgetItem): boolean {
+        return isMetadataFlagEnabled(item, HIDE_COMPLETED_KEY);
     }
 }
 

--- a/src/widgets/ToolCount.tsx
+++ b/src/widgets/ToolCount.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
+import type { ToolActivityEntry } from '../types/ToolCountMetrics';
 import type {
     CustomKeybind,
     Widget,
@@ -16,6 +17,7 @@ import type {
 } from '../types/Widget';
 import type { WidgetHookDef } from '../utils/hooks';
 import { shouldInsertInput } from '../utils/input-guards';
+import { basename } from '../utils/tool-count';
 
 import { makeModifierText } from './shared/editor-display';
 import {
@@ -24,9 +26,16 @@ import {
     toggleMetadataFlag
 } from './shared/metadata';
 
-type Mode = 'current' | 'count' | 'list';
-const MODES: Mode[] = ['current', 'count', 'list'];
-const MODE_LABELS: Record<Mode, string> = { current: 'last used', count: 'total count', list: 'unique list' };
+type Mode = 'current' | 'count' | 'list' | 'activity';
+const MODES: Mode[] = ['current', 'count', 'list', 'activity'];
+const MODE_LABELS: Record<Mode, string> = {
+    current: 'last used',
+    count: 'total count',
+    list: 'unique list',
+    activity: 'activity'
+};
+
+const ACTIVITY_TOP_DEFAULT = 3;
 
 type Scope = 'all' | 'builtin' | 'mcp';
 const SCOPES: Scope[] = ['all', 'builtin', 'mcp'];
@@ -74,33 +83,41 @@ export class ToolCountWidget implements Widget {
     supportsRawValue(): boolean { return true; }
     supportsColors(): boolean { return true; }
 
-    // PreToolUse (not PostToolUse) so the count updates before the next render.
+    // PreToolUse drives current/count/list; PostToolUse adds end events that pair
+    // with start events to power `activity` mode's running/completed distinction.
     // Shared/deduped with Skills' PreToolUse hook; handleHook routes by tool_name.
     getHooks(): WidgetHookDef[] {
-        return [{ event: 'PreToolUse' }];
+        return [
+            { event: 'PreToolUse' },
+            { event: 'PostToolUse' }
+        ];
     }
 
     getCustomKeybinds(item?: WidgetItem): CustomKeybind[] {
         const keybinds: CustomKeybind[] = [
-            { key: 'v', label: '(v)iew: last/count/list', action: 'cycle-mode' },
+            { key: 'v', label: '(v)iew: last/count/list/activity', action: 'cycle-mode' },
             { key: 's', label: '(s)cope: all/builtin/mcp', action: CYCLE_SCOPE_ACTION },
             { key: 'h', label: '(h)ide when empty', action: TOGGLE_HIDE_EMPTY_ACTION }
         ];
 
-        if (item && this.getMode(item) === 'list') {
-            keybinds.push({ key: 'l', label: '(l)imit', action: EDIT_LIST_LIMIT_ACTION });
+        if (item) {
+            const mode = this.getMode(item);
+            if (mode === 'list' || mode === 'activity') {
+                keybinds.push({ key: 'l', label: '(l)imit', action: EDIT_LIST_LIMIT_ACTION });
+            }
         }
 
         return keybinds;
     }
 
     getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
-        const modifiers = [MODE_LABELS[this.getMode(item)]];
+        const mode = this.getMode(item);
+        const modifiers = [MODE_LABELS[mode]];
         const scope = this.getScope(item);
         if (scope !== 'all') {
             modifiers.push(`scope: ${SCOPE_LABELS[scope]}`);
         }
-        if (this.getMode(item) === 'list') {
+        if (mode === 'list' || mode === 'activity') {
             const limit = parseListLimit(item);
             if (limit > 0) {
                 modifiers.push(`limit: ${limit}`);
@@ -115,7 +132,8 @@ export class ToolCountWidget implements Widget {
     handleEditorAction(action: string, item: WidgetItem): WidgetItem | null {
         if (action === 'cycle-mode') {
             const next = MODES[(MODES.indexOf(this.getMode(item)) + 1) % MODES.length] ?? 'current';
-            const nextItem = next === 'list' ? item : removeMetadataKeys(item, [LIST_LIMIT_KEY]);
+            const keepsLimit = next === 'list' || next === 'activity';
+            const nextItem = keepsLimit ? item : removeMetadataKeys(item, [LIST_LIMIT_KEY]);
             return { ...nextItem, metadata: { ...nextItem.metadata, mode: next } };
         }
         if (action === CYCLE_SCOPE_ACTION) {
@@ -148,6 +166,10 @@ export class ToolCountWidget implements Widget {
             if (mode === 'count') {
                 return raw ? '42' : 'Tools: 42';
             }
+            if (mode === 'activity') {
+                const preview = '◐ Edit: auth.ts | ✓ Read ×3 | ✓ Bash ×2';
+                return raw ? preview : `Tools: ${preview}`;
+            }
             const preview = 'Bash * 5, Edit * 4, Read * 2, MCP * 1';
             return raw ? preview : `Tools: ${preview}`;
         }
@@ -171,6 +193,18 @@ export class ToolCountWidget implements Widget {
             return raw ? String(total) : `Tools: ${total}`;
         }
 
+        if (mode === 'activity') {
+            const body = this.renderActivity(context, scope, parseListLimit(item));
+            if (body === null) {
+                if (hideWhenEmpty)
+                    return null;
+                return raw ? '' : 'Tools: none';
+            }
+            // Intentional: keep ◐/✓ icons even under rawValue — they are the only
+            // running/completed signal (×N is completed-only, :target is running-only).
+            return raw ? body : `Tools: ${body}`;
+        }
+
         const filtered = this.getScopedUniqueTools(context, scope);
         if (filtered.length === 0) {
             if (hideWhenEmpty) {
@@ -183,6 +217,54 @@ export class ToolCountWidget implements Widget {
         const visibleTools = limit > 0 ? filtered.slice(0, limit) : filtered;
         const list = visibleTools.join(', ');
         return raw ? list : `Tools: ${list}`;
+    }
+
+    private renderActivity(context: RenderContext, scope: Scope, configuredLimit: number): string | null {
+        const entries = context.toolCountMetrics?.activity ?? [];
+        const filtered = entries.filter((e) => {
+            if (e.tool_name === 'Agent')
+                return false;
+            if (scope === 'all')
+                return true;
+            if (scope === 'mcp')
+                return e.category === 'mcp';
+            return e.category === 'builtin';
+        });
+        if (filtered.length === 0)
+            return null;
+
+        const running: ToolActivityEntry[] = [];
+        const completedCounts = new Map<string, number>();
+        const lastEnd = new Map<string, number>();
+        for (const entry of filtered) {
+            if (entry.status === 'running') {
+                running.push(entry);
+            } else {
+                completedCounts.set(entry.tool_name, (completedCounts.get(entry.tool_name) ?? 0) + 1);
+                const endMs = entry.endTime?.getTime() ?? entry.startTime.getTime();
+                lastEnd.set(entry.tool_name, Math.max(lastEnd.get(entry.tool_name) ?? 0, endMs));
+            }
+        }
+
+        const topLimit = configuredLimit > 0 ? configuredLimit : ACTIVITY_TOP_DEFAULT;
+        const topCompleted = [...completedCounts.entries()]
+            .sort((a, b) => {
+                if (b[1] !== a[1])
+                    return b[1] - a[1];
+                return (lastEnd.get(b[0]) ?? 0) - (lastEnd.get(a[0]) ?? 0);
+            })
+            .slice(0, topLimit);
+
+        const runningParts = running.map((r) => {
+            const targetPart = r.target ? `: ${basename(r.target)}` : '';
+            return `◐ ${r.tool_name}${targetPart}`;
+        });
+        const completedParts = topCompleted.map(([name, count]) => (
+            count > 1 ? `✓ ${name} ×${count}` : `✓ ${name}`
+        ));
+
+        const parts = [...runningParts, ...completedParts];
+        return parts.length > 0 ? parts.join(' | ') : null;
     }
 
     private getScopedTotal(context: RenderContext, scope: Scope): number {

--- a/src/widgets/__tests__/AgentActivity.test.ts
+++ b/src/widgets/__tests__/AgentActivity.test.ts
@@ -30,10 +30,10 @@ describe('AgentActivityWidget — identity', () => {
         )).toBe(true);
     });
 
-    it('registers PreToolUse and PostToolUse hooks for Task', () => {
+    it('registers PreToolUse and PostToolUse hooks for Agent', () => {
         expect(widget.getHooks()).toEqual([
-            { event: 'PreToolUse', matcher: 'Task' },
-            { event: 'PostToolUse', matcher: 'Task' }
+            { event: 'PreToolUse', matcher: 'Agent' },
+            { event: 'PostToolUse', matcher: 'Agent' }
         ]);
     });
 });

--- a/src/widgets/__tests__/AgentActivity.test.ts
+++ b/src/widgets/__tests__/AgentActivity.test.ts
@@ -11,6 +11,7 @@ import type { WidgetItem } from '../../types/Widget';
 import {
     AgentActivityWidget,
     applyLimit,
+    dropStaleCompleted,
     filterByMode,
     formatAgent,
     formatElapsed,
@@ -30,10 +31,11 @@ describe('AgentActivityWidget — identity', () => {
         )).toBe(true);
     });
 
-    it('registers PreToolUse and PostToolUse hooks for Agent', () => {
+    it('registers Agent Pre/Post hooks plus UserPromptSubmit turn marker', () => {
         expect(widget.getHooks()).toEqual([
             { event: 'PreToolUse', matcher: 'Agent' },
-            { event: 'PostToolUse', matcher: 'Agent' }
+            { event: 'PostToolUse', matcher: 'Agent' },
+            { event: 'UserPromptSubmit' }
         ]);
     });
 });
@@ -195,6 +197,41 @@ describe('applyLimit', () => {
 
     it('returns all entries when agents.length <= limit', () => {
         expect(applyLimit(agents(2), 5).map(a => a.id)).toEqual(['a0', 'a1']);
+    });
+});
+
+describe('dropStaleCompleted', () => {
+    const now = new Date('2026-04-19T10:30:00.000Z');
+
+    it('returns input unchanged when staleMinutes=0', () => {
+        const input: AgentEntry[] = [
+            { id: 'a', type: 't', status: 'completed', startTime: new Date(0), endTime: new Date(0) }
+        ];
+        expect(dropStaleCompleted(input, 0, now)).toEqual(input);
+    });
+
+    it('drops completed agents older than staleMinutes', () => {
+        const input: AgentEntry[] = [
+            { id: 'old', type: 't', status: 'completed', startTime: new Date('2026-04-19T09:00:00Z'), endTime: new Date('2026-04-19T09:05:00Z') },
+            { id: 'new', type: 't', status: 'completed', startTime: new Date('2026-04-19T10:20:00Z'), endTime: new Date('2026-04-19T10:25:00Z') }
+        ];
+        // 30 minute threshold: 'old' ended ~85 min ago → purged; 'new' ended 5 min ago → kept
+        expect(dropStaleCompleted(input, 30, now).map(a => a.id)).toEqual(['new']);
+    });
+
+    it('always keeps running agents regardless of age', () => {
+        const input: AgentEntry[] = [
+            { id: 'old-running', type: 't', status: 'running', startTime: new Date('2026-04-19T00:00:00Z') }
+        ];
+        expect(dropStaleCompleted(input, 30, now)).toEqual(input);
+    });
+
+    it('uses startTime fallback when endTime undefined', () => {
+        const input: AgentEntry[] = [
+            // completed but missing endTime — treat startTime as the reference
+            { id: 'malformed', type: 't', status: 'completed', startTime: new Date('2026-04-19T09:00:00Z') }
+        ];
+        expect(dropStaleCompleted(input, 30, now)).toEqual([]);
     });
 });
 
@@ -411,30 +448,33 @@ describe('AgentActivityWidget.getCustomKeybinds', () => {
         }
     });
 
-    it('includes l and u keys in activity mode (default)', () => {
+    it('includes l, u, and s keys in activity mode (default)', () => {
         const keys = widget.getCustomKeybinds(base).map(k => k.key);
-        expect(keys).toEqual(['v', 'o', 't', 'e', 'h', 'l', 'u']);
+        expect(keys).toEqual(['v', 'o', 't', 'e', 'h', 'l', 'u', 's']);
     });
 
-    it('includes l but not u key in list mode', () => {
+    it('includes l and s but not u key in list mode', () => {
         const item = { ...base, metadata: { mode: 'list' } };
         const keys = widget.getCustomKeybinds(item).map(k => k.key);
         expect(keys).toContain('l');
+        expect(keys).toContain('s');
         expect(keys).not.toContain('u');
     });
 
-    it('omits l and u keys in current mode', () => {
+    it('omits l and u but keeps s in current mode', () => {
         const item = { ...base, metadata: { mode: 'current' } };
         const keys = widget.getCustomKeybinds(item).map(k => k.key);
         expect(keys).not.toContain('l');
         expect(keys).not.toContain('u');
+        expect(keys).toContain('s');
     });
 
-    it('omits l and u keys in count mode', () => {
+    it('omits l and u but keeps s in count mode', () => {
         const item = { ...base, metadata: { mode: 'count' } };
         const keys = widget.getCustomKeybinds(item).map(k => k.key);
         expect(keys).not.toContain('l');
         expect(keys).not.toContain('u');
+        expect(keys).toContain('s');
     });
 
     it('includes expected actions', () => {

--- a/src/widgets/__tests__/AgentActivity.test.ts
+++ b/src/widgets/__tests__/AgentActivity.test.ts
@@ -148,23 +148,29 @@ describe('filterByMode', () => {
         }));
     }
 
-    it('active returns only running agents', () => {
+    it('current returns a single-element array with the latest agent', () => {
         const input = agents(['running', 'completed', 'running']);
-        expect(filterByMode(input, 'active').map(a => a.id)).toEqual(['a0', 'a2']);
+        expect(filterByMode(input, 'current').map(a => a.id)).toEqual(['a2']);
     });
 
-    it('last returns a single-element array with the latest agent', () => {
-        const input = agents(['running', 'completed', 'running']);
-        expect(filterByMode(input, 'last').map(a => a.id)).toEqual(['a2']);
+    it('current returns empty array when no agents', () => {
+        expect(filterByMode([], 'current')).toEqual([]);
     });
 
-    it('last returns empty array when no agents', () => {
-        expect(filterByMode([], 'last')).toEqual([]);
+    it('activity returns the input unchanged when hideCompleted=false', () => {
+        const input = agents(['running', 'completed', 'running']);
+        expect(filterByMode(input, 'activity')).toEqual(input);
     });
 
-    it('mixed returns the input unchanged', () => {
+    it('activity with hideCompleted=true returns only running agents', () => {
         const input = agents(['running', 'completed', 'running']);
-        expect(filterByMode(input, 'mixed')).toEqual(input);
+        expect(filterByMode(input, 'activity', true).map(a => a.id)).toEqual(['a0', 'a2']);
+    });
+
+    it('count/list return all agents (aggregation handled in render)', () => {
+        const input = agents(['running', 'completed']);
+        expect(filterByMode(input, 'count')).toEqual(input);
+        expect(filterByMode(input, 'list')).toEqual(input);
     });
 });
 
@@ -221,7 +227,7 @@ describe('AgentActivityWidget.render — core modes', () => {
         endTime: new Date(Date.now() - 40_000)
     };
 
-    it('mixed mode joins with " | " and includes label', () => {
+    it('activity mode (default) joins with " | " and mixes running + completed', () => {
         const ctx = makeContext([runningAgent, completedAgent]);
         const output = widget.render(item, ctx, DEFAULT_SETTINGS);
         expect(output).toMatch(/^Agents: /);
@@ -230,21 +236,62 @@ describe('AgentActivityWidget.render — core modes', () => {
         expect(output).toContain('✓ code-reviewer');
     });
 
-    it('active mode joins with ", " and only contains running', () => {
+    it('activity mode with hideCompleted joins with ", " and only shows running', () => {
         const ctx = makeContext([runningAgent, completedAgent]);
-        const activeItem: WidgetItem = { ...item, metadata: { mode: 'active' } };
-        const output = widget.render(activeItem, ctx, DEFAULT_SETTINGS);
+        const runningOnly: WidgetItem = { ...item, metadata: { mode: 'activity', hideCompleted: 'true' } };
+        const output = widget.render(runningOnly, ctx, DEFAULT_SETTINGS);
         expect(output).toMatch(/^Agents: /);
         expect(output).not.toContain(' | ');
         expect(output).not.toContain('✓');
         expect(output).toContain('◐ explore');
     });
 
-    it('last mode shows one agent', () => {
+    it('current mode shows one agent (latest)', () => {
         const ctx = makeContext([runningAgent, completedAgent]);
-        const lastItem: WidgetItem = { ...item, metadata: { mode: 'last' } };
-        const output = widget.render(lastItem, ctx, DEFAULT_SETTINGS);
+        const currentItem: WidgetItem = { ...item, metadata: { mode: 'current' } };
+        const output = widget.render(currentItem, ctx, DEFAULT_SETTINGS);
         expect(output).toMatch(/^Agents: /);
+        expect(output).toContain('code-reviewer');
+        expect(output).not.toContain('explore');
+    });
+
+    it('count mode shows total agent count', () => {
+        const ctx = makeContext([runningAgent, completedAgent]);
+        const countItem: WidgetItem = { ...item, metadata: { mode: 'count' } };
+        expect(widget.render(countItem, ctx, DEFAULT_SETTINGS)).toBe('Agents: 2');
+    });
+
+    it('list mode aggregates by type and sorts by count desc', () => {
+        const extra: AgentEntry = { ...runningAgent, id: 'r2' };
+        const ctx = makeContext([runningAgent, completedAgent, extra]);
+        const listItem: WidgetItem = { ...item, metadata: { mode: 'list' } };
+        expect(widget.render(listItem, ctx, DEFAULT_SETTINGS))
+            .toBe('Agents: explore ×2, code-reviewer ×1');
+    });
+});
+
+describe('AgentActivityWidget.render — legacy metadata', () => {
+    const widget = new AgentActivityWidget();
+    const runningAgent: AgentEntry = { id: 'r1', type: 'explore', status: 'running', startTime: new Date(Date.now() - 1000) };
+    const completedAgent: AgentEntry = { id: 'c1', type: 'code-reviewer', status: 'completed', startTime: new Date(Date.now() - 3000), endTime: new Date(Date.now() - 2000) };
+
+    it('maps legacy mode "mixed" to activity', () => {
+        const legacy: WidgetItem = { id: 'a', type: 'agent-activity', metadata: { mode: 'mixed' } };
+        const output = widget.render(legacy, makeContext([runningAgent, completedAgent]), DEFAULT_SETTINGS);
+        expect(output).toContain('◐ explore');
+        expect(output).toContain('✓ code-reviewer');
+    });
+
+    it('maps legacy mode "active" to activity + hideCompleted', () => {
+        const legacy: WidgetItem = { id: 'a', type: 'agent-activity', metadata: { mode: 'active' } };
+        const output = widget.render(legacy, makeContext([runningAgent, completedAgent]), DEFAULT_SETTINGS);
+        expect(output).toContain('◐ explore');
+        expect(output).not.toContain('✓');
+    });
+
+    it('maps legacy mode "last" to current', () => {
+        const legacy: WidgetItem = { id: 'a', type: 'agent-activity', metadata: { mode: 'last' } };
+        const output = widget.render(legacy, makeContext([runningAgent, completedAgent]), DEFAULT_SETTINGS);
         expect(output).toContain('code-reviewer');
         expect(output).not.toContain('explore');
     });
@@ -290,12 +337,26 @@ describe('AgentActivityWidget.render — rawValue and empty', () => {
         expect(widget.render(item, makeContext([]), DEFAULT_SETTINGS))
             .toBe('');
     });
+
+    it('count mode returns "Agents: 0" when no agents (hideWhenEmpty off)', () => {
+        const item: WidgetItem = { id: 'a', type: 'agent-activity', metadata: { mode: 'count' } };
+        expect(widget.render(item, makeContext([]), DEFAULT_SETTINGS)).toBe('Agents: 0');
+    });
+
+    it('count mode with hideWhenEmpty returns null when 0', () => {
+        const item: WidgetItem = {
+            id: 'a',
+            type: 'agent-activity',
+            metadata: { mode: 'count', hideWhenEmpty: 'true' }
+        };
+        expect(widget.render(item, makeContext([]), DEFAULT_SETTINGS)).toBeNull();
+    });
 });
 
 describe('AgentActivityWidget.render — preview', () => {
     const widget = new AgentActivityWidget();
 
-    it('mixed preview contains both running and completed samples', () => {
+    it('activity preview contains both running and completed samples', () => {
         const item: WidgetItem = { id: 'a', type: 'agent-activity' };
         const output = widget.render(item, makeContext([], true), DEFAULT_SETTINGS) ?? '';
         expect(output).toMatch(/^Agents: /);
@@ -303,18 +364,29 @@ describe('AgentActivityWidget.render — preview', () => {
         expect(output).toContain('✓ code-reviewer');
     });
 
-    it('active preview contains only running sample', () => {
-        const item: WidgetItem = { id: 'a', type: 'agent-activity', metadata: { mode: 'active' } };
+    it('activity preview with hideCompleted contains only running sample', () => {
+        const item: WidgetItem = { id: 'a', type: 'agent-activity', metadata: { hideCompleted: 'true' } };
         const output = widget.render(item, makeContext([], true), DEFAULT_SETTINGS) ?? '';
         expect(output).toContain('◐ explore');
         expect(output).not.toContain('✓');
     });
 
-    it('last preview contains one completed sample', () => {
-        const item: WidgetItem = { id: 'a', type: 'agent-activity', metadata: { mode: 'last' } };
+    it('current preview shows one completed sample', () => {
+        const item: WidgetItem = { id: 'a', type: 'agent-activity', metadata: { mode: 'current' } };
         const output = widget.render(item, makeContext([], true), DEFAULT_SETTINGS) ?? '';
         expect(output).toContain('✓ code-reviewer');
         expect(output).not.toContain('◐');
+    });
+
+    it('count preview shows a numeric sample', () => {
+        const item: WidgetItem = { id: 'a', type: 'agent-activity', metadata: { mode: 'count' } };
+        expect(widget.render(item, makeContext([], true), DEFAULT_SETTINGS)).toBe('Agents: 3');
+    });
+
+    it('list preview shows aggregated sample', () => {
+        const item: WidgetItem = { id: 'a', type: 'agent-activity', metadata: { mode: 'list' } };
+        expect(widget.render(item, makeContext([], true), DEFAULT_SETTINGS))
+            .toBe('Agents: explore ×2, code-reviewer ×1');
     });
 
     it('rawValue preview omits "Agents:" prefix', () => {
@@ -328,21 +400,30 @@ describe('AgentActivityWidget.getCustomKeybinds', () => {
     const widget = new AgentActivityWidget();
     const base: WidgetItem = { id: 'a', type: 'agent-activity' };
 
-    it('includes l key when mode is mixed', () => {
+    it('includes l and r keys in activity mode (default)', () => {
         const keys = widget.getCustomKeybinds(base).map(k => k.key);
-        expect(keys).toEqual(['v', 'm', 'd', 'e', 'h', 'l']);
+        expect(keys).toEqual(['v', 'm', 'd', 'e', 'h', 'l', 'r']);
     });
 
-    it('includes l key when mode is active', () => {
-        const item = { ...base, metadata: { mode: 'active' } };
+    it('includes l but not r key in list mode', () => {
+        const item = { ...base, metadata: { mode: 'list' } };
         const keys = widget.getCustomKeybinds(item).map(k => k.key);
         expect(keys).toContain('l');
+        expect(keys).not.toContain('r');
     });
 
-    it('omits l key when mode is last', () => {
-        const item = { ...base, metadata: { mode: 'last' } };
+    it('omits l and r keys in current mode', () => {
+        const item = { ...base, metadata: { mode: 'current' } };
         const keys = widget.getCustomKeybinds(item).map(k => k.key);
         expect(keys).not.toContain('l');
+        expect(keys).not.toContain('r');
+    });
+
+    it('omits l and r keys in count mode', () => {
+        const item = { ...base, metadata: { mode: 'count' } };
+        const keys = widget.getCustomKeybinds(item).map(k => k.key);
+        expect(keys).not.toContain('l');
+        expect(keys).not.toContain('r');
     });
 
     it('includes expected actions', () => {
@@ -352,6 +433,7 @@ describe('AgentActivityWidget.getCustomKeybinds', () => {
         expect(actions).toContain('toggle-hide-model');
         expect(actions).toContain('toggle-hide-description');
         expect(actions).toContain('toggle-hide-elapsed');
+        expect(actions).toContain('toggle-hide-completed');
         expect(actions).toContain('toggle-hide-empty');
         expect(actions).toContain('edit-limit');
     });
@@ -361,13 +443,16 @@ describe('AgentActivityWidget.handleEditorAction', () => {
     const widget = new AgentActivityWidget();
     const base: WidgetItem = { id: 'a', type: 'agent-activity' };
 
-    it('cycle-mode progresses mixed → active → last → mixed', () => {
+    it('cycle-mode progresses activity → current → count → list → activity', () => {
+        // default mode is 'activity'
         const a = widget.handleEditorAction('cycle-mode', base);
-        expect(a?.metadata?.mode).toBe('active');
+        expect(a?.metadata?.mode).toBe('current');
         const b = widget.handleEditorAction('cycle-mode', a ?? base);
-        expect(b?.metadata?.mode).toBe('last');
+        expect(b?.metadata?.mode).toBe('count');
         const c = widget.handleEditorAction('cycle-mode', b ?? base);
-        expect(c?.metadata?.mode).toBe('mixed');
+        expect(c?.metadata?.mode).toBe('list');
+        const d = widget.handleEditorAction('cycle-mode', c ?? base);
+        expect(d?.metadata?.mode).toBe('activity');
     });
 
     it('toggle-hide-model flips flag', () => {
@@ -387,6 +472,11 @@ describe('AgentActivityWidget.handleEditorAction', () => {
         expect(a?.metadata?.hideElapsed).toBe('true');
     });
 
+    it('toggle-hide-completed flips flag', () => {
+        const a = widget.handleEditorAction('toggle-hide-completed', base);
+        expect(a?.metadata?.hideCompleted).toBe('true');
+    });
+
     it('toggle-hide-empty flips flag', () => {
         const a = widget.handleEditorAction('toggle-hide-empty', base);
         expect(a?.metadata?.hideWhenEmpty).toBe('true');
@@ -400,28 +490,48 @@ describe('AgentActivityWidget.handleEditorAction', () => {
 describe('AgentActivityWidget.getEditorDisplay', () => {
     const widget = new AgentActivityWidget();
 
-    it('shows only mode when no other modifiers', () => {
+    it('shows activity label by default', () => {
         const display = widget.getEditorDisplay({ id: 'a', type: 'agent-activity' });
         expect(display.displayText).toBe('Agent Activity');
-        expect(display.modifierText).toBe('(mixed)');
+        expect(display.modifierText).toBe('(activity)');
     });
 
-    it('shows explicit mode', () => {
+    it('shows current label for current mode', () => {
+        const display = widget.getEditorDisplay({ id: 'a', type: 'agent-activity', metadata: { mode: 'current' } });
+        expect(display.modifierText).toBe('(current)');
+    });
+
+    it('shows count label for count mode', () => {
+        const display = widget.getEditorDisplay({ id: 'a', type: 'agent-activity', metadata: { mode: 'count' } });
+        expect(display.modifierText).toBe('(count)');
+    });
+
+    it('shows list label for list mode', () => {
+        const display = widget.getEditorDisplay({ id: 'a', type: 'agent-activity', metadata: { mode: 'list' } });
+        expect(display.modifierText).toBe('(list)');
+    });
+
+    it('appends running only when hideCompleted set on activity mode', () => {
         const display = widget.getEditorDisplay({
             id: 'a',
             type: 'agent-activity',
-            metadata: { mode: 'active' }
+            metadata: { mode: 'activity', hideCompleted: 'true' }
         });
-        expect(display.modifierText).toBe('(active)');
+        expect(display.modifierText).toBe('(activity, running only)');
     });
 
-    it('appends limit when non-default', () => {
+    it('legacy mode=active resolves to activity + running only', () => {
+        const display = widget.getEditorDisplay({ id: 'a', type: 'agent-activity', metadata: { mode: 'active' } });
+        expect(display.modifierText).toBe('(activity, running only)');
+    });
+
+    it('appends limit when non-default in activity mode', () => {
         const display = widget.getEditorDisplay({
             id: 'a',
             type: 'agent-activity',
             metadata: { limit: '5' }
         });
-        expect(display.modifierText).toBe('(mixed, limit: 5)');
+        expect(display.modifierText).toBe('(activity, limit: 5)');
     });
 
     it('shows limit: ∞ when limit is 0', () => {
@@ -430,7 +540,7 @@ describe('AgentActivityWidget.getEditorDisplay', () => {
             type: 'agent-activity',
             metadata: { limit: '0' }
         });
-        expect(display.modifierText).toBe('(mixed, limit: ∞)');
+        expect(display.modifierText).toBe('(activity, limit: ∞)');
     });
 
     it('omits limit modifier when limit equals default (3)', () => {
@@ -439,7 +549,14 @@ describe('AgentActivityWidget.getEditorDisplay', () => {
             type: 'agent-activity',
             metadata: { limit: '3' }
         });
-        expect(display.modifierText).toBe('(mixed)');
+        expect(display.modifierText).toBe('(activity)');
+    });
+
+    it('omits limit modifier in count or current modes', () => {
+        const count = widget.getEditorDisplay({ id: 'a', type: 'agent-activity', metadata: { mode: 'count', limit: '5' } });
+        expect(count.modifierText).toBe('(count)');
+        const current = widget.getEditorDisplay({ id: 'a', type: 'agent-activity', metadata: { mode: 'current', limit: '5' } });
+        expect(current.modifierText).toBe('(current)');
     });
 
     it('appends hideXxx flags', () => {
@@ -452,7 +569,7 @@ describe('AgentActivityWidget.getEditorDisplay', () => {
                 hideElapsed: 'true'
             }
         });
-        expect(display.modifierText).toBe('(mixed, no model, no desc, no elapsed)');
+        expect(display.modifierText).toBe('(activity, no model, no desc, no elapsed)');
     });
 
     it('appends hide when empty', () => {
@@ -461,6 +578,6 @@ describe('AgentActivityWidget.getEditorDisplay', () => {
             type: 'agent-activity',
             metadata: { hideWhenEmpty: 'true' }
         });
-        expect(display.modifierText).toBe('(mixed, hide when empty)');
+        expect(display.modifierText).toBe('(activity, hide when empty)');
     });
 });

--- a/src/widgets/__tests__/AgentActivity.test.ts
+++ b/src/widgets/__tests__/AgentActivity.test.ts
@@ -1,0 +1,466 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import type { AgentEntry } from '../../types/AgentActivityMetrics';
+import type { RenderContext } from '../../types/RenderContext';
+import { DEFAULT_SETTINGS } from '../../types/Settings';
+import type { WidgetItem } from '../../types/Widget';
+import {
+    AgentActivityWidget,
+    applyLimit,
+    filterByMode,
+    formatAgent,
+    formatElapsed,
+    type AgentDisplayFlags
+} from '../AgentActivity';
+
+describe('AgentActivityWidget — identity', () => {
+    const widget = new AgentActivityWidget();
+
+    it('has stable widget metadata', () => {
+        expect(widget.getDefaultColor()).toBe('magenta');
+        expect(widget.getDisplayName()).toBe('Agent Activity');
+        expect(widget.getCategory()).toBe('Session');
+        expect(widget.supportsRawValue()).toBe(true);
+        expect(widget.supportsColors(
+            { id: 'agent-activity', type: 'agent-activity' }
+        )).toBe(true);
+    });
+
+    it('registers PreToolUse and PostToolUse hooks for Task', () => {
+        expect(widget.getHooks()).toEqual([
+            { event: 'PreToolUse', matcher: 'Task' },
+            { event: 'PostToolUse', matcher: 'Task' }
+        ]);
+    });
+});
+
+describe('formatElapsed', () => {
+    function elapsed(startMs: number, endMs: number | undefined): string {
+        return formatElapsed(new Date(startMs), endMs === undefined ? undefined : new Date(endMs), new Date(endMs ?? startMs + 500));
+    }
+
+    it('returns <1s for sub-second durations', () => {
+        expect(elapsed(1000, 1500)).toBe('<1s');
+    });
+
+    it('returns seconds for <60s', () => {
+        expect(elapsed(1000, 1000 + 12_000)).toBe('12s');
+    });
+
+    it('returns minutes and seconds for 1-60min', () => {
+        expect(elapsed(1000, 1000 + (2 * 60 + 34) * 1000)).toBe('2m 34s');
+    });
+
+    it('returns hours and minutes for >=1h', () => {
+        expect(elapsed(1000, 1000 + (3 * 3600 + 45 * 60) * 1000)).toBe('3h 45m');
+    });
+
+    it('computes running elapsed using "now" when endTime undefined', () => {
+        const start = new Date(0);
+        expect(formatElapsed(start, undefined, new Date(42_000))).toBe('42s');
+    });
+});
+
+describe('formatAgent', () => {
+    function makeAgent(overrides: Partial<AgentEntry> = {}): AgentEntry {
+        return {
+            id: 'a',
+            type: 'explore',
+            model: 'haiku',
+            description: 'Finding auth code',
+            status: 'running',
+            startTime: new Date(0),
+            ...overrides
+        };
+    }
+
+    const defaultFlags: AgentDisplayFlags = { hideModel: false, hideDescription: false, hideElapsed: false };
+    const now = new Date(12_000);
+
+    it('renders full running agent with all fields', () => {
+        expect(formatAgent(makeAgent(), defaultFlags, false, now))
+            .toBe('◐ explore [haiku]: Finding auth code (12s)');
+    });
+
+    it('renders completed agent with ✓ icon', () => {
+        const agent = makeAgent({
+            status: 'completed',
+            endTime: new Date(12_000)
+        });
+        expect(formatAgent(agent, defaultFlags, false, now))
+            .toBe('✓ explore [haiku]: Finding auth code (12s)');
+    });
+
+    it('omits icon and label when rawValue=true', () => {
+        expect(formatAgent(makeAgent(), defaultFlags, true, now))
+            .toBe('explore [haiku]: Finding auth code (12s)');
+    });
+
+    it('hides model when hideModel flag set', () => {
+        const flags: AgentDisplayFlags = { ...defaultFlags, hideModel: true };
+        expect(formatAgent(makeAgent(), flags, false, now))
+            .toBe('◐ explore: Finding auth code (12s)');
+    });
+
+    it('hides description when hideDescription flag set', () => {
+        const flags: AgentDisplayFlags = { ...defaultFlags, hideDescription: true };
+        expect(formatAgent(makeAgent(), flags, false, now))
+            .toBe('◐ explore [haiku] (12s)');
+    });
+
+    it('hides elapsed when hideElapsed flag set', () => {
+        const flags: AgentDisplayFlags = { ...defaultFlags, hideElapsed: true };
+        expect(formatAgent(makeAgent(), flags, false, now))
+            .toBe('◐ explore [haiku]: Finding auth code');
+    });
+
+    it('truncates description to 40 chars with ellipsis', () => {
+        const longDesc = 'x'.repeat(50);
+        const agent = makeAgent({ description: longDesc });
+        const output = formatAgent(agent, defaultFlags, false, now);
+        expect(output).toContain(`: ${'x'.repeat(37)}...`);
+    });
+
+    it('omits model bracket when agent.model undefined', () => {
+        const agent = makeAgent({ model: undefined });
+        expect(formatAgent(agent, defaultFlags, false, now))
+            .toBe('◐ explore: Finding auth code (12s)');
+    });
+
+    it('omits description when agent.description undefined', () => {
+        const agent = makeAgent({ description: undefined });
+        expect(formatAgent(agent, defaultFlags, false, now))
+            .toBe('◐ explore [haiku] (12s)');
+    });
+});
+
+describe('filterByMode', () => {
+    function agents(statuses: ('running' | 'completed')[]): AgentEntry[] {
+        return statuses.map((status, i) => ({
+            id: `a${i}`,
+            type: `t${i}`,
+            status,
+            startTime: new Date(i * 1000)
+        }));
+    }
+
+    it('active returns only running agents', () => {
+        const input = agents(['running', 'completed', 'running']);
+        expect(filterByMode(input, 'active').map(a => a.id)).toEqual(['a0', 'a2']);
+    });
+
+    it('last returns a single-element array with the latest agent', () => {
+        const input = agents(['running', 'completed', 'running']);
+        expect(filterByMode(input, 'last').map(a => a.id)).toEqual(['a2']);
+    });
+
+    it('last returns empty array when no agents', () => {
+        expect(filterByMode([], 'last')).toEqual([]);
+    });
+
+    it('mixed returns the input unchanged', () => {
+        const input = agents(['running', 'completed', 'running']);
+        expect(filterByMode(input, 'mixed')).toEqual(input);
+    });
+});
+
+describe('applyLimit', () => {
+    function agents(count: number): AgentEntry[] {
+        return Array.from({ length: count }, (_, i) => ({
+            id: `a${i}`,
+            type: `t${i}`,
+            status: 'running' as const,
+            startTime: new Date(i * 1000)
+        }));
+    }
+
+    it('returns array unchanged when limit=0', () => {
+        const input = agents(5);
+        expect(applyLimit(input, 0)).toEqual(input);
+    });
+
+    it('returns last N entries when agents.length > limit', () => {
+        expect(applyLimit(agents(5), 3).map(a => a.id)).toEqual(['a2', 'a3', 'a4']);
+    });
+
+    it('returns all entries when agents.length <= limit', () => {
+        expect(applyLimit(agents(2), 5).map(a => a.id)).toEqual(['a0', 'a1']);
+    });
+});
+
+function makeContext(agents: AgentEntry[], isPreview = false): RenderContext {
+    return {
+        agentActivityMetrics: { agents },
+        isPreview
+    };
+}
+
+describe('AgentActivityWidget.render — core modes', () => {
+    const widget = new AgentActivityWidget();
+    const item: WidgetItem = { id: 'a', type: 'agent-activity' };
+
+    const runningAgent: AgentEntry = {
+        id: 'r1',
+        type: 'explore',
+        model: 'haiku',
+        description: 'Finding auth',
+        status: 'running',
+        startTime: new Date(Date.now() - 12_000)
+    };
+    const completedAgent: AgentEntry = {
+        id: 'c1',
+        type: 'code-reviewer',
+        model: 'opus',
+        description: 'Review complete',
+        status: 'completed',
+        startTime: new Date(Date.now() - 200_000),
+        endTime: new Date(Date.now() - 40_000)
+    };
+
+    it('mixed mode joins with " | " and includes label', () => {
+        const ctx = makeContext([runningAgent, completedAgent]);
+        const output = widget.render(item, ctx, DEFAULT_SETTINGS);
+        expect(output).toMatch(/^Agents: /);
+        expect(output).toContain(' | ');
+        expect(output).toContain('◐ explore');
+        expect(output).toContain('✓ code-reviewer');
+    });
+
+    it('active mode joins with ", " and only contains running', () => {
+        const ctx = makeContext([runningAgent, completedAgent]);
+        const activeItem: WidgetItem = { ...item, metadata: { mode: 'active' } };
+        const output = widget.render(activeItem, ctx, DEFAULT_SETTINGS);
+        expect(output).toMatch(/^Agents: /);
+        expect(output).not.toContain(' | ');
+        expect(output).not.toContain('✓');
+        expect(output).toContain('◐ explore');
+    });
+
+    it('last mode shows one agent', () => {
+        const ctx = makeContext([runningAgent, completedAgent]);
+        const lastItem: WidgetItem = { ...item, metadata: { mode: 'last' } };
+        const output = widget.render(lastItem, ctx, DEFAULT_SETTINGS);
+        expect(output).toMatch(/^Agents: /);
+        expect(output).toContain('code-reviewer');
+        expect(output).not.toContain('explore');
+    });
+});
+
+describe('AgentActivityWidget.render — rawValue and empty', () => {
+    const widget = new AgentActivityWidget();
+
+    it('rawValue=true strips "Agents:" label and icons', () => {
+        const agent: AgentEntry = {
+            id: 'a',
+            type: 'explore',
+            model: 'haiku',
+            description: 'Finding auth',
+            status: 'running',
+            startTime: new Date(Date.now() - 12_000)
+        };
+        const item: WidgetItem = { id: 'a', type: 'agent-activity', rawValue: true };
+        const output = widget.render(item, makeContext([agent]), DEFAULT_SETTINGS);
+        expect(output).not.toMatch(/^Agents: /);
+        expect(output).not.toContain('◐');
+        expect(output).toContain('explore [haiku]');
+    });
+
+    it('returns "Agents: none" for empty agents when hideWhenEmpty off', () => {
+        const item: WidgetItem = { id: 'a', type: 'agent-activity' };
+        expect(widget.render(item, makeContext([]), DEFAULT_SETTINGS))
+            .toBe('Agents: none');
+    });
+
+    it('returns null for empty agents when hideWhenEmpty on', () => {
+        const item: WidgetItem = {
+            id: 'a',
+            type: 'agent-activity',
+            metadata: { hideWhenEmpty: 'true' }
+        };
+        expect(widget.render(item, makeContext([]), DEFAULT_SETTINGS))
+            .toBeNull();
+    });
+
+    it('returns empty string for empty agents when rawValue=true and hideWhenEmpty off', () => {
+        const item: WidgetItem = { id: 'a', type: 'agent-activity', rawValue: true };
+        expect(widget.render(item, makeContext([]), DEFAULT_SETTINGS))
+            .toBe('');
+    });
+});
+
+describe('AgentActivityWidget.render — preview', () => {
+    const widget = new AgentActivityWidget();
+
+    it('mixed preview contains both running and completed samples', () => {
+        const item: WidgetItem = { id: 'a', type: 'agent-activity' };
+        const output = widget.render(item, makeContext([], true), DEFAULT_SETTINGS) ?? '';
+        expect(output).toMatch(/^Agents: /);
+        expect(output).toContain('◐ explore');
+        expect(output).toContain('✓ code-reviewer');
+    });
+
+    it('active preview contains only running sample', () => {
+        const item: WidgetItem = { id: 'a', type: 'agent-activity', metadata: { mode: 'active' } };
+        const output = widget.render(item, makeContext([], true), DEFAULT_SETTINGS) ?? '';
+        expect(output).toContain('◐ explore');
+        expect(output).not.toContain('✓');
+    });
+
+    it('last preview contains one completed sample', () => {
+        const item: WidgetItem = { id: 'a', type: 'agent-activity', metadata: { mode: 'last' } };
+        const output = widget.render(item, makeContext([], true), DEFAULT_SETTINGS) ?? '';
+        expect(output).toContain('✓ code-reviewer');
+        expect(output).not.toContain('◐');
+    });
+
+    it('rawValue preview omits "Agents:" prefix', () => {
+        const item: WidgetItem = { id: 'a', type: 'agent-activity', rawValue: true };
+        const output = widget.render(item, makeContext([], true), DEFAULT_SETTINGS) ?? '';
+        expect(output).not.toMatch(/^Agents: /);
+    });
+});
+
+describe('AgentActivityWidget.getCustomKeybinds', () => {
+    const widget = new AgentActivityWidget();
+    const base: WidgetItem = { id: 'a', type: 'agent-activity' };
+
+    it('includes l key when mode is mixed', () => {
+        const keys = widget.getCustomKeybinds(base).map(k => k.key);
+        expect(keys).toEqual(['v', 'm', 'd', 'e', 'h', 'l']);
+    });
+
+    it('includes l key when mode is active', () => {
+        const item = { ...base, metadata: { mode: 'active' } };
+        const keys = widget.getCustomKeybinds(item).map(k => k.key);
+        expect(keys).toContain('l');
+    });
+
+    it('omits l key when mode is last', () => {
+        const item = { ...base, metadata: { mode: 'last' } };
+        const keys = widget.getCustomKeybinds(item).map(k => k.key);
+        expect(keys).not.toContain('l');
+    });
+
+    it('includes expected actions', () => {
+        const keybinds = widget.getCustomKeybinds(base);
+        const actions = keybinds.map(k => k.action);
+        expect(actions).toContain('cycle-mode');
+        expect(actions).toContain('toggle-hide-model');
+        expect(actions).toContain('toggle-hide-description');
+        expect(actions).toContain('toggle-hide-elapsed');
+        expect(actions).toContain('toggle-hide-empty');
+        expect(actions).toContain('edit-limit');
+    });
+});
+
+describe('AgentActivityWidget.handleEditorAction', () => {
+    const widget = new AgentActivityWidget();
+    const base: WidgetItem = { id: 'a', type: 'agent-activity' };
+
+    it('cycle-mode progresses mixed → active → last → mixed', () => {
+        const a = widget.handleEditorAction('cycle-mode', base);
+        expect(a?.metadata?.mode).toBe('active');
+        const b = widget.handleEditorAction('cycle-mode', a ?? base);
+        expect(b?.metadata?.mode).toBe('last');
+        const c = widget.handleEditorAction('cycle-mode', b ?? base);
+        expect(c?.metadata?.mode).toBe('mixed');
+    });
+
+    it('toggle-hide-model flips flag', () => {
+        const a = widget.handleEditorAction('toggle-hide-model', base);
+        expect(a?.metadata?.hideModel).toBe('true');
+        const b = widget.handleEditorAction('toggle-hide-model', a ?? base);
+        expect(b?.metadata?.hideModel).toBe('false');
+    });
+
+    it('toggle-hide-description flips flag', () => {
+        const a = widget.handleEditorAction('toggle-hide-description', base);
+        expect(a?.metadata?.hideDescription).toBe('true');
+    });
+
+    it('toggle-hide-elapsed flips flag', () => {
+        const a = widget.handleEditorAction('toggle-hide-elapsed', base);
+        expect(a?.metadata?.hideElapsed).toBe('true');
+    });
+
+    it('toggle-hide-empty flips flag', () => {
+        const a = widget.handleEditorAction('toggle-hide-empty', base);
+        expect(a?.metadata?.hideWhenEmpty).toBe('true');
+    });
+
+    it('returns null for unknown action', () => {
+        expect(widget.handleEditorAction('unknown-action', base)).toBeNull();
+    });
+});
+
+describe('AgentActivityWidget.getEditorDisplay', () => {
+    const widget = new AgentActivityWidget();
+
+    it('shows only mode when no other modifiers', () => {
+        const display = widget.getEditorDisplay({ id: 'a', type: 'agent-activity' });
+        expect(display.displayText).toBe('Agent Activity');
+        expect(display.modifierText).toBe('(mixed)');
+    });
+
+    it('shows explicit mode', () => {
+        const display = widget.getEditorDisplay({
+            id: 'a',
+            type: 'agent-activity',
+            metadata: { mode: 'active' }
+        });
+        expect(display.modifierText).toBe('(active)');
+    });
+
+    it('appends limit when non-default', () => {
+        const display = widget.getEditorDisplay({
+            id: 'a',
+            type: 'agent-activity',
+            metadata: { limit: '5' }
+        });
+        expect(display.modifierText).toBe('(mixed, limit: 5)');
+    });
+
+    it('shows limit: ∞ when limit is 0', () => {
+        const display = widget.getEditorDisplay({
+            id: 'a',
+            type: 'agent-activity',
+            metadata: { limit: '0' }
+        });
+        expect(display.modifierText).toBe('(mixed, limit: ∞)');
+    });
+
+    it('omits limit modifier when limit equals default (3)', () => {
+        const display = widget.getEditorDisplay({
+            id: 'a',
+            type: 'agent-activity',
+            metadata: { limit: '3' }
+        });
+        expect(display.modifierText).toBe('(mixed)');
+    });
+
+    it('appends hideXxx flags', () => {
+        const display = widget.getEditorDisplay({
+            id: 'a',
+            type: 'agent-activity',
+            metadata: {
+                hideModel: 'true',
+                hideDescription: 'true',
+                hideElapsed: 'true'
+            }
+        });
+        expect(display.modifierText).toBe('(mixed, no model, no desc, no elapsed)');
+    });
+
+    it('appends hide when empty', () => {
+        const display = widget.getEditorDisplay({
+            id: 'a',
+            type: 'agent-activity',
+            metadata: { hideWhenEmpty: 'true' }
+        });
+        expect(display.modifierText).toBe('(mixed, hide when empty)');
+    });
+});

--- a/src/widgets/__tests__/AgentActivity.test.ts
+++ b/src/widgets/__tests__/AgentActivity.test.ts
@@ -400,30 +400,41 @@ describe('AgentActivityWidget.getCustomKeybinds', () => {
     const widget = new AgentActivityWidget();
     const base: WidgetItem = { id: 'a', type: 'agent-activity' };
 
-    it('includes l and r keys in activity mode (default)', () => {
-        const keys = widget.getCustomKeybinds(base).map(k => k.key);
-        expect(keys).toEqual(['v', 'm', 'd', 'e', 'h', 'l', 'r']);
+    it('uses collision-free keys (avoids ItemsEditor-reserved a/i/d/c/r/m)', () => {
+        const RESERVED = new Set(['a', 'i', 'd', 'c', 'r', 'm']);
+        const modes = [undefined, 'current', 'count', 'list', 'activity'] as const;
+        for (const mode of modes) {
+            const item: WidgetItem = mode ? { ...base, metadata: { mode } } : base;
+            for (const kb of widget.getCustomKeybinds(item)) {
+                expect(RESERVED.has(kb.key)).toBe(false);
+            }
+        }
     });
 
-    it('includes l but not r key in list mode', () => {
+    it('includes l and u keys in activity mode (default)', () => {
+        const keys = widget.getCustomKeybinds(base).map(k => k.key);
+        expect(keys).toEqual(['v', 'o', 't', 'e', 'h', 'l', 'u']);
+    });
+
+    it('includes l but not u key in list mode', () => {
         const item = { ...base, metadata: { mode: 'list' } };
         const keys = widget.getCustomKeybinds(item).map(k => k.key);
         expect(keys).toContain('l');
-        expect(keys).not.toContain('r');
+        expect(keys).not.toContain('u');
     });
 
-    it('omits l and r keys in current mode', () => {
+    it('omits l and u keys in current mode', () => {
         const item = { ...base, metadata: { mode: 'current' } };
         const keys = widget.getCustomKeybinds(item).map(k => k.key);
         expect(keys).not.toContain('l');
-        expect(keys).not.toContain('r');
+        expect(keys).not.toContain('u');
     });
 
-    it('omits l and r keys in count mode', () => {
+    it('omits l and u keys in count mode', () => {
         const item = { ...base, metadata: { mode: 'count' } };
         const keys = widget.getCustomKeybinds(item).map(k => k.key);
         expect(keys).not.toContain('l');
-        expect(keys).not.toContain('r');
+        expect(keys).not.toContain('u');
     });
 
     it('includes expected actions', () => {

--- a/src/widgets/__tests__/Skills.test.ts
+++ b/src/widgets/__tests__/Skills.test.ts
@@ -19,7 +19,7 @@ describe('SkillsWidget', () => {
     it('uses v as the mode toggle keybind', () => {
         const widget = new SkillsWidget();
         expect(widget.getCustomKeybinds({ id: 'skills', type: 'skills' })).toEqual([
-            { key: 'v', label: '(v)iew: last/count/list', action: 'cycle-mode' },
+            { key: 'v', label: '(v)iew: current/count/list/activity', action: 'cycle-mode' },
             { key: 'h', label: '(h)ide when empty', action: 'toggle-hide-empty' }
         ]);
         expect(widget.getCustomKeybinds({
@@ -27,37 +27,44 @@ describe('SkillsWidget', () => {
             type: 'skills',
             metadata: { mode: 'list' }
         })).toEqual([
-            { key: 'v', label: '(v)iew: last/count/list', action: 'cycle-mode' },
+            { key: 'v', label: '(v)iew: current/count/list/activity', action: 'cycle-mode' },
             { key: 'h', label: '(h)ide when empty', action: 'toggle-hide-empty' },
             { key: 'l', label: '(l)imit', action: 'edit-list-limit' }
         ]);
+        expect(widget.getCustomKeybinds({
+            id: 'skills',
+            type: 'skills',
+            metadata: { mode: 'activity' }
+        }).some(k => k.key === 'l')).toBe(true);
     });
 
-    it('cycles mode current -> count -> list -> current', () => {
+    it('cycles mode current -> count -> list -> activity -> current', () => {
         const widget = new SkillsWidget();
         const base: WidgetItem = { id: 'skills', type: 'skills' };
         const count = widget.handleEditorAction('cycle-mode', base);
         const list = widget.handleEditorAction('cycle-mode', count ?? base);
-        const current = widget.handleEditorAction('cycle-mode', list ?? base);
+        const activity = widget.handleEditorAction('cycle-mode', list ?? base);
+        const current = widget.handleEditorAction('cycle-mode', activity ?? base);
 
         expect(count?.metadata?.mode).toBe('count');
         expect(list?.metadata?.mode).toBe('list');
+        expect(activity?.metadata?.mode).toBe('activity');
         expect(current?.metadata?.mode).toBe('current');
     });
 
-    it('clears list limit metadata when leaving list mode', () => {
+    it('keeps list limit when cycling list -> activity; drops when leaving both', () => {
         const widget = new SkillsWidget();
-        const updated = widget.handleEditorAction('cycle-mode', {
+        const afterList = widget.handleEditorAction('cycle-mode', {
             id: 'skills',
             type: 'skills',
-            metadata: {
-                mode: 'list',
-                listLimit: '2'
-            }
+            metadata: { mode: 'list', listLimit: '2' }
         });
+        expect(afterList?.metadata?.mode).toBe('activity');
+        expect(afterList?.metadata?.listLimit).toBe('2');
 
-        expect(updated?.metadata?.mode).toBe('current');
-        expect(updated?.metadata?.listLimit).toBeUndefined();
+        const afterActivity = widget.handleEditorAction('cycle-mode', afterList ?? { id: 'skills', type: 'skills' });
+        expect(afterActivity?.metadata?.mode).toBe('current');
+        expect(afterActivity?.metadata?.listLimit).toBeUndefined();
     });
 
     it('toggles hide-when-empty metadata', () => {
@@ -78,7 +85,7 @@ describe('SkillsWidget', () => {
             metadata: { hideWhenEmpty: 'true' }
         });
 
-        expect(display.modifierText).toBe('(last used, hide when empty)');
+        expect(display.modifierText).toBe('(current, hide when empty)');
     });
 
     it('shows list limit in editor modifier text when configured', () => {
@@ -89,7 +96,7 @@ describe('SkillsWidget', () => {
             metadata: { mode: 'list', listLimit: '2' }
         });
 
-        expect(display.modifierText).toBe('(unique list, limit: 2)');
+        expect(display.modifierText).toBe('(list, limit: 2)');
     });
 
     it('renders current, count, and list modes from skills metrics', () => {
@@ -97,7 +104,8 @@ describe('SkillsWidget', () => {
             skillsMetrics: {
                 totalInvocations: 3,
                 uniqueSkills: ['commit', 'review-pr'],
-                lastSkill: 'review-pr'
+                lastSkill: 'review-pr',
+                recent: ['commit', 'review-pr', 'commit']
             }
         };
 
@@ -108,12 +116,53 @@ describe('SkillsWidget', () => {
         expect(render({ id: 'skills', type: 'skills', metadata: { mode: 'list', listLimit: '0' } }, context)).toBe('Skills: commit, review-pr');
     });
 
+    it('renders activity mode as time-ordered recent invocations joined by →', () => {
+        const context: RenderContext = {
+            skillsMetrics: {
+                totalInvocations: 3,
+                uniqueSkills: ['commit', 'review-pr'],
+                lastSkill: 'commit',
+                recent: ['commit', 'review-pr', 'commit']
+            }
+        };
+        expect(render({ id: 'skills', type: 'skills', metadata: { mode: 'activity' } }, context))
+            .toBe('Skills: commit → review-pr → commit');
+    });
+
+    it('activity mode respects listLimit as a tail window', () => {
+        const context: RenderContext = {
+            skillsMetrics: {
+                totalInvocations: 5,
+                uniqueSkills: ['a', 'b', 'c'],
+                lastSkill: 'c',
+                recent: ['a', 'b', 'c', 'a', 'c']
+            }
+        };
+        expect(render({
+            id: 'skills',
+            type: 'skills',
+            metadata: { mode: 'activity', listLimit: '2' }
+        }, context)).toBe('Skills: a → c');
+    });
+
+    it('activity mode with empty recent returns "Skills: none" / null per hideWhenEmpty', () => {
+        const empty: RenderContext = { skillsMetrics: { totalInvocations: 0, uniqueSkills: [], lastSkill: null, recent: [] } };
+        expect(render({ id: 'skills', type: 'skills', metadata: { mode: 'activity' } }, empty))
+            .toBe('Skills: none');
+        expect(render({
+            id: 'skills',
+            type: 'skills',
+            metadata: { mode: 'activity', hideWhenEmpty: 'true' }
+        }, empty)).toBeNull();
+    });
+
     it('shows non-hidden empty outputs by default', () => {
         const context: RenderContext = {
             skillsMetrics: {
                 totalInvocations: 0,
                 uniqueSkills: [],
-                lastSkill: null
+                lastSkill: null,
+                recent: []
             }
         };
 
@@ -127,7 +176,8 @@ describe('SkillsWidget', () => {
             skillsMetrics: {
                 totalInvocations: 0,
                 uniqueSkills: [],
-                lastSkill: null
+                lastSkill: null,
+                recent: []
             }
         };
 

--- a/src/widgets/__tests__/TodoProgress.test.ts
+++ b/src/widgets/__tests__/TodoProgress.test.ts
@@ -116,8 +116,11 @@ describe('TodoProgressWidget', () => {
         expect(widget.supportsRawValue()).toBe(true);
     });
 
-    it('registers a PostToolUse+TodoWrite hook', () => {
-        expect(widget.getHooks()).toEqual([{ event: 'PostToolUse', matcher: 'TodoWrite' }]);
+    it('registers PostToolUse+TodoWrite and UserPromptSubmit (turn marker) hooks', () => {
+        expect(widget.getHooks()).toEqual([
+            { event: 'PostToolUse', matcher: 'TodoWrite' },
+            { event: 'UserPromptSubmit' }
+        ]);
     });
 
     it('returns preview output in preview mode', () => {
@@ -177,5 +180,46 @@ describe('TodoProgressWidget', () => {
 
     it('returns no modifiers when flags clean', () => {
         expect(widget.getEditorDisplay(makeItem()).modifierText).toBeUndefined();
+    });
+
+    it('surfaces stale minutes in editor modifier when configured', () => {
+        const item = makeItem({ metadata: { staleMinutes: '30' } });
+        expect(widget.getEditorDisplay(item).modifierText).toBe('(stale: 30m)');
+    });
+
+    it('treats snapshot as empty when staleMinutes exceeded', () => {
+        const oldTimestamp = new Date(Date.now() - 60 * 60_000).toISOString();  // 60 min ago
+        const ctx: RenderContext = {
+            todoProgressMetrics: {
+                todos: [{ content: 'Stale task', status: 'in_progress' }],
+                timestamp: oldTimestamp
+            }
+        };
+        const item = makeItem({ metadata: { staleMinutes: '30' } });  // 30 min threshold
+        expect(widget.render(item, ctx, settings)).toBe('Todo: none');
+    });
+
+    it('keeps snapshot when within staleMinutes window', () => {
+        const recent = new Date(Date.now() - 10 * 60_000).toISOString();  // 10 min ago
+        const ctx: RenderContext = {
+            todoProgressMetrics: {
+                todos: [{ content: 'Fresh task', status: 'in_progress' }],
+                timestamp: recent
+            }
+        };
+        const item = makeItem({ metadata: { staleMinutes: '30' } });
+        expect(widget.render(item, ctx, settings)).toBe('▸ Fresh task (0/1)');
+    });
+
+    it('staleMinutes=0 disables the check', () => {
+        const ancient = new Date(2020, 0, 1).toISOString();
+        const ctx: RenderContext = {
+            todoProgressMetrics: {
+                todos: [{ content: 'Old but not stale', status: 'in_progress' }],
+                timestamp: ancient
+            }
+        };
+        const item = makeItem({ metadata: { staleMinutes: '0' } });
+        expect(widget.render(item, ctx, settings)).toBe('▸ Old but not stale (0/1)');
     });
 });

--- a/src/widgets/__tests__/TodoProgress.test.ts
+++ b/src/widgets/__tests__/TodoProgress.test.ts
@@ -1,0 +1,181 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import type { Settings } from '../../types/Settings';
+import type { TodoItem } from '../../types/TodoProgressMetrics';
+import type { WidgetItem } from '../../types/Widget';
+import {
+    TodoProgressWidget,
+    formatTodoProgress
+} from '../TodoProgress';
+
+function makeItem(overrides: Partial<WidgetItem> = {}): WidgetItem {
+    return { id: 'w1', type: 'todo-progress', ...overrides };
+}
+
+function makeContext(todos: TodoItem[], overrides: Partial<RenderContext> = {}): RenderContext {
+    return {
+        todoProgressMetrics: { todos, timestamp: '2026-04-19T10:00:00.000Z' },
+        ...overrides
+    };
+}
+
+const settings = {} as Settings;
+
+describe('formatTodoProgress', () => {
+    const off = { hideProgress: false, hideContent: false };
+
+    it('returns Todo: none when todos empty', () => {
+        expect(formatTodoProgress([], off, false)).toBe('Todo: none');
+    });
+
+    it('returns empty string when empty and rawValue', () => {
+        expect(formatTodoProgress([], off, true)).toBe('');
+    });
+
+    it('formats in_progress with progress by default', () => {
+        const todos: TodoItem[] = [
+            { content: 'Fix auth', status: 'in_progress' },
+            { content: 'Ship', status: 'pending' },
+            { content: 'Done', status: 'completed' }
+        ];
+        expect(formatTodoProgress(todos, off, false)).toBe('▸ Fix auth (1/3)');
+    });
+
+    it('omits icon and label in rawValue for in_progress', () => {
+        const todos: TodoItem[] = [
+            { content: 'Fix auth', status: 'in_progress' },
+            { content: 'Ship', status: 'pending' }
+        ];
+        expect(formatTodoProgress(todos, off, true)).toBe('Fix auth (0/2)');
+    });
+
+    it('truncates long in_progress content at 40 chars', () => {
+        const long = 'a'.repeat(60);
+        const todos: TodoItem[] = [{ content: long, status: 'in_progress' }];
+        const out = formatTodoProgress(todos, off, false);
+        expect(out).toBe(`▸ ${`a`.repeat(37)}... (0/1)`);
+    });
+
+    it('hideProgress strips the ratio', () => {
+        const todos: TodoItem[] = [
+            { content: 'Fix auth', status: 'in_progress' }
+        ];
+        expect(formatTodoProgress(todos, { hideProgress: true, hideContent: false }, false))
+            .toBe('▸ Fix auth');
+    });
+
+    it('hideContent replaces content with in progress label', () => {
+        const todos: TodoItem[] = [
+            { content: 'Fix auth', status: 'in_progress' },
+            { content: 'Ship', status: 'completed' }
+        ];
+        expect(formatTodoProgress(todos, { hideProgress: false, hideContent: true }, false))
+            .toBe('Todo: 1/2 in progress');
+    });
+
+    it('hideContent + hideProgress collapses to in progress', () => {
+        const todos: TodoItem[] = [
+            { content: 'Fix auth', status: 'in_progress' }
+        ];
+        expect(formatTodoProgress(todos, { hideProgress: true, hideContent: true }, false))
+            .toBe('Todo: in progress');
+    });
+
+    it('without any in_progress shows done ratio', () => {
+        const todos: TodoItem[] = [
+            { content: 'A', status: 'completed' },
+            { content: 'B', status: 'pending' }
+        ];
+        expect(formatTodoProgress(todos, off, false)).toBe('Todo: 1/2 done');
+    });
+
+    it('without in_progress + hideProgress shows bare done', () => {
+        const todos: TodoItem[] = [{ content: 'A', status: 'completed' }];
+        expect(formatTodoProgress(todos, { hideProgress: true, hideContent: false }, false))
+            .toBe('Todo: done');
+    });
+
+    it('rawValue strips Todo: label for done state', () => {
+        const todos: TodoItem[] = [{ content: 'A', status: 'completed' }];
+        expect(formatTodoProgress(todos, off, true)).toBe('1/1 done');
+    });
+});
+
+describe('TodoProgressWidget', () => {
+    const widget = new TodoProgressWidget();
+
+    it('reports static metadata', () => {
+        expect(widget.getDisplayName()).toBe('Todo Progress');
+        expect(widget.getCategory()).toBe('Session');
+        expect(widget.getDefaultColor()).toBe('yellow');
+        expect(widget.supportsRawValue()).toBe(true);
+    });
+
+    it('registers a PostToolUse+TodoWrite hook', () => {
+        expect(widget.getHooks()).toEqual([{ event: 'PostToolUse', matcher: 'TodoWrite' }]);
+    });
+
+    it('returns preview output in preview mode', () => {
+        const result = widget.render(makeItem(), { isPreview: true }, settings);
+        expect(result).toBe('▸ Fix authentication bug (1/5)');
+    });
+
+    it('renders Todo: none when no metrics', () => {
+        expect(widget.render(makeItem(), {}, settings)).toBe('Todo: none');
+    });
+
+    it('returns null when empty and hideWhenEmpty is on', () => {
+        const item = makeItem({ metadata: { hideWhenEmpty: 'true' } });
+        expect(widget.render(item, {}, settings)).toBeNull();
+    });
+
+    it('renders in_progress with progress from context', () => {
+        const ctx = makeContext([
+            { content: 'Fix bug', status: 'in_progress' },
+            { content: 'Ship', status: 'pending' }
+        ]);
+        expect(widget.render(makeItem(), ctx, settings)).toBe('▸ Fix bug (0/2)');
+    });
+
+    it('respects hideProgress metadata', () => {
+        const ctx = makeContext([{ content: 'Fix bug', status: 'in_progress' }]);
+        const item = makeItem({ metadata: { hideProgress: 'true' } });
+        expect(widget.render(item, ctx, settings)).toBe('▸ Fix bug');
+    });
+
+    it('respects hideContent metadata', () => {
+        const ctx = makeContext([
+            { content: 'Fix bug', status: 'in_progress' },
+            { content: 'Ship', status: 'completed' }
+        ]);
+        const item = makeItem({ metadata: { hideContent: 'true' } });
+        expect(widget.render(item, ctx, settings)).toBe('Todo: 1/2 in progress');
+    });
+
+    it('cycles toggle handlers', () => {
+        const base = makeItem();
+        const afterP = widget.handleEditorAction('toggle-hide-progress', base);
+        expect(afterP?.metadata?.hideProgress).toBe('true');
+        const afterC = widget.handleEditorAction('toggle-hide-content', base);
+        expect(afterC?.metadata?.hideContent).toBe('true');
+        const afterH = widget.handleEditorAction('toggle-hide-empty', base);
+        expect(afterH?.metadata?.hideWhenEmpty).toBe('true');
+        expect(widget.handleEditorAction('unknown', base)).toBeNull();
+    });
+
+    it('builds editor display modifiers in order', () => {
+        const item = makeItem({ metadata: { hideContent: 'true', hideProgress: 'true', hideWhenEmpty: 'true' } });
+        const display = widget.getEditorDisplay(item);
+        expect(display.displayText).toBe('Todo Progress');
+        expect(display.modifierText).toBe('(no content, no progress, hide when empty)');
+    });
+
+    it('returns no modifiers when flags clean', () => {
+        expect(widget.getEditorDisplay(makeItem()).modifierText).toBeUndefined();
+    });
+});

--- a/src/widgets/__tests__/ToolCount.test.ts
+++ b/src/widgets/__tests__/ToolCount.test.ts
@@ -200,4 +200,68 @@ describe('ToolCountWidget — keybinds & editor display across modes', () => {
         const display = widget.getEditorDisplay(makeItem({ metadata: { mode: 'activity', listLimit: '2' } }));
         expect(display.modifierText).toBe('(activity, limit: 2)');
     });
+
+    it('exposes (r)unning only only in activity mode', () => {
+        const activity = widget.getCustomKeybinds(makeItem({ metadata: activityMode }));
+        expect(activity.find(k => k.action === 'toggle-hide-completed')).toBeDefined();
+
+        const list = widget.getCustomKeybinds(makeItem({ metadata: { mode: 'list' } }));
+        expect(list.find(k => k.action === 'toggle-hide-completed')).toBeUndefined();
+    });
+
+    it('uses current label in cycle-mode keybind', () => {
+        const keybind = widget.getCustomKeybinds(makeItem()).find(k => k.action === 'cycle-mode');
+        expect(keybind?.label).toContain('current');
+        expect(keybind?.label).not.toContain('last');
+    });
+
+    it('appends running only to activity modifier when hideCompleted set', () => {
+        const display = widget.getEditorDisplay(makeItem({ metadata: { mode: 'activity', hideCompleted: 'true' } }));
+        expect(display.modifierText).toBe('(activity, running only)');
+    });
+});
+
+describe('ToolCountWidget — activity mode + hideCompleted', () => {
+    it('filters out completed entries when hideCompleted=true', () => {
+        const activity = [
+            { id: 'u0', tool_name: 'Edit', category: 'builtin' as const, status: 'running' as const, target: '/x/auth.ts', startTime: new Date('2026-04-19T10:00:00Z') },
+            { id: 'u1', tool_name: 'Read', category: 'builtin' as const, status: 'completed' as const, startTime: new Date('2026-04-19T10:01:00Z') },
+            { id: 'u2', tool_name: 'Read', category: 'builtin' as const, status: 'completed' as const, startTime: new Date('2026-04-19T10:02:00Z') }
+        ];
+        const out = widget.render(
+            makeItem({ metadata: { mode: 'activity', hideCompleted: 'true' } }),
+            makeContext({ activity }),
+            settings
+        );
+        expect(out).toBe('Tools: ◐ Edit: auth.ts');
+    });
+
+    it('keeps completed aggregation when hideCompleted unset', () => {
+        const activity = [
+            { id: 'u0', tool_name: 'Edit', category: 'builtin' as const, status: 'running' as const, target: '/x/auth.ts', startTime: new Date('2026-04-19T10:00:00Z') },
+            { id: 'u1', tool_name: 'Read', category: 'builtin' as const, status: 'completed' as const, startTime: new Date('2026-04-19T10:01:00Z') }
+        ];
+        const out = widget.render(
+            makeItem({ metadata: activityMode }),
+            makeContext({ activity }),
+            settings
+        );
+        expect(out).toBe('Tools: ◐ Edit: auth.ts | ✓ Read');
+    });
+
+    it('hideCompleted=true with only completed entries yields none/null per hideWhenEmpty', () => {
+        const activity = [
+            { id: 'u1', tool_name: 'Read', category: 'builtin' as const, status: 'completed' as const, startTime: new Date('2026-04-19T10:01:00Z') }
+        ];
+        expect(widget.render(
+            makeItem({ metadata: { mode: 'activity', hideCompleted: 'true' } }),
+            makeContext({ activity }),
+            settings
+        )).toBe('Tools: none');
+        expect(widget.render(
+            makeItem({ metadata: { mode: 'activity', hideCompleted: 'true', hideWhenEmpty: 'true' } }),
+            makeContext({ activity }),
+            settings
+        )).toBeNull();
+    });
 });

--- a/src/widgets/__tests__/ToolCount.test.ts
+++ b/src/widgets/__tests__/ToolCount.test.ts
@@ -1,0 +1,203 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import type { Settings } from '../../types/Settings';
+import type {
+    ToolActivityEntry,
+    ToolCountMetrics
+} from '../../types/ToolCountMetrics';
+import type { WidgetItem } from '../../types/Widget';
+import { ToolCountWidget } from '../ToolCount';
+
+function makeItem(overrides: Partial<WidgetItem> = {}): WidgetItem {
+    return { id: 'w1', type: 'tool-count', ...overrides };
+}
+
+function makeActivity(entries: Partial<ToolActivityEntry>[]): ToolActivityEntry[] {
+    return entries.map((e, i) => ({
+        id: e.id ?? `u${i}`,
+        tool_name: e.tool_name ?? 'Read',
+        category: e.category ?? 'builtin',
+        status: e.status ?? 'completed',
+        target: e.target,
+        startTime: e.startTime ?? new Date(`2026-04-19T10:0${i}:00.000Z`),
+        endTime: e.endTime
+    }));
+}
+
+function makeContext(metrics: Partial<ToolCountMetrics>): RenderContext {
+    return {
+        toolCountMetrics: {
+            totalInvocations: metrics.totalInvocations ?? 0,
+            byCategory: metrics.byCategory ?? { builtin: 0, mcp: 0 },
+            byTool: metrics.byTool ?? {},
+            lastTool: metrics.lastTool ?? null,
+            activity: metrics.activity ?? []
+        }
+    };
+}
+
+const settings = {} as Settings;
+const widget = new ToolCountWidget();
+const activityMode = { mode: 'activity' };
+
+describe('ToolCountWidget — activity mode', () => {
+    it('renders running with target plus completed aggregated by frequency', () => {
+        const activity = makeActivity([
+            { tool_name: 'Edit', status: 'running', target: '/repo/src/auth.ts' },
+            { tool_name: 'Read', status: 'completed' },
+            { tool_name: 'Read', status: 'completed' },
+            { tool_name: 'Read', status: 'completed' },
+            { tool_name: 'Bash', status: 'completed' },
+            { tool_name: 'Bash', status: 'completed' }
+        ]);
+        const out = widget.render(
+            makeItem({ metadata: activityMode }),
+            makeContext({ activity }),
+            settings
+        );
+        expect(out).toBe('Tools: ◐ Edit: auth.ts | ✓ Read ×3 | ✓ Bash ×2');
+    });
+
+    it('omits ×N suffix when completed count is 1', () => {
+        const activity = makeActivity([
+            { tool_name: 'Read', status: 'completed' }
+        ]);
+        const out = widget.render(
+            makeItem({ metadata: activityMode }),
+            makeContext({ activity }),
+            settings
+        );
+        expect(out).toBe('Tools: ✓ Read');
+    });
+
+    it('omits target for running tools that have none (e.g. Bash)', () => {
+        const activity = makeActivity([
+            { tool_name: 'Bash', status: 'running' }
+        ]);
+        const out = widget.render(
+            makeItem({ metadata: activityMode }),
+            makeContext({ activity }),
+            settings
+        );
+        expect(out).toBe('Tools: ◐ Bash');
+    });
+
+    it('filters Agent tool out of activity output', () => {
+        const activity = makeActivity([
+            { tool_name: 'Agent', status: 'running', target: 'explore' },
+            { tool_name: 'Edit', status: 'completed' }
+        ]);
+        const out = widget.render(
+            makeItem({ metadata: activityMode }),
+            makeContext({ activity }),
+            settings
+        );
+        expect(out).toBe('Tools: ✓ Edit');
+    });
+
+    it('returns Tools: none when no activity and hideWhenEmpty off', () => {
+        const out = widget.render(
+            makeItem({ metadata: activityMode }),
+            makeContext({}),
+            settings
+        );
+        expect(out).toBe('Tools: none');
+    });
+
+    it('returns null when no activity and hideWhenEmpty on', () => {
+        const out = widget.render(
+            makeItem({ metadata: { mode: 'activity', hideWhenEmpty: 'true' } }),
+            makeContext({}),
+            settings
+        );
+        expect(out).toBeNull();
+    });
+
+    it('preserves icons under rawValue', () => {
+        const activity = makeActivity([
+            { tool_name: 'Edit', status: 'running', target: '/x/y.ts' },
+            { tool_name: 'Read', status: 'completed' },
+            { tool_name: 'Read', status: 'completed' }
+        ]);
+        const out = widget.render(
+            makeItem({ metadata: activityMode, rawValue: true }),
+            makeContext({ activity }),
+            settings
+        );
+        expect(out).toBe('◐ Edit: y.ts | ✓ Read ×2');
+    });
+
+    it('respects listLimit for top-N completed aggregation', () => {
+        const activity = makeActivity([
+            { tool_name: 'A', status: 'completed' },
+            { tool_name: 'A', status: 'completed' },
+            { tool_name: 'B', status: 'completed' },
+            { tool_name: 'C', status: 'completed' }
+        ]);
+        const out = widget.render(
+            makeItem({ metadata: { mode: 'activity', listLimit: '2' } }),
+            makeContext({ activity }),
+            settings
+        );
+        // A has highest count (2), then B/C tied at 1 — second slot goes to most-recent-end.
+        expect(out?.startsWith('Tools: ✓ A ×2 | ✓ ')).toBe(true);
+        expect(out?.split(' | ')).toHaveLength(2);
+    });
+
+    it('filters by scope=mcp', () => {
+        const activity = makeActivity([
+            { tool_name: 'Edit', category: 'builtin', status: 'completed' },
+            { tool_name: 'mcp__foo__bar', category: 'mcp', status: 'completed' }
+        ]);
+        const out = widget.render(
+            makeItem({ metadata: { mode: 'activity', scope: 'mcp' } }),
+            makeContext({ activity }),
+            settings
+        );
+        expect(out).toBe('Tools: ✓ mcp__foo__bar');
+    });
+
+    it('renders preview in activity mode', () => {
+        const out = widget.render(
+            makeItem({ metadata: activityMode }),
+            { isPreview: true },
+            settings
+        );
+        expect(out).toBe('Tools: ◐ Edit: auth.ts | ✓ Read ×3 | ✓ Bash ×2');
+    });
+});
+
+describe('ToolCountWidget — keybinds & editor display across modes', () => {
+    it('exposes (l)imit on list and activity modes', () => {
+        const activity = widget.getCustomKeybinds(makeItem({ metadata: activityMode }));
+        expect(activity.find(k => k.action === 'edit-list-limit')).toBeDefined();
+
+        const list = widget.getCustomKeybinds(makeItem({ metadata: { mode: 'list' } }));
+        expect(list.find(k => k.action === 'edit-list-limit')).toBeDefined();
+
+        const count = widget.getCustomKeybinds(makeItem({ metadata: { mode: 'count' } }));
+        expect(count.find(k => k.action === 'edit-list-limit')).toBeUndefined();
+    });
+
+    it('cycles mode current → count → list → activity → current', () => {
+        let item = makeItem();
+        item = widget.handleEditorAction('cycle-mode', item) ?? item;
+        expect(item.metadata?.mode).toBe('count');
+        item = widget.handleEditorAction('cycle-mode', item) ?? item;
+        expect(item.metadata?.mode).toBe('list');
+        item = widget.handleEditorAction('cycle-mode', item) ?? item;
+        expect(item.metadata?.mode).toBe('activity');
+        item = widget.handleEditorAction('cycle-mode', item) ?? item;
+        expect(item.metadata?.mode).toBe('current');
+    });
+
+    it('surfaces activity label and limit in editor display', () => {
+        const display = widget.getEditorDisplay(makeItem({ metadata: { mode: 'activity', listLimit: '2' } }));
+        expect(display.modifierText).toBe('(activity, limit: 2)');
+    });
+});

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -58,3 +58,4 @@ export { GitWorktreeModeWidget } from './GitWorktreeMode';
 export { GitWorktreeNameWidget } from './GitWorktreeName';
 export { GitWorktreeBranchWidget } from './GitWorktreeBranch';
 export { GitWorktreeOriginalBranchWidget } from './GitWorktreeOriginalBranch';
+export { AgentActivityWidget } from './AgentActivity';

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -51,6 +51,7 @@ export { WeeklyResetTimerWidget } from './WeeklyResetTimer';
 export { ContextBarWidget } from './ContextBar';
 export { LinkWidget } from './Link';
 export { SkillsWidget } from './Skills';
+export { ToolCountWidget } from './ToolCount';
 export { ThinkingEffortWidget } from './ThinkingEffort';
 export { VimModeWidget } from './VimMode';
 export { GitWorktreeModeWidget } from './GitWorktreeMode';

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -59,3 +59,4 @@ export { GitWorktreeNameWidget } from './GitWorktreeName';
 export { GitWorktreeBranchWidget } from './GitWorktreeBranch';
 export { GitWorktreeOriginalBranchWidget } from './GitWorktreeOriginalBranch';
 export { AgentActivityWidget } from './AgentActivity';
+export { TodoProgressWidget } from './TodoProgress';


### PR DESCRIPTION
Adds a new `tool-count` widget that records every Claude Code tool call
(built-in + MCP) to a per-session JSONL file via the PreToolUse hook,
displaying counts in the status line. Supports current/count/list display
modes and all/builtin/mcp scope filters; list mode renders as
`Name * N, ..., MCP * N` sorted by descending count.

Skills widget's PreToolUse matcher is removed so both widgets share a
single deduplicated hook registration; handleHook routes by tool_name.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>