### PR TITLE
fix: detect terminal width on Windows via parent console

### DIFF
--- a/src/utils/__tests__/terminal.test.ts
+++ b/src/utils/__tests__/terminal.test.ts
@@ -1,4 +1,10 @@
-import { execSync } from 'child_process';
+import {
+    execSync,
+    spawnSync
+} from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
     afterEach,
     beforeEach,
@@ -13,7 +19,15 @@ import {
     getTerminalWidth
 } from '../terminal';
 
-vi.mock('child_process', () => ({ execSync: vi.fn() }));
+vi.mock('child_process', () => ({ execSync: vi.fn(), spawnSync: vi.fn() }));
+
+function clearWindowsWidthCache(): void {
+    try {
+        fs.rmSync(path.join(os.tmpdir(), 'ccstatusline-win-width-cache.json'), { force: true });
+    } catch {
+        // ignore
+    }
+}
 
 describe('terminal utils', () => {
     const mockExecSync = execSync as unknown as {
@@ -26,6 +40,10 @@ describe('terminal utils', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.restoreAllMocks();
+        // Default to the Unix probe path for all tests that don't explicitly
+        // override `process.platform`. The Windows path uses a completely
+        // different mechanism (PowerShell probe) and is covered below.
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
     });
 
     afterEach(() => {
@@ -156,11 +174,65 @@ describe('terminal utils', () => {
         expect(canDetectTerminalWidth()).toBe(false);
     });
 
-    it('disables width detection on Windows', () => {
-        vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    describe('Windows width detection', () => {
+        const mockSpawnSync = spawnSync as unknown as {
+            mock: { calls: unknown[][] };
+            mockImplementation: (impl: (cmd: string, args: string[]) => { status: number; stdout: string; stderr: string }) => void;
+            mockImplementationOnce: (impl: () => never) => void;
+        };
 
-        expect(getTerminalWidth()).toBeNull();
-        expect(canDetectTerminalWidth()).toBe(false);
-        expect(mockExecSync.mock.calls.length).toBe(0);
+        beforeEach(() => {
+            vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+            clearWindowsWidthCache();
+        });
+
+        afterEach(() => {
+            clearWindowsWidthCache();
+        });
+
+        it('parses a width from the PowerShell probe output', () => {
+            mockSpawnSync.mockImplementation(() => ({ status: 0, stdout: '209\n', stderr: '' }));
+
+            expect(getTerminalWidth()).toBe(209);
+            expect(mockSpawnSync.mock.calls.length).toBe(1);
+            const [cmd, args] = mockSpawnSync.mock.calls[0] as [string, string[]];
+            expect(cmd).toBe('powershell.exe');
+            expect(args).toContain('-EncodedCommand');
+        });
+
+        it('returns null when the probe emits no width', () => {
+            mockSpawnSync.mockImplementation(() => ({ status: 0, stdout: '\n', stderr: '' }));
+
+            expect(getTerminalWidth()).toBeNull();
+        });
+
+        it('returns null when the probe exits non-zero', () => {
+            mockSpawnSync.mockImplementation(() => ({ status: 1, stdout: '', stderr: 'oops' }));
+
+            expect(getTerminalWidth()).toBeNull();
+        });
+
+        it('returns null when spawnSync throws', () => {
+            mockSpawnSync.mockImplementationOnce(() => { throw new Error('pwsh missing'); });
+
+            expect(getTerminalWidth()).toBeNull();
+        });
+
+        it('serves a fresh cached width without spawning PowerShell again', () => {
+            mockSpawnSync.mockImplementation(() => ({ status: 0, stdout: '209\n', stderr: '' }));
+
+            expect(getTerminalWidth()).toBe(209);
+            expect(mockSpawnSync.mock.calls.length).toBe(1);
+
+            expect(getTerminalWidth()).toBe(209);
+            expect(mockSpawnSync.mock.calls.length).toBe(1);
+        });
+
+        it('does not fall through to the Unix ps/stty probes on Windows', () => {
+            mockSpawnSync.mockImplementation(() => ({ status: 0, stdout: '120\n', stderr: '' }));
+
+            expect(canDetectTerminalWidth()).toBe(true);
+            expect(mockExecSync.mock.calls.length).toBe(0);
+        });
     });
 });

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,5 +1,9 @@
-import { execSync } from 'child_process';
+import {
+    execSync,
+    spawnSync
+} from 'child_process';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 // Get package version
@@ -33,10 +37,12 @@ export function getPackageVersion(): string {
 }
 
 function probeTerminalWidth(): number | null {
-    // Preserve historical behavior on Windows: width detection is unavailable.
-    // This avoids Unix fallback command behavior (e.g. 2>/dev/null) on Windows.
+    // On Windows, the claude.exe process owns the real ConPTY that knows the
+    // terminal size. ccstatusline is spawned by claude.exe with piped stdio, so
+    // it has no console of its own — we walk up the PPID chain, AttachConsole
+    // to an ancestor (preferring claude.exe), and ask `mode con` for the width.
     if (process.platform === 'win32') {
-        return null;
+        return probeTerminalWidthWindows();
     }
 
     // Claude Code can spawn ccstatusline with piped stdio, leaving the immediate
@@ -75,6 +81,141 @@ function probeTerminalWidth(): number | null {
     }
 
     return null;
+}
+
+// PowerShell script that walks the PPID chain via a single toolhelp32 snapshot
+// (native, fast) and asks each ancestor's console for its width via
+// AttachConsole + `mode con`. Prefers the claude.exe ancestor — it owns the
+// real ConPTY tied to the host terminal — falling back to the widest
+// successful read. Emits a positive integer on stdout when found, else nothing.
+const WINDOWS_WIDTH_PROBE_SCRIPT = `$ErrorActionPreference='SilentlyContinue'
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+public class NP {
+    [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
+    public struct PROCESSENTRY32 {
+        public uint dwSize; public uint cntUsage; public uint th32ProcessID;
+        public IntPtr th32DefaultHeapID; public uint th32ModuleID; public uint cntThreads;
+        public uint th32ParentProcessID; public int pcPriClassBase; public uint dwFlags;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst=260)] public string szExeFile;
+    }
+    [DllImport("kernel32.dll", SetLastError=true)] public static extern IntPtr CreateToolhelp32Snapshot(uint dwFlags, uint th32ProcessID);
+    [DllImport("kernel32.dll", CharSet=CharSet.Auto)] public static extern bool Process32First(IntPtr hSnapshot, ref PROCESSENTRY32 lppe);
+    [DllImport("kernel32.dll", CharSet=CharSet.Auto)] public static extern bool Process32Next(IntPtr hSnapshot, ref PROCESSENTRY32 lppe);
+    [DllImport("kernel32.dll", SetLastError=true)] public static extern bool CloseHandle(IntPtr hObject);
+    [DllImport("kernel32.dll", SetLastError=true)] public static extern bool AttachConsole(uint dwProcessId);
+    [DllImport("kernel32.dll")] public static extern bool FreeConsole();
+}
+"@
+$snap = [NP]::CreateToolhelp32Snapshot(2, 0)
+$entry = New-Object NP+PROCESSENTRY32
+$entry.dwSize = [System.Runtime.InteropServices.Marshal]::SizeOf($entry)
+$byPid = @{}
+if ([NP]::Process32First($snap, [ref]$entry)) {
+    do { $byPid[[int]$entry.th32ProcessID] = @{ ppid = [int]$entry.th32ParentProcessID; name = $entry.szExeFile } } while ([NP]::Process32Next($snap, [ref]$entry))
+}
+[NP]::CloseHandle($snap) | Out-Null
+$claudeW = 0
+$maxW = 0
+$cur = $PID
+for ($i = 0; $i -lt 12; $i++) {
+    $p = $byPid[[int]$cur]
+    if ($null -eq $p) { break }
+    if ($cur -ne $PID) {
+        [NP]::FreeConsole() | Out-Null
+        if ([NP]::AttachConsole($cur)) {
+            $m = cmd /c mode con 2>$null
+            $line = $m | Where-Object { $_ -match 'Columns' } | Select-Object -First 1
+            if ($line -match '(\\d+)') {
+                $w = [int]$Matches[1]
+                if ($w -gt $maxW) { $maxW = $w }
+                if ($p.name -ieq 'claude.exe' -or $p.name -ieq 'claude') { $claudeW = $w }
+            }
+            [NP]::FreeConsole() | Out-Null
+        }
+    }
+    $cur = $p.ppid
+    if ($cur -eq 0) { break }
+}
+if ($claudeW -gt 0) { Write-Output $claudeW } elseif ($maxW -gt 0) { Write-Output $maxW }`;
+
+// The probe spawns PowerShell (cold start + Add-Type JIT ≈ 3–5s on first run),
+// which is too slow for every status-line tick. Cache the result briefly so we
+// only pay the cost once per minute. Users who resize the terminal will see
+// stale width for up to WINDOWS_WIDTH_CACHE_TTL_MS before the probe refreshes.
+const WINDOWS_WIDTH_CACHE_TTL_MS = 60 * 1000;
+
+function getWindowsWidthCachePath(): string {
+    return path.join(os.tmpdir(), 'ccstatusline-win-width-cache.json');
+}
+
+function readWindowsWidthCache(): number | null {
+    try {
+        const cachePath = getWindowsWidthCachePath();
+        const raw = fs.readFileSync(cachePath, 'utf8');
+        const parsed = JSON.parse(raw) as { width?: unknown; cachedAt?: unknown };
+        if (typeof parsed.width !== 'number' || typeof parsed.cachedAt !== 'number') {
+            return null;
+        }
+        if (Date.now() - parsed.cachedAt > WINDOWS_WIDTH_CACHE_TTL_MS) {
+            return null;
+        }
+        return parsed.width > 0 ? parsed.width : null;
+    } catch {
+        return null;
+    }
+}
+
+function writeWindowsWidthCache(width: number): void {
+    try {
+        fs.writeFileSync(
+            getWindowsWidthCachePath(),
+            JSON.stringify({ width, cachedAt: Date.now() }),
+            'utf8'
+        );
+    } catch {
+        // Cache is a nice-to-have; silently drop write failures.
+    }
+}
+
+function probeTerminalWidthWindows(): number | null {
+    const cached = readWindowsWidthCache();
+    if (cached !== null) {
+        return cached;
+    }
+
+    try {
+        // PowerShell -EncodedCommand expects a UTF-16LE base64 string. Using
+        // it sidesteps all the quoting headaches of passing multi-line script
+        // text through a Windows command line. spawnSync (not execSync) is
+        // used so the args reach powershell.exe directly, bypassing cmd.exe —
+        // cmd's argument handling and output buffering eat the result at the
+        // sizes our encoded command reaches.
+        const encoded = Buffer.from(WINDOWS_WIDTH_PROBE_SCRIPT, 'utf16le').toString('base64');
+        const result = spawnSync(
+            'powershell.exe',
+            ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-EncodedCommand', encoded],
+            {
+                encoding: 'utf8',
+                stdio: ['pipe', 'pipe', 'pipe'],
+                timeout: 10000,
+                windowsHide: true
+            }
+        );
+
+        if (result.status !== 0) {
+            return null;
+        }
+
+        const width = parsePositiveInteger(result.stdout.trim());
+        if (width !== null) {
+            writeWindowsWidthCache(width);
+        }
+        return width;
+    } catch {
+        return null;
+    }
 }
 
 function parsePositiveInteger(value: string): number | null {


### PR DESCRIPTION
## Problem

  On Windows, `getTerminalWidth()` unconditionally returned `null`, so flex separators collapsed to `' | '` and no long-line truncation happened. The root cause is Claude-Code-side:

  1. The status-line JSON over stdin has no `columns` / `terminal_width` field
  2. No `COLUMNS` env var is exported
  3. The child is spawned with `stdio: 'pipe'` + `windowsHide: true` — no TTY, so `process.stdout.columns` is `undefined`
  4. The existing Unix ancestor-walk (`ps` / `stty`) doesn't apply on Windows

  ## Approach

  Walk the PPID chain to an ancestor that owns the real console (reliably `claude.exe`, which owns the ConPTY hooked into Windows Terminal), `AttachConsole` into it via a PowerShell P/Invoke probe, and read
  `mode con`'s `Columns:` line.

  ## Notes

  - `CreateToolhelp32Snapshot` is used for the PPID walk (native, one call) rather than `Get-CimInstance` (~1s per ancestor via WMI/DCOM)
  - `spawnSync` + `-EncodedCommand` (UTF-16LE base64), not `execSync` — `cmd.exe`'s arg handling dropped the script output at the encoded-command size we're passing
  - The probe is cached at `%TEMP%/ccstatusline-win-width-cache.json` with a 60s TTL: cold call ≈ 5s (unavoidable PowerShell startup + `Add-Type` JIT), warm ≈ 5ms
  - Resize lag: up to 60s before the cache refreshes — acceptable for a status line
  - If PowerShell or the probe fails for any reason, returns `null`, falling back to today's behavior — no regression

  ## Long-term

  This is a workaround for Claude Code not providing the width. The real fix is upstream: include `columns` in the status-line JSON (the sub-agent status line feature already does). When that lands, the whole
  Windows branch here becomes obsolete.

  ## Test coverage

  - Probe output parses to width
  - Empty stdout / non-zero exit / `spawnSync` throw all return `null`
  - Cache hit avoids a second spawn
  - Unix path tests untouched in behavior (but now explicitly mock `process.platform = 'linux'` so they pass on Windows dev boxes too)

  ## How to verify

  Unit: `bun run vitest run src/utils/__tests__/terminal.test.ts` (12 tests).

  Live: `bun run build`, point `~/.claude/settings.json` `statusLine.command` at `dist/ccstatusline.js`, add a Flex Separator between widgets, resize the terminal — the status line now spans the full width.