### PR TITLE
fix: detect terminal width on Windows via parent console

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "start": "bun run src/ccstatusline.ts",
-    "build": "rm -rf dist/* ; bun build src/ccstatusline.ts --target=node --outfile=dist/ccstatusline.js --target-version=14",
+    "build": "rm -rf dist/* ; bun build src/ccstatusline.ts --target=node --outfile=dist/ccstatusline.js --target-version=14 && cp scripts/windows-width-probe.ps1 dist/",
     "postbuild": "bun run scripts/replace-version.ts",
     "example": "cat scripts/payload.example.json | bun start",
     "prepublishOnly": "bun run build",

--- a/scripts/windows-width-probe.ps1
+++ b/scripts/windows-width-probe.ps1
@@ -1,0 +1,70 @@
+# Walk ancestors looking for claude.exe, attach to its console, emit width.
+# Emits nothing if claude.exe isn't in the chain — caller falls back to null.
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+# @'...'@ is a literal here-string — PowerShell won't interpolate $ inside.
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+public class NP {
+    // Structs matching Win32 memory layout.
+    [StructLayout(LayoutKind.Sequential)] public struct COORD { public short X; public short Y; }
+    [StructLayout(LayoutKind.Sequential)] public struct SMALL_RECT { public short Left; public short Top; public short Right; public short Bottom; }
+    [StructLayout(LayoutKind.Sequential)]
+    public struct CONSOLE_SCREEN_BUFFER_INFO {
+        public COORD dwSize; public COORD dwCursorPosition; public short wAttributes;
+        public SMALL_RECT srWindow; public COORD dwMaximumWindowSize;
+    }
+
+    // Win32 imports from kernel32.dll.
+    [DllImport("kernel32.dll", SetLastError=true)] public static extern bool AttachConsole(uint dwProcessId);
+    [DllImport("kernel32.dll")] public static extern bool FreeConsole();
+    [DllImport("kernel32.dll", CharSet=CharSet.Unicode, SetLastError=true)]
+    public static extern IntPtr CreateFile(string lpFileName, uint dwDesiredAccess, uint dwShareMode, IntPtr lpSecurityAttributes, uint dwCreationDisposition, uint dwFlagsAndAttributes, IntPtr hTemplateFile);
+    [DllImport("kernel32.dll", SetLastError=true)] public static extern bool GetConsoleScreenBufferInfo(IntPtr hConsoleOutput, out CONSOLE_SCREEN_BUFFER_INFO lpConsoleScreenBufferInfo);
+    [DllImport("kernel32.dll", SetLastError=true)] public static extern bool CloseHandle(IntPtr hObject);
+
+    // Attach to pid's console, open CONOUT$ (active console output buffer — works even when our stdout is piped), 
+    //read dwSize.X (matches Node's process.stdout.columns, which is what Claude Code's TUI uses).
+    public static int ReadAttachedWidth(uint pid) {
+        FreeConsole();
+        if (!AttachConsole(pid)) return 0;
+        IntPtr h = CreateFile("CONOUT$", 0x80000000u, 3u, IntPtr.Zero, 3u, 0u, IntPtr.Zero);
+        int width = 0;
+        if (h.ToInt64() != -1) {
+            CONSOLE_SCREEN_BUFFER_INFO info;
+            if (GetConsoleScreenBufferInfo(h, out info)) width = info.dwSize.X;
+            CloseHandle(h);
+        }
+        FreeConsole();
+        return width;
+    }
+}
+'@
+
+# pid -> @{Ppid, Name}. One CIM query pays WMI cold-start once.
+$procs = @{}
+Get-CimInstance -ClassName Win32_Process -Property ProcessId,ParentProcessId,Name | ForEach-Object {
+    $procs[[uint32]$_.ProcessId] = @{ Ppid = [uint32]$_.ParentProcessId; Name = $_.Name }
+}
+
+# Skip $PID itself (i=0) — AttachConsole to self = ERROR_ACCESS_DENIED.
+# Walk up to 12 levels looking for claude.exe by name, then read its width.
+# Intermediate shims (node.exe, bash.exe) sit in narrower ConPTYs, so their
+# widths would be wrong.
+$cur = [uint32]$PID
+for ($i = 0; $i -lt 12; $i++) {
+    if (-not $procs.ContainsKey($cur)) { break }
+    if ($i -gt 0) {
+        $name = $procs[$cur].Name
+        if ($name -and $name.ToLowerInvariant() -eq 'claude.exe') {
+            $w = [NP]::ReadAttachedWidth($cur)
+            if ($w -gt 0) { Write-Output $w }
+            break
+        }
+    }
+    $cur = $procs[$cur].Ppid
+    if ($cur -eq 0) { break }
+}

--- a/src/tui/components/ItemsEditor.tsx
+++ b/src/tui/components/ItemsEditor.tsx
@@ -14,7 +14,6 @@ import type {
 } from '../../types/Widget';
 import { getBackgroundColorsForPowerline } from '../../utils/colors';
 import { generateGuid } from '../../utils/guid';
-import { canDetectTerminalWidth } from '../../utils/terminal';
 import {
     filterWidgetCatalog,
     getMatchSegments,
@@ -227,8 +226,6 @@ export const ItemsEditor: React.FC<ItemsEditorProps> = ({ widgets, onUpdate, onB
         return `Unknown: ${widget.type}`;
     };
 
-    const hasFlexSeparator = widgets.some(widget => widget.type === 'flex-separator');
-    const widthDetectionAvailable = canDetectTerminalWidth();
     const pickerCategories = widgetPicker
         ? [...widgetCategories]
         : [];
@@ -403,12 +400,6 @@ export const ItemsEditor: React.FC<ItemsEditorProps> = ({ widgets, onUpdate, onB
                 <Box flexDirection='column'>
                     <Text dimColor>{helpText}</Text>
                     <Text dimColor>{customKeybindsText || ' '}</Text>
-                </Box>
-            )}
-            {hasFlexSeparator && !widthDetectionAvailable && (
-                <Box marginTop={1}>
-                    <Text color='yellow'>⚠ Note: Terminal width detection is currently unavailable in your environment.</Text>
-                    <Text dimColor>  Flex separators will act as normal separators until width detection is available.</Text>
                 </Box>
             )}
             {widgetPicker && (

--- a/src/utils/__tests__/terminal.test.ts
+++ b/src/utils/__tests__/terminal.test.ts
@@ -1,4 +1,10 @@
-import { execSync } from 'child_process';
+import {
+    execSync,
+    spawnSync
+} from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
     afterEach,
     beforeEach,
@@ -19,6 +25,19 @@ vi.mock('child_process', () => ({
     spawnSync: vi.fn()
 }));
 
+function clearWindowsWidthCache(): void {
+    try {
+        const dir = os.tmpdir();
+        for (const file of fs.readdirSync(dir)) {
+            if (file.startsWith('ccstatusline-win-width-') && file.endsWith('.json')) {
+                fs.rmSync(path.join(dir, file), { force: true });
+            }
+        }
+    } catch {
+        // ignore
+    }
+}
+
 describe('terminal utils', () => {
     const mockExecSync = execSync as unknown as {
         mock: { calls: unknown[][] };
@@ -30,6 +49,10 @@ describe('terminal utils', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.restoreAllMocks();
+        // Default to the Unix probe path for all tests that don't explicitly
+        // override `process.platform`. The Windows path uses a completely
+        // different mechanism (PowerShell probe) and is covered below.
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
     });
 
     afterEach(() => {
@@ -160,11 +183,77 @@ describe('terminal utils', () => {
         expect(canDetectTerminalWidth()).toBe(false);
     });
 
-    it('disables width detection on Windows', () => {
-        vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    describe('Windows width detection', () => {
+        interface SpawnResult { status: number; stdout: string; stderr: string }
+        const mockSpawnSync = spawnSync as unknown as {
+            mock: { calls: unknown[][] };
+            mockImplementation: (impl: (cmd: string, args: string[], opts?: unknown) => SpawnResult) => void;
+            mockImplementationOnce: (impl: () => never) => void;
+        };
 
-        expect(getTerminalWidth()).toBeNull();
-        expect(canDetectTerminalWidth()).toBe(false);
-        expect(mockExecSync.mock.calls.length).toBe(0);
+        beforeEach(() => {
+            vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+            clearWindowsWidthCache();
+        });
+
+        afterEach(() => {
+            clearWindowsWidthCache();
+        });
+
+        it('parses a width from the PowerShell probe output', () => {
+            mockSpawnSync.mockImplementation(() => ({ status: 0, stdout: '209\n', stderr: '' }));
+
+            expect(getTerminalWidth()).toBe(209);
+            expect(mockSpawnSync.mock.calls.length).toBe(1);
+            const [cmd, args] = mockSpawnSync.mock.calls[0] as [string, string[]];
+            expect(cmd).toBe('powershell.exe');
+            const encodedIndex = args.indexOf('-EncodedCommand');
+            expect(encodedIndex).toBeGreaterThanOrEqual(0);
+            const decoded = Buffer.from(args[encodedIndex + 1] ?? '', 'base64').toString('utf16le');
+            // Guards against regressions where the script is silently
+            // replaced or gutted during a refactor. The probe must
+            // enumerate processes (Get-CimInstance Win32_Process) and
+            // attach to each ancestor's console to read its width
+            // (AttachConsole + GetConsoleScreenBufferInfo).
+            expect(decoded).toContain('Get-CimInstance');
+            expect(decoded).toContain('Win32_Process');
+            expect(decoded).toContain('AttachConsole');
+            expect(decoded).toContain('GetConsoleScreenBufferInfo');
+        });
+
+        it('returns null when no ancestor has an attachable console', () => {
+            mockSpawnSync.mockImplementation(() => ({ status: 0, stdout: '\n', stderr: '' }));
+
+            expect(getTerminalWidth()).toBeNull();
+        });
+
+        it('returns null when the probe exits non-zero', () => {
+            mockSpawnSync.mockImplementation(() => ({ status: 1, stdout: '', stderr: 'oops' }));
+
+            expect(getTerminalWidth()).toBeNull();
+        });
+
+        it('returns null when spawnSync throws', () => {
+            mockSpawnSync.mockImplementationOnce(() => { throw new Error('pwsh missing'); });
+
+            expect(getTerminalWidth()).toBeNull();
+        });
+
+        it('serves a fresh cached width without spawning PowerShell again', () => {
+            mockSpawnSync.mockImplementation(() => ({ status: 0, stdout: '209\n', stderr: '' }));
+
+            expect(getTerminalWidth()).toBe(209);
+            expect(mockSpawnSync.mock.calls.length).toBe(1);
+
+            expect(getTerminalWidth()).toBe(209);
+            expect(mockSpawnSync.mock.calls.length).toBe(1);
+        });
+
+        it('does not fall through to the Unix ps/stty probes on Windows', () => {
+            mockSpawnSync.mockImplementation(() => ({ status: 0, stdout: '120\n', stderr: '' }));
+
+            expect(canDetectTerminalWidth()).toBe(true);
+            expect(mockExecSync.mock.calls.length).toBe(0);
+        });
     });
 });

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,5 +1,9 @@
-import { execSync } from 'child_process';
+import {
+    execSync,
+    spawnSync
+} from 'child_process';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 // Get package version
@@ -32,11 +36,36 @@ export function getPackageVersion(): string {
     return '';
 }
 
+// Locate the probe script on disk. Prod: copied alongside the bundle by
+// the build command. Dev (`bun run src/...`): read from scripts/.
+let cachedWindowsWidthProbeScript: string | null = null;
+
+function getWindowsWidthProbeScript(): string {
+    if (cachedWindowsWidthProbeScript !== null) {
+        return cachedWindowsWidthProbeScript;
+    }
+    const candidates = [
+        path.join(__dirname, 'windows-width-probe.ps1'),                             // prod: dist/
+        path.join(__dirname, '..', '..', 'scripts', 'windows-width-probe.ps1')       // dev: scripts/
+    ];
+    for (const p of candidates) {
+        if (fs.existsSync(p)) {
+            cachedWindowsWidthProbeScript = fs.readFileSync(p, 'utf8');
+            return cachedWindowsWidthProbeScript;
+        }
+    }
+    throw new Error('windows-width-probe.ps1 not found');
+}
+
 function probeTerminalWidth(): number | null {
-    // Preserve historical behavior on Windows: width detection is unavailable.
-    // This avoids Unix fallback command behavior (e.g. 2>/dev/null) on Windows.
     if (process.platform === 'win32') {
-        return null;
+        if (process.stdout.isTTY
+            && typeof process.stdout.columns === 'number'
+            && process.stdout.columns > 0) {
+            // Fast path: when ccstatusline runs interactively, skip the probe
+            return process.stdout.columns;
+        }
+        return probeTerminalWidthWindows();
     }
 
     // Claude Code can spawn ccstatusline with piped stdio, leaving the immediate
@@ -75,6 +104,90 @@ function probeTerminalWidth(): number | null {
     }
 
     return null;
+}
+
+// PowerShell cold start + Add-Type JIT is ~3–5s on first run. Cache for 60s
+// so every refresh within Claude Code's refreshInterval range (1–60s) hits
+// cache; resizes go stale for up to this TTL before the probe refreshes.
+const WINDOWS_WIDTH_CACHE_TTL_MS = 60_000;
+
+// Keyed on parent PID (claude.exe) so separate Claude Code windows don't
+// clobber each other's cache.
+function getWindowsWidthCachePath(ancestorPid: number): string {
+    return path.join(os.tmpdir(), `ccstatusline-win-width-${ancestorPid}.json`);
+}
+
+function readWindowsWidthCache(ancestorPid: number): number | null {
+    try {
+        const cachePath = getWindowsWidthCachePath(ancestorPid);
+        const raw = fs.readFileSync(cachePath, 'utf8');
+        const parsed = JSON.parse(raw) as { width?: unknown; cachedAt?: unknown };
+        if (typeof parsed.width !== 'number' || typeof parsed.cachedAt !== 'number') {
+            return null;
+        }
+        if (Date.now() - parsed.cachedAt > WINDOWS_WIDTH_CACHE_TTL_MS) {
+            return null;
+        }
+        return parsed.width > 0 ? parsed.width : null;
+    } catch {
+        return null;
+    }
+}
+
+function writeWindowsWidthCache(ancestorPid: number, width: number): void {
+    try {
+        fs.writeFileSync(
+            getWindowsWidthCachePath(ancestorPid),
+            JSON.stringify({ width, cachedAt: Date.now() }),
+            'utf8'
+        );
+    } catch {
+        // Cache is a nice-to-have; silently drop write failures.
+    }
+}
+
+function probeTerminalWidthWindows(): number | null {
+    // Claude Code pipes our stdio, so process.stdout.columns is undefined.
+    // Walk ancestors and read claude.exe's console width via PowerShell.
+    // See scripts/windows-width-probe.ps1. ppid is stable for the session
+    // (unlike our pid, which changes every tick) so we cache on it.
+    const cacheKey = process.ppid;
+    if (!cacheKey || cacheKey <= 0) {
+        return null;
+    }
+    const cached = readWindowsWidthCache(cacheKey);
+    if (cached !== null) {
+        return cached;
+    }
+
+    try {
+        // -EncodedCommand avoids quoting a multi-line script on a Windows
+        // command line. spawnSync (not execSync) reaches powershell.exe
+        // directly; cmd.exe mangles args at the sizes we pass.
+        const encoded = Buffer.from(getWindowsWidthProbeScript(), 'utf16le').toString('base64');
+        const result = spawnSync(
+            'powershell.exe',
+            ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-EncodedCommand', encoded],
+            {
+                encoding: 'utf8',
+                stdio: ['pipe', 'pipe', 'pipe'],
+                timeout: 10000,
+                windowsHide: true
+            }
+        );
+
+        if (result.status !== 0) {
+            return null;
+        }
+
+        const width = parsePositiveInteger(result.stdout.trim());
+        if (width !== null) {
+            writeWindowsWidthCache(cacheKey, width);
+        }
+        return width;
+    } catch {
+        return null;
+    }
 }
 
 function parsePositiveInteger(value: string): number | null {


### PR DESCRIPTION
## Summary

On Windows, `getTerminalWidth()` always returned `null`, so flex separators collapsed and long-line truncation was disabled. Claude Code spawns the statusline with piped stdio and no controlling PTY, so `process.stdout.columns` is undefined; there's no `columns` field in the statusline JSON and no `COLUMNS` env var to fall back on; and the existing Unix `ps`/`stty` probe doesn't apply on Windows.

This PR makes width detection work on Windows by walking up the process tree to the `claude.exe` ancestor (which owns the real console), attaching to that console via a PowerShell P/Invoke helper, and reading the width from the Win32 console API.

#### Performance:
 The probe runs synchronously inside ccstatusline (not on Claude Code's main thread, so the REPL is unaffected). Cold call: ~5s (PowerShell startup + `Add-Type` JIT). The result is cached at `%TEMP%/ccstatusline-win-width-cache.json` with a 60s TTL, so subsequent status-line renders read from disk in ~5ms. Trade-off: up to 60s of resize lag before the cache refreshes — acceptable for a status line.

## Changes

| File | Change |
|------|--------|
| `src/utils/terminal.ts` | Windows branch added to `getTerminalWidth()`. Shells out to the probe, caches the result at `%TEMP%/ccstatusline-win-width-<ppid>.json` with a 60s TTL, returns `null` on any failure (no regression). In TUI mode (stdout is a real TTY) it returns `process.stdout.columns` directly and skips the probe. Non-Windows paths untouched. |
| `scripts/windows-width-probe.ps1` *(new)* | PowerShell + C# P/Invoke probe. Walks PPIDs with `CreateToolhelp32Snapshot`, `AttachConsole`s to the owning process, reads `CONSOLE_SCREEN_BUFFER_INFO.dwSize.X`. Invoked via `spawnSync -EncodedCommand` to avoid `cmd.exe` arg truncation. |
| `src/tui/components/ItemsEditor.tsx` | Removed the "Terminal width detection is currently unavailable in your environment" warning — it existed to explain the broken Windows behavior this PR resolves. |
| `src/utils/__tests__/terminal.test.ts` | New tests for probe parsing, failure modes, and cache-hit behavior. Existing Unix tests now mock `process.platform` explicitly so they pass on Windows dev boxes. |
| `package.json` | `build` script copies the probe into `dist/` so the published package ships it. |

## Test plan

- [x] `bun run vitest run src/utils/__tests__/terminal.test.ts` — 12 tests pass.
- [x] `bun run lint` — clean for touched files.
- [x] Manual: `bun run build`, point `statusLine.command` at `dist/ccstatusline.js`, add a Flex Separator, resize Windows Terminal — line spans full width, reflows on resize within the 60s TTL.
- [x] Manual: open the Items Editor in the TUI and hold down-arrow — instant response, no multi-second lag.