### PR TITLE
feat(tui): add wrap-around navigation to all menus and move modes

### DIFF
--- a/src/tui/components/LineSelector.tsx
+++ b/src/tui/components/LineSelector.tsx
@@ -97,26 +97,28 @@ const LineSelector: React.FC<LineSelectorProps> = ({
         }
 
         if (moveMode) {
-            if (key.upArrow && selectedIndex > 0) {
+            if (key.upArrow && localLines.length > 1) {
                 const newLines = [...localLines];
+                const targetIndex = selectedIndex - 1 < 0 ? localLines.length - 1 : selectedIndex - 1;
                 const temp = newLines[selectedIndex];
-                const prev = newLines[selectedIndex - 1];
+                const prev = newLines[targetIndex];
                 if (temp && prev) {
-                    [newLines[selectedIndex], newLines[selectedIndex - 1]] = [prev, temp];
+                    [newLines[selectedIndex], newLines[targetIndex]] = [prev, temp];
                 }
                 setLocalLines(newLines);
                 onLinesUpdate(newLines);
-                setSelectedIndex(selectedIndex - 1);
-            } else if (key.downArrow && selectedIndex < localLines.length - 1) {
+                setSelectedIndex(targetIndex);
+            } else if (key.downArrow && localLines.length > 1) {
                 const newLines = [...localLines];
+                const targetIndex = selectedIndex + 1 > localLines.length - 1 ? 0 : selectedIndex + 1;
                 const temp = newLines[selectedIndex];
-                const next = newLines[selectedIndex + 1];
+                const next = newLines[targetIndex];
                 if (temp && next) {
-                    [newLines[selectedIndex], newLines[selectedIndex + 1]] = [next, temp];
+                    [newLines[selectedIndex], newLines[targetIndex]] = [next, temp];
                 }
                 setLocalLines(newLines);
                 onLinesUpdate(newLines);
-                setSelectedIndex(selectedIndex + 1);
+                setSelectedIndex(targetIndex);
             } else if (key.escape || key.return) {
                 setMoveMode(false);
             }

--- a/src/tui/components/List.tsx
+++ b/src/tui/components/List.tsx
@@ -39,7 +39,7 @@ export function List<V = string | number>({
     initialSelection = 0,
     showBackButton,
     color,
-    wrapNavigation = false,
+    wrapNavigation = true,
     ...boxProps
 }: ListProps<V>) {
     const [selectedIndex, setSelectedIndex] = useState(initialSelection);

--- a/src/tui/components/PowerlineSeparatorEditor.tsx
+++ b/src/tui/components/PowerlineSeparatorEditor.tsx
@@ -146,10 +146,10 @@ export const PowerlineSeparatorEditor: React.FC<PowerlineSeparatorEditorProps> =
             // Normal mode
             if (key.escape) {
                 onBack();
-            } else if (key.upArrow) {
-                setSelectedIndex(Math.max(0, selectedIndex - 1));
+            } else if (key.upArrow && separators.length > 0) {
+                setSelectedIndex(selectedIndex - 1 < 0 ? separators.length - 1 : selectedIndex - 1);
             } else if (key.downArrow && separators.length > 0) {
-                setSelectedIndex(Math.min(separators.length - 1, selectedIndex + 1));
+                setSelectedIndex(selectedIndex + 1 > separators.length - 1 ? 0 : selectedIndex + 1);
             } else if ((key.leftArrow || key.rightArrow) && separators.length > 0) {
                 // Cycle through preset separators
                 const currentChar = separators[selectedIndex] ?? '\uE0B0';

--- a/src/tui/components/items-editor/__tests__/input-handlers.test.ts
+++ b/src/tui/components/items-editor/__tests__/input-handlers.test.ts
@@ -178,6 +178,176 @@ describe('items-editor input handlers', () => {
         expect(pickerState.get()?.level).toBe('category');
     });
 
+    it('wraps to last category when pressing up at first category', () => {
+        const widgetCatalog = createCatalog([
+            { type: 'git-branch', displayName: 'Git Branch', category: 'Git' },
+            { type: 'tokens-input', displayName: 'Tokens Input', category: 'Tokens' }
+        ]);
+        const widgetCategories = ['All', 'Git', 'Tokens'];
+        const pickerState = createStateSetter<WidgetPickerState | null>({
+            action: 'change',
+            level: 'category',
+            selectedCategory: 'All',
+            categoryQuery: '',
+            widgetQuery: '',
+            selectedType: null
+        });
+
+        handlePickerInputMode({
+            input: '',
+            key: { upArrow: true },
+            widgetPicker: requireState(pickerState.get()),
+            widgetCatalog,
+            widgetCategories,
+            setWidgetPicker: pickerState.set,
+            applyWidgetPickerSelection: vi.fn()
+        });
+
+        expect(pickerState.get()?.selectedCategory).toBe('Tokens');
+    });
+
+    it('wraps to first category when pressing down at last category', () => {
+        const widgetCatalog = createCatalog([
+            { type: 'git-branch', displayName: 'Git Branch', category: 'Git' },
+            { type: 'tokens-input', displayName: 'Tokens Input', category: 'Tokens' }
+        ]);
+        const widgetCategories = ['All', 'Git', 'Tokens'];
+        const pickerState = createStateSetter<WidgetPickerState | null>({
+            action: 'change',
+            level: 'category',
+            selectedCategory: 'Tokens',
+            categoryQuery: '',
+            widgetQuery: '',
+            selectedType: null
+        });
+
+        handlePickerInputMode({
+            input: '',
+            key: { downArrow: true },
+            widgetPicker: requireState(pickerState.get()),
+            widgetCatalog,
+            widgetCategories,
+            setWidgetPicker: pickerState.set,
+            applyWidgetPickerSelection: vi.fn()
+        });
+
+        expect(pickerState.get()?.selectedCategory).toBe('All');
+    });
+
+    it('wraps to last widget when pressing up at first widget in picker', () => {
+        const widgetCatalog = createCatalog([
+            { type: 'git-branch', displayName: 'Git Branch', category: 'Git' },
+            { type: 'git-changes', displayName: 'Git Changes', category: 'Git' },
+            { type: 'git-insertions', displayName: 'Git Insertions', category: 'Git' }
+        ]);
+        const widgetCategories = ['All', 'Git'];
+        const pickerState = createStateSetter<WidgetPickerState | null>({
+            action: 'change',
+            level: 'widget',
+            selectedCategory: 'Git',
+            categoryQuery: '',
+            widgetQuery: '',
+            selectedType: 'git-branch'
+        });
+
+        handlePickerInputMode({
+            input: '',
+            key: { upArrow: true },
+            widgetPicker: requireState(pickerState.get()),
+            widgetCatalog,
+            widgetCategories,
+            setWidgetPicker: pickerState.set,
+            applyWidgetPickerSelection: vi.fn()
+        });
+
+        expect(pickerState.get()?.selectedType).toBe('git-insertions');
+    });
+
+    it('wraps to first widget when pressing down at last widget in picker', () => {
+        const widgetCatalog = createCatalog([
+            { type: 'git-branch', displayName: 'Git Branch', category: 'Git' },
+            { type: 'git-changes', displayName: 'Git Changes', category: 'Git' },
+            { type: 'git-insertions', displayName: 'Git Insertions', category: 'Git' }
+        ]);
+        const widgetCategories = ['All', 'Git'];
+        const pickerState = createStateSetter<WidgetPickerState | null>({
+            action: 'change',
+            level: 'widget',
+            selectedCategory: 'Git',
+            categoryQuery: '',
+            widgetQuery: '',
+            selectedType: 'git-insertions'
+        });
+
+        handlePickerInputMode({
+            input: '',
+            key: { downArrow: true },
+            widgetPicker: requireState(pickerState.get()),
+            widgetCatalog,
+            widgetCategories,
+            setWidgetPicker: pickerState.set,
+            applyWidgetPickerSelection: vi.fn()
+        });
+
+        expect(pickerState.get()?.selectedType).toBe('git-branch');
+    });
+
+    it('wraps to last search result when pressing up at first in top-level search', () => {
+        const widgetCatalog = createCatalog([
+            { type: 'git-branch', displayName: 'Git Branch', category: 'Git' },
+            { type: 'git-changes', displayName: 'Git Changes', category: 'Git' }
+        ]);
+        const widgetCategories = ['All', 'Git'];
+        const pickerState = createStateSetter<WidgetPickerState | null>({
+            action: 'change',
+            level: 'category',
+            selectedCategory: 'All',
+            categoryQuery: 'git',
+            widgetQuery: '',
+            selectedType: 'git-branch'
+        });
+
+        handlePickerInputMode({
+            input: '',
+            key: { upArrow: true },
+            widgetPicker: requireState(pickerState.get()),
+            widgetCatalog,
+            widgetCategories,
+            setWidgetPicker: pickerState.set,
+            applyWidgetPickerSelection: vi.fn()
+        });
+
+        expect(pickerState.get()?.selectedType).toBe('git-changes');
+    });
+
+    it('wraps to first search result when pressing down at last in top-level search', () => {
+        const widgetCatalog = createCatalog([
+            { type: 'git-branch', displayName: 'Git Branch', category: 'Git' },
+            { type: 'git-changes', displayName: 'Git Changes', category: 'Git' }
+        ]);
+        const widgetCategories = ['All', 'Git'];
+        const pickerState = createStateSetter<WidgetPickerState | null>({
+            action: 'change',
+            level: 'category',
+            selectedCategory: 'All',
+            categoryQuery: 'git',
+            widgetQuery: '',
+            selectedType: 'git-changes'
+        });
+
+        handlePickerInputMode({
+            input: '',
+            key: { downArrow: true },
+            widgetPicker: requireState(pickerState.get()),
+            widgetCatalog,
+            widgetCategories,
+            setWidgetPicker: pickerState.set,
+            applyWidgetPickerSelection: vi.fn()
+        });
+
+        expect(pickerState.get()?.selectedType).toBe('git-branch');
+    });
+
     it('moves selected widget up in move mode', () => {
         const widgets: WidgetItem[] = [
             { id: '1', type: 'tokens-input' },
@@ -202,6 +372,112 @@ describe('items-editor input handlers', () => {
         ]);
         expect(setSelectedIndex).toHaveBeenCalledWith(0);
         expect(setMoveMode).not.toHaveBeenCalled();
+    });
+
+    it('wraps to last widget when pressing up at first position in normal mode', () => {
+        const widgets: WidgetItem[] = [
+            { id: '1', type: 'tokens-input' },
+            { id: '2', type: 'tokens-output' },
+            { id: '3', type: 'git-branch' }
+        ];
+        const setSelectedIndex = vi.fn();
+
+        handleNormalInputMode({
+            input: '',
+            key: { upArrow: true },
+            widgets,
+            selectedIndex: 0,
+            separatorChars: ['|'],
+            onBack: vi.fn(),
+            onUpdate: vi.fn(),
+            setSelectedIndex,
+            setMoveMode: vi.fn(),
+            setShowClearConfirm: vi.fn(),
+            openWidgetPicker: vi.fn(),
+            getCustomKeybindsForWidget: (widgetImpl, widget) => widgetImpl.getCustomKeybinds ? widgetImpl.getCustomKeybinds(widget) : [],
+            setCustomEditorWidget: vi.fn()
+        });
+
+        expect(setSelectedIndex).toHaveBeenCalledWith(2);
+    });
+
+    it('wraps to first widget when pressing down at last position in normal mode', () => {
+        const widgets: WidgetItem[] = [
+            { id: '1', type: 'tokens-input' },
+            { id: '2', type: 'tokens-output' },
+            { id: '3', type: 'git-branch' }
+        ];
+        const setSelectedIndex = vi.fn();
+
+        handleNormalInputMode({
+            input: '',
+            key: { downArrow: true },
+            widgets,
+            selectedIndex: 2,
+            separatorChars: ['|'],
+            onBack: vi.fn(),
+            onUpdate: vi.fn(),
+            setSelectedIndex,
+            setMoveMode: vi.fn(),
+            setShowClearConfirm: vi.fn(),
+            openWidgetPicker: vi.fn(),
+            getCustomKeybindsForWidget: (widgetImpl, widget) => widgetImpl.getCustomKeybinds ? widgetImpl.getCustomKeybinds(widget) : [],
+            setCustomEditorWidget: vi.fn()
+        });
+
+        expect(setSelectedIndex).toHaveBeenCalledWith(0);
+    });
+
+    it('wraps to last position when moving widget up from first position', () => {
+        const widgets: WidgetItem[] = [
+            { id: '1', type: 'tokens-input' },
+            { id: '2', type: 'tokens-output' },
+            { id: '3', type: 'git-branch' }
+        ];
+        const onUpdate = vi.fn();
+        const setSelectedIndex = vi.fn();
+
+        handleMoveInputMode({
+            key: { upArrow: true },
+            widgets,
+            selectedIndex: 0,
+            onUpdate,
+            setSelectedIndex,
+            setMoveMode: vi.fn()
+        });
+
+        expect(onUpdate).toHaveBeenCalledWith([
+            { id: '3', type: 'git-branch' },
+            { id: '2', type: 'tokens-output' },
+            { id: '1', type: 'tokens-input' }
+        ]);
+        expect(setSelectedIndex).toHaveBeenCalledWith(2);
+    });
+
+    it('wraps to first position when moving widget down from last position', () => {
+        const widgets: WidgetItem[] = [
+            { id: '1', type: 'tokens-input' },
+            { id: '2', type: 'tokens-output' },
+            { id: '3', type: 'git-branch' }
+        ];
+        const onUpdate = vi.fn();
+        const setSelectedIndex = vi.fn();
+
+        handleMoveInputMode({
+            key: { downArrow: true },
+            widgets,
+            selectedIndex: 2,
+            onUpdate,
+            setSelectedIndex,
+            setMoveMode: vi.fn()
+        });
+
+        expect(onUpdate).toHaveBeenCalledWith([
+            { id: '3', type: 'git-branch' },
+            { id: '2', type: 'tokens-output' },
+            { id: '1', type: 'tokens-input' }
+        ]);
+        expect(setSelectedIndex).toHaveBeenCalledWith(0);
     });
 
     it('toggles raw value in normal mode for supported widgets', () => {

--- a/src/tui/components/items-editor/input-handlers.ts
+++ b/src/tui/components/items-editor/input-handlers.ts
@@ -190,8 +190,8 @@ export function handlePickerInputMode({
                 }
 
                 const nextIndex = key.downArrow
-                    ? Math.min(topLevelSearchEntries.length - 1, currentIndex + 1)
-                    : Math.max(0, currentIndex - 1);
+                    ? (currentIndex + 1 > topLevelSearchEntries.length - 1 ? 0 : currentIndex + 1)
+                    : (currentIndex - 1 < 0 ? topLevelSearchEntries.length - 1 : currentIndex - 1);
                 const nextType = topLevelSearchEntries[nextIndex]?.type ?? null;
                 setPickerState(setWidgetPicker, normalizeState, prev => ({
                     ...prev,
@@ -208,8 +208,8 @@ export function handlePickerInputMode({
                 }
 
                 const nextIndex = key.downArrow
-                    ? Math.min(filteredCategories.length - 1, currentIndex + 1)
-                    : Math.max(0, currentIndex - 1);
+                    ? (currentIndex + 1 > filteredCategories.length - 1 ? 0 : currentIndex + 1)
+                    : (currentIndex - 1 < 0 ? filteredCategories.length - 1 : currentIndex - 1);
                 const nextCategory = filteredCategories[nextIndex] ?? null;
                 setPickerState(setWidgetPicker, normalizeState, prev => ({
                     ...prev,
@@ -262,8 +262,8 @@ export function handlePickerInputMode({
             }
 
             const nextIndex = key.downArrow
-                ? Math.min(filteredWidgets.length - 1, currentIndex + 1)
-                : Math.max(0, currentIndex - 1);
+                ? (currentIndex + 1 > filteredWidgets.length - 1 ? 0 : currentIndex + 1)
+                : (currentIndex - 1 < 0 ? filteredWidgets.length - 1 : currentIndex - 1);
             const nextType = filteredWidgets[nextIndex]?.type ?? null;
             setPickerState(setWidgetPicker, normalizeState, prev => ({
                 ...prev,
@@ -307,24 +307,26 @@ export function handleMoveInputMode({
     setSelectedIndex,
     setMoveMode
 }: HandleMoveInputModeArgs): void {
-    if (key.upArrow && selectedIndex > 0) {
+    if (key.upArrow && widgets.length > 1) {
         const newWidgets = [...widgets];
+        const targetIndex = selectedIndex - 1 < 0 ? widgets.length - 1 : selectedIndex - 1;
         const temp = newWidgets[selectedIndex];
-        const prev = newWidgets[selectedIndex - 1];
+        const prev = newWidgets[targetIndex];
         if (temp && prev) {
-            [newWidgets[selectedIndex], newWidgets[selectedIndex - 1]] = [prev, temp];
+            [newWidgets[selectedIndex], newWidgets[targetIndex]] = [prev, temp];
         }
         onUpdate(newWidgets);
-        setSelectedIndex(selectedIndex - 1);
-    } else if (key.downArrow && selectedIndex < widgets.length - 1) {
+        setSelectedIndex(targetIndex);
+    } else if (key.downArrow && widgets.length > 1) {
         const newWidgets = [...widgets];
+        const targetIndex = selectedIndex + 1 > widgets.length - 1 ? 0 : selectedIndex + 1;
         const temp = newWidgets[selectedIndex];
-        const next = newWidgets[selectedIndex + 1];
+        const next = newWidgets[targetIndex];
         if (temp && next) {
-            [newWidgets[selectedIndex], newWidgets[selectedIndex + 1]] = [next, temp];
+            [newWidgets[selectedIndex], newWidgets[targetIndex]] = [next, temp];
         }
         onUpdate(newWidgets);
-        setSelectedIndex(selectedIndex + 1);
+        setSelectedIndex(targetIndex);
     } else if (key.escape || key.return) {
         setMoveMode(false);
     }
@@ -362,9 +364,9 @@ export function handleNormalInputMode({
     setCustomEditorWidget
 }: HandleNormalInputModeArgs): void {
     if (key.upArrow && widgets.length > 0) {
-        setSelectedIndex(Math.max(0, selectedIndex - 1));
+        setSelectedIndex(selectedIndex - 1 < 0 ? widgets.length - 1 : selectedIndex - 1);
     } else if (key.downArrow && widgets.length > 0) {
-        setSelectedIndex(Math.min(widgets.length - 1, selectedIndex + 1));
+        setSelectedIndex(selectedIndex + 1 > widgets.length - 1 ? 0 : selectedIndex + 1);
     } else if (key.leftArrow && widgets.length > 0) {
         openWidgetPicker('change');
     } else if (key.rightArrow && widgets.length > 0) {


### PR DESCRIPTION
## Summary
- Enable circular cursor movement across all TUI menus and lists — pressing up at the first item wraps to the last, and pressing down at the last wraps to the first
- Also applies to move/reorder modes, allowing items to be moved cyclically through list boundaries
- No existing PR covers this functionality

## Changes
- `List.tsx` — change `wrapNavigation` default from `false` to `true`, enabling wrap-around for all `<List>`-based menus     (MainMenu, InstallMenu, PowerlineSetup, etc.)
- `input-handlers.ts` — replace `Math.max`/`Math.min` clamping with wrap-around logic in `handleNormalInputMode`, `handleMoveInputMode`, and `handlePickerInputMode`
- `PowerlineSeparatorEditor.tsx` — wrap-around for separator list navigation
- `LineSelector.tsx` — wrap-around in line move mode

## Test Plan
- 789 tests pass (10 new), TypeScript and ESLint clean
- New tests cover wrap boundaries for: normal mode (up/down), move mode (up/down), picker categories (up/down), picker widgets (up/down), and top-level search (up/down)