### PR TITLE
feat(widgets): add Docker Containers widget

### DIFF
--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -64,6 +64,7 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'claude-account-email', create: () => new widgets.ClaudeAccountEmailWidget() },
     { type: 'session-name', create: () => new widgets.SessionNameWidget() },
     { type: 'free-memory', create: () => new widgets.FreeMemoryWidget() },
+    { type: 'docker-containers', create: () => new widgets.DockerContainersWidget() },
     { type: 'session-usage', create: () => new widgets.SessionUsageWidget() },
     { type: 'weekly-usage', create: () => new widgets.WeeklyUsageWidget() },
     { type: 'reset-timer', create: () => new widgets.BlockResetTimerWidget() },

--- a/src/widgets/DockerContainers.ts
+++ b/src/widgets/DockerContainers.ts
@@ -1,0 +1,92 @@
+import { execSync } from 'child_process';
+
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+
+const STATE_SYMBOLS: Record<string, string> = {
+    running: '▲',
+    exited: '■',
+    paused: '◐',
+    restarting: '↻',
+    created: '◌',
+    removing: '◌',
+    dead: '✗'
+};
+
+function symbolFor(state: string): string {
+    return STATE_SYMBOLS[state.toLowerCase()] ?? '?';
+}
+
+interface DockerContainer {
+    name: string;
+    state: string;
+}
+
+function parseContainers(output: string): DockerContainer[] {
+    const containers: DockerContainer[] = [];
+    for (const line of output.split('\n')) {
+        if (!line)
+            continue;
+        const [name, state] = line.split('|');
+        if (!name || !state)
+            continue;
+        containers.push({ name, state });
+    }
+    return containers;
+}
+
+export class DockerContainersWidget implements Widget {
+    getDefaultColor(): string { return 'blue'; }
+    getDescription(): string { return 'Lists Docker containers and their status'; }
+    getDisplayName(): string { return 'Docker Containers'; }
+    getCategory(): string { return 'Environment'; }
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
+        return { displayText: this.getDisplayName() };
+    }
+
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
+        if (context.isPreview) {
+            const sample = 'tc-server▲ tc-agent-1▲ db■';
+            return item.rawValue ? sample : `🐳 ${sample}`;
+        }
+
+        let output: string;
+        try {
+            output = execSync('docker ps -a --format "{{.Names}}|{{.State}}"', {
+                encoding: 'utf8',
+                timeout: 2000,
+                stdio: ['ignore', 'pipe', 'ignore'],
+                env: process.env
+            }).trim();
+        } catch (error) {
+            if (error instanceof Error) {
+                const execError = error as Error & { code?: string };
+                if (execError.code === 'ENOENT') {
+                    return item.rawValue ? null : '[No docker]';
+                }
+                if (execError.code === 'ETIMEDOUT') {
+                    return item.rawValue ? null : '[Docker timeout]';
+                }
+            }
+            return item.rawValue ? null : '[Docker down]';
+        }
+
+        const containers = parseContainers(output);
+        if (containers.length === 0) {
+            return item.rawValue ? '' : '🐳 (none)';
+        }
+
+        const value = containers
+            .map(({ name, state }) => `${name}${symbolFor(state)}`)
+            .join(' ');
+        return item.rawValue ? value : `🐳 ${value}`;
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/__tests__/DockerContainers.test.ts
+++ b/src/widgets/__tests__/DockerContainers.test.ts
@@ -1,0 +1,208 @@
+import * as childProcess from 'child_process';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import type {
+    RenderContext,
+    WidgetItem
+} from '../../types';
+import { DEFAULT_SETTINGS } from '../../types/Settings';
+import { DockerContainersWidget } from '../DockerContainers';
+
+describe('DockerContainersWidget', () => {
+    const widget = new DockerContainersWidget();
+    let mockExecSync: {
+        mockImplementation: (fn: () => never) => void;
+        mockReturnValue: (value: string) => void;
+    };
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        mockExecSync = vi.spyOn(childProcess, 'execSync');
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('metadata', () => {
+        it('should return correct display name', () => {
+            expect(widget.getDisplayName()).toBe('Docker Containers');
+        });
+
+        it('should return correct description', () => {
+            expect(widget.getDescription()).toBe('Lists Docker containers and their status');
+        });
+
+        it('should return blue as default color', () => {
+            expect(widget.getDefaultColor()).toBe('blue');
+        });
+
+        it('should return Environment category', () => {
+            expect(widget.getCategory()).toBe('Environment');
+        });
+
+        it('should support raw value', () => {
+            expect(widget.supportsRawValue()).toBe(true);
+        });
+
+        it('should support colors', () => {
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers' };
+            expect(widget.supportsColors(item)).toBe(true);
+        });
+    });
+
+    describe('preview mode', () => {
+        it('should return sample with prefix in preview mode', () => {
+            const context: RenderContext = { isPreview: true };
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers' };
+
+            const result = widget.render(item, context, DEFAULT_SETTINGS);
+
+            expect(result).toBe('🐳 tc-server▲ tc-agent-1▲ db■');
+        });
+
+        it('should return sample without prefix when rawValue is true', () => {
+            const context: RenderContext = { isPreview: true };
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers', rawValue: true };
+
+            const result = widget.render(item, context, DEFAULT_SETTINGS);
+
+            expect(result).toBe('tc-server▲ tc-agent-1▲ db■');
+        });
+    });
+
+    describe('rendering', () => {
+        it('should render running and exited containers with symbols', () => {
+            mockExecSync.mockReturnValue('tc-server|running\ntc-agent-1|running\ndb|exited\n');
+
+            const context: RenderContext = {};
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers' };
+
+            const result = widget.render(item, context, DEFAULT_SETTINGS);
+
+            expect(result).toBe('🐳 tc-server▲ tc-agent-1▲ db■');
+        });
+
+        it('should render paused and restarting states', () => {
+            mockExecSync.mockReturnValue('c1|paused\nc2|restarting\nc3|dead\nc4|created\n');
+
+            const context: RenderContext = {};
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers', rawValue: true };
+
+            const result = widget.render(item, context, DEFAULT_SETTINGS);
+
+            expect(result).toBe('c1◐ c2↻ c3✗ c4◌');
+        });
+
+        it('should handle unknown state with fallback symbol', () => {
+            mockExecSync.mockReturnValue('c1|weird-state\n');
+
+            const context: RenderContext = {};
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers', rawValue: true };
+
+            const result = widget.render(item, context, DEFAULT_SETTINGS);
+
+            expect(result).toBe('c1?');
+        });
+
+        it('should handle empty container list', () => {
+            mockExecSync.mockReturnValue('');
+
+            const context: RenderContext = {};
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers' };
+
+            const result = widget.render(item, context, DEFAULT_SETTINGS);
+
+            expect(result).toBe('🐳 (none)');
+        });
+
+        it('should return empty string for empty list in raw mode', () => {
+            mockExecSync.mockReturnValue('');
+
+            const context: RenderContext = {};
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers', rawValue: true };
+
+            const result = widget.render(item, context, DEFAULT_SETTINGS);
+
+            expect(result).toBe('');
+        });
+
+        it('should be case-insensitive for state names', () => {
+            mockExecSync.mockReturnValue('c1|Running\nc2|EXITED\n');
+
+            const context: RenderContext = {};
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers', rawValue: true };
+
+            const result = widget.render(item, context, DEFAULT_SETTINGS);
+
+            expect(result).toBe('c1▲ c2■');
+        });
+    });
+
+    describe('error handling', () => {
+        it('should return [No docker] when docker is not installed', () => {
+            mockExecSync.mockImplementation(() => {
+                const err = new Error('not found') as Error & { code?: string };
+                err.code = 'ENOENT';
+                throw err;
+            });
+
+            const context: RenderContext = {};
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers' };
+
+            const result = widget.render(item, context, DEFAULT_SETTINGS);
+
+            expect(result).toBe('[No docker]');
+        });
+
+        it('should return [Docker timeout] on timeout', () => {
+            mockExecSync.mockImplementation(() => {
+                const err = new Error('timeout') as Error & { code?: string };
+                err.code = 'ETIMEDOUT';
+                throw err;
+            });
+
+            const context: RenderContext = {};
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers' };
+
+            const result = widget.render(item, context, DEFAULT_SETTINGS);
+
+            expect(result).toBe('[Docker timeout]');
+        });
+
+        it('should return [Docker down] when daemon is unreachable', () => {
+            mockExecSync.mockImplementation(() => {
+                throw new Error('Cannot connect to the Docker daemon');
+            });
+
+            const context: RenderContext = {};
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers' };
+
+            const result = widget.render(item, context, DEFAULT_SETTINGS);
+
+            expect(result).toBe('[Docker down]');
+        });
+
+        it('should return null errors in raw mode', () => {
+            mockExecSync.mockImplementation(() => {
+                const err = new Error('not found') as Error & { code?: string };
+                err.code = 'ENOENT';
+                throw err;
+            });
+
+            const context: RenderContext = {};
+            const item: WidgetItem = { id: 'docker', type: 'docker-containers', rawValue: true };
+
+            const result = widget.render(item, context, DEFAULT_SETTINGS);
+
+            expect(result).toBeNull();
+        });
+    });
+});

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -43,6 +43,7 @@ export { InputSpeedWidget } from './InputSpeed';
 export { OutputSpeedWidget } from './OutputSpeed';
 export { TotalSpeedWidget } from './TotalSpeed';
 export { FreeMemoryWidget } from './FreeMemory';
+export { DockerContainersWidget } from './DockerContainers';
 export { SessionNameWidget } from './SessionName';
 export { SessionUsageWidget } from './SessionUsage';
 export { WeeklyUsageWidget } from './WeeklyUsage';


### PR DESCRIPTION
Displays Docker containers by name with a status symbol (running, exited, paused, restarting, created/removing, dead). Uses `docker ps -a` with a 2s timeout; gracefully handles missing docker, daemon-down, and timeout.