### PR TITLE
fix(widget): claude-account-email respects CLAUDE_CONFIG_DIR

### DIFF
--- a/src/utils/__tests__/claude-settings.test.ts
+++ b/src/utils/__tests__/claude-settings.test.ts
@@ -16,6 +16,7 @@ import { DEFAULT_SETTINGS } from '../../types/Settings';
 import {
     CCSTATUSLINE_COMMANDS,
     getClaudeCodeVersion,
+    getClaudeJsonPath,
     getClaudeSettingsPath,
     getExistingStatusLine,
     getRefreshInterval,
@@ -125,6 +126,26 @@ describe('isKnownCommand', () => {
 
     it('should match command containing a quoted ccstatusline.ts path', () => {
         expect(isKnownCommand('bun run "/Users/Jane Doe/ccstatusline/src/ccstatusline.ts"')).toBe(true);
+    });
+});
+
+describe('Claude config paths', () => {
+    it('should resolve .claude.json inside CLAUDE_CONFIG_DIR when configured', () => {
+        expect(getClaudeJsonPath()).toBe(path.join(testClaudeConfigDir, '.claude.json'));
+    });
+
+    it('should resolve .claude.json beside the default Claude config dir when CLAUDE_CONFIG_DIR is unset', () => {
+        delete process.env.CLAUDE_CONFIG_DIR;
+
+        expect(getClaudeJsonPath()).toBe(path.join(os.homedir(), '.claude.json'));
+    });
+
+    it('should use default .claude.json path when CLAUDE_CONFIG_DIR points to a file', () => {
+        const invalidConfigDir = path.join(testClaudeConfigDir, 'not-a-dir');
+        fs.writeFileSync(invalidConfigDir, 'not a directory', 'utf-8');
+        process.env.CLAUDE_CONFIG_DIR = invalidConfigDir;
+
+        expect(getClaudeJsonPath()).toBe(path.join(os.homedir(), '.claude.json'));
     });
 });
 

--- a/src/utils/claude-settings.ts
+++ b/src/utils/claude-settings.ts
@@ -89,6 +89,23 @@ export function getClaudeConfigDir(): string {
 }
 
 /**
+ * Gets the full path to Claude Code's .claude.json account state file.
+ *
+ * Claude Code stores this as a sibling of the default ~/.claude directory, but
+ * inside CLAUDE_CONFIG_DIR when a valid config directory override is active.
+ */
+export function getClaudeJsonPath(): string {
+    const configDir = getClaudeConfigDir();
+    const envConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+    if (envConfigDir && configDir === path.resolve(envConfigDir)) {
+        return path.join(configDir, '.claude.json');
+    }
+
+    return path.join(path.dirname(configDir), '.claude.json');
+}
+
+/**
  * Gets the full path to the Claude settings.json file.
  */
 export function getClaudeSettingsPath(): string {

--- a/src/widgets/ClaudeAccountEmail.ts
+++ b/src/widgets/ClaudeAccountEmail.ts
@@ -1,6 +1,4 @@
 import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
 
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
@@ -9,24 +7,9 @@ import type {
     WidgetEditorDisplay,
     WidgetItem
 } from '../types/Widget';
+import { getClaudeJsonPath } from '../utils/claude-settings';
 
 interface ClaudeJson { oauthAccount?: { emailAddress?: string } }
-
-/**
- * Resolves the path to Claude Code's `.claude.json` state file.
- *
- * - When `CLAUDE_CONFIG_DIR` is set, Claude Code stores `.claude.json` inside
- *   that directory along with the rest of its config.
- * - When unset, `.claude.json` lives at `~/.claude.json` (sibling of the
- *   default `~/.claude` config dir).
- */
-function getClaudeJsonPath(): string {
-    const envConfigDir = process.env.CLAUDE_CONFIG_DIR;
-    if (envConfigDir) {
-        return path.resolve(envConfigDir, '.claude.json');
-    }
-    return path.join(os.homedir(), '.claude.json');
-}
 
 export class ClaudeAccountEmailWidget implements Widget {
     getDefaultColor(): string { return 'blue'; }

--- a/src/widgets/ClaudeAccountEmail.ts
+++ b/src/widgets/ClaudeAccountEmail.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 import type { RenderContext } from '../types/RenderContext';
@@ -8,9 +9,24 @@ import type {
     WidgetEditorDisplay,
     WidgetItem
 } from '../types/Widget';
-import { getClaudeConfigDir } from '../utils/claude-settings';
 
 interface ClaudeJson { oauthAccount?: { emailAddress?: string } }
+
+/**
+ * Resolves the path to Claude Code's `.claude.json` state file.
+ *
+ * - When `CLAUDE_CONFIG_DIR` is set, Claude Code stores `.claude.json` inside
+ *   that directory along with the rest of its config.
+ * - When unset, `.claude.json` lives at `~/.claude.json` (sibling of the
+ *   default `~/.claude` config dir).
+ */
+function getClaudeJsonPath(): string {
+    const envConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    if (envConfigDir) {
+        return path.resolve(envConfigDir, '.claude.json');
+    }
+    return path.join(os.homedir(), '.claude.json');
+}
 
 export class ClaudeAccountEmailWidget implements Widget {
     getDefaultColor(): string { return 'blue'; }
@@ -27,19 +43,11 @@ export class ClaudeAccountEmailWidget implements Widget {
         }
 
         try {
-            const configDir = getClaudeConfigDir();
-            const claudeJsonPath = path.join(configDir, '..', '.claude.json');
-            const resolved = path.resolve(claudeJsonPath);
-
-            if (!fs.existsSync(resolved)) {
-                return null;
-            }
-
-            const content = fs.readFileSync(resolved, 'utf-8');
+            const content = fs.readFileSync(getClaudeJsonPath(), 'utf-8');
             const data = JSON.parse(content) as ClaudeJson;
             const email = data.oauthAccount?.emailAddress;
 
-            if (!email) {
+            if (typeof email !== 'string' || email.length === 0) {
                 return null;
             }
 

--- a/src/widgets/__tests__/ClaudeAccountEmail.test.ts
+++ b/src/widgets/__tests__/ClaudeAccountEmail.test.ts
@@ -101,4 +101,53 @@ describe('ClaudeAccountEmailWidget', () => {
 
         expect(render()).toBeNull();
     });
+
+    it('reads from $CLAUDE_CONFIG_DIR/.claude.json when CLAUDE_CONFIG_DIR is set', () => {
+        // Regression test for #317: the widget previously read $HOME/.claude.json
+        // regardless of CLAUDE_CONFIG_DIR, causing all profiles to show the same email.
+        const customConfigDir = path.join(tempHomeDir, '.claude-work');
+        fs.mkdirSync(customConfigDir, { recursive: true });
+        process.env.CLAUDE_CONFIG_DIR = customConfigDir;
+
+        const claudeJsonPath = path.join(customConfigDir, '.claude.json');
+        fs.writeFileSync(
+            claudeJsonPath,
+            JSON.stringify({ oauthAccount: { emailAddress: 'work@example.com' } }),
+            'utf-8'
+        );
+
+        expect(render()).toBe('Account: work@example.com');
+    });
+
+    it('does not fall back to $HOME/.claude.json when CLAUDE_CONFIG_DIR points to a dir without one', () => {
+        // Verifies the fix for #317 doesn't silently leak the wrong profile's
+        // email when the configured profile has no .claude.json yet.
+        const customConfigDir = path.join(tempHomeDir, '.claude-empty');
+        fs.mkdirSync(customConfigDir, { recursive: true });
+        process.env.CLAUDE_CONFIG_DIR = customConfigDir;
+
+        // Plant a .claude.json in $HOME — the widget must NOT pick this up
+        vi.spyOn(os, 'homedir').mockReturnValue(tempHomeDir);
+        fs.writeFileSync(
+            path.join(tempHomeDir, '.claude.json'),
+            JSON.stringify({ oauthAccount: { emailAddress: 'leak@example.com' } }),
+            'utf-8'
+        );
+
+        expect(render()).toBeNull();
+    });
+
+    it('returns null when emailAddress is not a string', () => {
+        delete process.env.CLAUDE_CONFIG_DIR;
+        vi.spyOn(os, 'homedir').mockReturnValue(tempHomeDir);
+
+        const claudeJsonPath = path.join(tempHomeDir, '.claude.json');
+        fs.writeFileSync(
+            claudeJsonPath,
+            JSON.stringify({ oauthAccount: { emailAddress: 12345 } }),
+            'utf-8'
+        );
+
+        expect(render()).toBeNull();
+    });
 });


### PR DESCRIPTION
Closes #317.

The widget reads the same `.claude.json` no matter what `CLAUDE_CONFIG_DIR` is set to, so every profile ends up showing the same account email.

The path was built like this:

```ts
path.join(getClaudeConfigDir(), '..', '.claude.json')
```

That works for the default `~/.claude` config dir, since going up one level lands at `$HOME` where `.claude.json` actually lives. But when someone sets `CLAUDE_CONFIG_DIR=~/.claude-work`, the `..` still lands at `$HOME`, so every profile keeps reading the same file.

The reason it's not a simple fix: `.claude.json` lives at `$HOME` by default, but Claude Code moves it inside `CLAUDE_CONFIG_DIR` when that env var is set. The path needs to branch on whether the env var is there:

```ts
function getClaudeJsonPath(): string {
    const envConfigDir = process.env.CLAUDE_CONFIG_DIR;
    if (envConfigDir) {
        return path.resolve(envConfigDir, '.claude.json');
    }
    return path.join(os.homedir(), '.claude.json');
}
```

A few small extra changes I made in the same render method:

- Removed an `existsSync` check before `readFileSync`. The outer try/catch already handles missing files, and dropping the check also closes a small race window between the two calls.
- Dropped a redundant `path.resolve` on a path that was already absolute.
- Tightened the email check from `if (!email)` to `typeof email === 'string' && email.length > 0`. The old check would let a non-string `emailAddress` field through, so `{"emailAddress": 12345}` would have rendered as `Account: 12345`.

## Tests

Three new tests:

1. Widget reads from `$CLAUDE_CONFIG_DIR/.claude.json` when the env var is set. This is the regression test.
2. Widget returns null when `CLAUDE_CONFIG_DIR` points at a directory with no `.claude.json`, even if `$HOME/.claude.json` exists. Guards against the old fallback coming back.
3. Non-string `emailAddress` returns null.

All existing tests still pass. `bun run lint`, `bun test`, and `bun run build` are all clean.

@daren-porter — if you have a minute, could you check this against your work/personal alias setup? The new tests mirror what you described in the issue, but a real-world confirmation would help.