### PR TITLE
feat(widgets): add Context Window widget

### DIFF
--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -49,6 +49,7 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'output-speed', create: () => new widgets.OutputSpeedWidget() },
     { type: 'total-speed', create: () => new widgets.TotalSpeedWidget() },
     { type: 'context-length', create: () => new widgets.ContextLengthWidget() },
+    { type: 'context-window', create: () => new widgets.ContextWindowWidget() },
     { type: 'context-percentage', create: () => new widgets.ContextPercentageWidget() },
     { type: 'context-percentage-usable', create: () => new widgets.ContextPercentageUsableWidget() },
     { type: 'session-clock', create: () => new widgets.SessionClockWidget() },

--- a/src/widgets/ContextWindow.ts
+++ b/src/widgets/ContextWindow.ts
@@ -1,0 +1,45 @@
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+import { getContextWindowSize } from '../utils/context-window';
+import {
+    getContextConfig,
+    getModelContextIdentifier
+} from '../utils/model-context';
+import { formatTokens } from '../utils/renderer';
+
+export class ContextWindowWidget implements Widget {
+    getDefaultColor(): string { return 'brightBlack'; }
+    getDescription(): string { return 'Shows the total context window size for the current model'; }
+    getDisplayName(): string { return 'Context Window'; }
+    getCategory(): string { return 'Context'; }
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
+        return { displayText: this.getDisplayName() };
+    }
+
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
+        if (context.isPreview) {
+            return item.rawValue ? '200k' : 'Win: 200k';
+        }
+
+        let total = getContextWindowSize(context.data);
+
+        if (total === null) {
+            const modelIdentifier = getModelContextIdentifier(context.data?.model);
+            total = getContextConfig(modelIdentifier).maxTokens;
+        }
+
+        if (total <= 0) {
+            return null;
+        }
+
+        return item.rawValue ? formatTokens(total) : `Win: ${formatTokens(total)}`;
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -26,6 +26,7 @@ export { TokensOutputWidget } from './TokensOutput';
 export { TokensCachedWidget } from './TokensCached';
 export { TokensTotalWidget } from './TokensTotal';
 export { ContextLengthWidget } from './ContextLength';
+export { ContextWindowWidget } from './ContextWindow';
 export { ContextPercentageWidget } from './ContextPercentage';
 export { ContextPercentageUsableWidget } from './ContextPercentageUsable';
 export { SessionClockWidget } from './SessionClock';


### PR DESCRIPTION
## Summary

Adds a new `context-window` widget that renders the total context
window size for the current model (e.g. `1.0M` for Opus 1M, `200k`
for Sonnet 4.6 / Haiku 4.5).

This complements the existing `context-length` and `context-percentage`
widgets so users can build a "used / total (pct)" display without
pulling in `context-bar` (which always renders the progress bar).
Example layout:

```
context-length  •  /  •  context-window  •  ( • context-percentage • )
→ 60.0k/1.0M (6.0%)
```

The widget is fully dynamic: when the active model changes (and Claude
Code reports a different `context_window_size`), the value updates on
the next render.

## Implementation

- New `ContextWindowWidget` in `src/widgets/ContextWindow.ts`. Mirrors
  the size-resolution logic of `ContextBarWidget`:
  1. Read `windowSize` from `getContextWindowMetrics(context.data)`.
  2. Fall back to `getContextConfig(modelIdentifier).maxTokens` when
     the runtime payload doesn't carry a window size.
- Registered as type `context-window` in
  `src/utils/widget-manifest.ts`.
- Re-exported from `src/widgets/index.ts`.
- Supports `rawValue` (bare number) and the standard `Win: <n>` label.
- Uses the shared `formatTokens` helper, so output formatting stays
  consistent with `context-length` (`60.0k`, `1.0M`, etc.).

No changes to existing widgets, settings schema, or render pipeline.

## Test plan

- [x] `bun run lint` — clean (TypeScript + ESLint, max-warnings=0)
- [x] `bun test` — 824 / 824 pass, no regressions
- [x] `bun run build` — bundle compiles, `dist/ccstatusline.js`
      produced
- [x] Smoke render: feeding a sample status JSON yields
      `60.0k/1.0M (6.0%)` for Opus 1M and switches to `200.0k` when
      `context_window_size` is set to 200000
- [x] Verified the widget appears in the TUI's "Context" category
      alongside `Context Length` / `Context Percentage` and renders
      its preview value