### PR TITLE
feat: support local/IANA timezone in reset timer date mode

### DIFF
--- a/src/tui/components/items-editor/__tests__/input-handlers.test.ts
+++ b/src/tui/components/items-editor/__tests__/input-handlers.test.ts
@@ -641,6 +641,37 @@ describe('items-editor input handlers', () => {
         expect(customEditorState?.widget?.type).toBe('reset-timer');
     });
 
+    it('opens custom editor for reset timer locale action', () => {
+        const widgets: WidgetItem[] = [
+            { id: '1', type: 'reset-timer', metadata: { absolute: 'true' } }
+        ];
+        const onUpdate = vi.fn();
+        const setCustomEditorWidget = vi.fn();
+
+        handleNormalInputMode({
+            input: 'l',
+            key: {},
+            widgets,
+            selectedIndex: 0,
+            separatorChars: ['|', '-'],
+            onBack: vi.fn(),
+            onUpdate,
+            setSelectedIndex: vi.fn(),
+            setMoveMode: vi.fn(),
+            setShowClearConfirm: vi.fn(),
+            openWidgetPicker: vi.fn(),
+            getCustomKeybindsForWidget: (widgetImpl, widget) => widgetImpl.getCustomKeybinds ? widgetImpl.getCustomKeybinds(widget) : [],
+            setCustomEditorWidget
+        });
+
+        expect(onUpdate).not.toHaveBeenCalled();
+        const customEditorState = setCustomEditorWidget.mock.calls[0]?.[0] as
+            | { action?: string; widget?: WidgetItem }
+            | undefined;
+        expect(customEditorState?.action).toBe('edit-locale');
+        expect(customEditorState?.widget?.type).toBe('reset-timer');
+    });
+
     it('uses v to cycle skills widget mode', () => {
         const widgets: WidgetItem[] = [
             { id: '1', type: 'skills' }

--- a/src/tui/components/items-editor/__tests__/input-handlers.test.ts
+++ b/src/tui/components/items-editor/__tests__/input-handlers.test.ts
@@ -584,6 +584,63 @@ describe('items-editor input handlers', () => {
         expect(updated?.[0]?.metadata?.absolute).toBe('true');
     });
 
+    it('uses h to toggle reset timer hour format in timestamp mode', () => {
+        const widgets: WidgetItem[] = [
+            { id: '1', type: 'reset-timer', metadata: { absolute: 'true' } }
+        ];
+        const onUpdate = vi.fn();
+
+        handleNormalInputMode({
+            input: 'h',
+            key: {},
+            widgets,
+            selectedIndex: 0,
+            separatorChars: ['|', '-'],
+            onBack: vi.fn(),
+            onUpdate,
+            setSelectedIndex: vi.fn(),
+            setMoveMode: vi.fn(),
+            setShowClearConfirm: vi.fn(),
+            openWidgetPicker: vi.fn(),
+            getCustomKeybindsForWidget: (widgetImpl, widget) => widgetImpl.getCustomKeybinds ? widgetImpl.getCustomKeybinds(widget) : [],
+            setCustomEditorWidget: vi.fn()
+        });
+
+        const updated = onUpdate.mock.calls[0]?.[0] as WidgetItem[] | undefined;
+        expect(updated?.[0]?.metadata?.hour12).toBe('true');
+    });
+
+    it('opens custom editor for reset timer timezone action', () => {
+        const widgets: WidgetItem[] = [
+            { id: '1', type: 'reset-timer', metadata: { absolute: 'true' } }
+        ];
+        const onUpdate = vi.fn();
+        const setCustomEditorWidget = vi.fn();
+
+        handleNormalInputMode({
+            input: 'z',
+            key: {},
+            widgets,
+            selectedIndex: 0,
+            separatorChars: ['|', '-'],
+            onBack: vi.fn(),
+            onUpdate,
+            setSelectedIndex: vi.fn(),
+            setMoveMode: vi.fn(),
+            setShowClearConfirm: vi.fn(),
+            openWidgetPicker: vi.fn(),
+            getCustomKeybindsForWidget: (widgetImpl, widget) => widgetImpl.getCustomKeybinds ? widgetImpl.getCustomKeybinds(widget) : [],
+            setCustomEditorWidget
+        });
+
+        expect(onUpdate).not.toHaveBeenCalled();
+        const customEditorState = setCustomEditorWidget.mock.calls[0]?.[0] as
+            | { action?: string; widget?: WidgetItem }
+            | undefined;
+        expect(customEditorState?.action).toBe('edit-timezone');
+        expect(customEditorState?.widget?.type).toBe('reset-timer');
+    });
+
     it('uses v to cycle skills widget mode', () => {
         const widgets: WidgetItem[] = [
             { id: '1', type: 'skills' }

--- a/src/utils/__tests__/locales.test.ts
+++ b/src/utils/__tests__/locales.test.ts
@@ -1,0 +1,83 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import {
+    DEFAULT_RESET_LOCALE,
+    canonicalizeLocale,
+    filterLocaleOptions,
+    getLocaleMatchSegments,
+    getLocaleOptions,
+    getSystemLocale,
+    isValidLocale
+} from '../locales';
+
+describe('locale helpers', () => {
+    it('includes the default locale first and curated common locales', () => {
+        const options = getLocaleOptions();
+
+        expect(options[0]?.value).toBe(DEFAULT_RESET_LOCALE);
+        expect(options.some(option => option.value === 'ja-JP')).toBe(true);
+        expect(options.some(option => option.value === 'en-US')).toBe(true);
+        expect(options.some(option => option.value === 'en-CA')).toBe(true);
+    });
+
+    it('includes the system locale when it differs from the default', () => {
+        const systemLocale = getSystemLocale();
+        const options = getLocaleOptions();
+
+        expect(systemLocale === null || options.some(option => option.value === systemLocale)).toBe(true);
+    });
+
+    it('includes the configured locale when it is valid and uncommon', () => {
+        const configuredLocale = canonicalizeLocale('en-AU');
+        if (!configuredLocale) {
+            return;
+        }
+
+        const options = getLocaleOptions(configuredLocale);
+
+        expect(options.some(option => option.value === configuredLocale && option.description === 'Configured locale')).toBe(true);
+    });
+
+    it('filters locale options with fuzzy matching', () => {
+        const matches = filterLocaleOptions(getLocaleOptions(), 'japan');
+
+        expect(matches[0]?.value).toBe('ja-JP');
+    });
+
+    it('adds a custom locale option for valid typed locales outside the curated list', () => {
+        const customLocale = canonicalizeLocale('en-AU');
+        if (!customLocale) {
+            return;
+        }
+
+        const matches = filterLocaleOptions(getLocaleOptions(), 'en-au');
+
+        expect(matches[0]).toMatchObject({
+            value: customLocale,
+            displayName: `Use ${customLocale}`,
+            description: 'Custom locale'
+        });
+    });
+
+    it('does not add a custom locale option for invalid typed locales', () => {
+        const matches = filterLocaleOptions(getLocaleOptions(), 'not-a-locale');
+
+        expect(matches.some(option => option.description === 'Custom locale')).toBe(false);
+    });
+
+    it('highlights locale match segments', () => {
+        const segments = getLocaleMatchSegments('ja-JP', 'ja');
+
+        expect(segments.some(segment => segment.text === 'ja' && segment.matched)).toBe(true);
+    });
+
+    it('canonicalizes and validates BCP 47 locale tags', () => {
+        expect(canonicalizeLocale('ja-jp')).toBe('ja-JP');
+        expect(isValidLocale('fr-ca')).toBe(true);
+        expect(isValidLocale('not-a-locale')).toBe(false);
+    });
+});

--- a/src/utils/__tests__/timezones.test.ts
+++ b/src/utils/__tests__/timezones.test.ts
@@ -1,0 +1,61 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import {
+    filterTimezoneOptions,
+    getLocalTimezone,
+    getTimezoneMatchSegments,
+    getTimezoneOptions,
+    isValidTimezone
+} from '../timezones';
+
+describe('timezone helpers', () => {
+    it('includes default UTC and local timezone options first', () => {
+        const options = getTimezoneOptions();
+
+        expect(options[0]?.value).toBe('UTC');
+        expect(options[1]?.value).toBe('local');
+        expect(options[1]?.displayName).toContain('Local');
+    });
+
+    it('lists native IANA timezones when available', () => {
+        const options = getTimezoneOptions();
+        const hasNativeTimezoneList = typeof Intl.supportedValuesOf === 'function';
+
+        if (hasNativeTimezoneList) {
+            expect(options.some(option => option.value === 'Asia/Tokyo')).toBe(true);
+        }
+    });
+
+    it('filters timezone options with fuzzy matching', () => {
+        const options = getTimezoneOptions();
+        const matches = filterTimezoneOptions(options, 'tokyo');
+
+        if (typeof Intl.supportedValuesOf === 'function') {
+            expect(matches[0]?.value).toBe('Asia/Tokyo');
+        } else {
+            expect(matches).toHaveLength(0);
+        }
+    });
+
+    it('highlights timezone match segments', () => {
+        const segments = getTimezoneMatchSegments('America/New_York', 'ny');
+
+        expect(segments.some(segment => segment.text === 'N' && segment.matched)).toBe(true);
+        expect(segments.some(segment => segment.text === 'Y' && segment.matched)).toBe(true);
+    });
+
+    it('validates IANA timezone names', () => {
+        expect(isValidTimezone('Asia/Tokyo')).toBe(true);
+        expect(isValidTimezone('Not/A_Real_Zone')).toBe(false);
+    });
+
+    it('returns the system local timezone when available', () => {
+        const timezone = getLocalTimezone();
+
+        expect(timezone === null || timezone.length > 0).toBe(true);
+    });
+});

--- a/src/utils/__tests__/usage.test.ts
+++ b/src/utils/__tests__/usage.test.ts
@@ -188,6 +188,28 @@ describe('usage window helpers', () => {
         expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2} \S+$/);
     });
 
+    it('uses the supplied locale to choose the timezone abbreviation', () => {
+        // ja-JP returns 'JST' for Asia/Tokyo, en-CA returns 'GMT+9'
+        const ja = formatUsageResetAt('2026-04-27T10:00:00.000Z', false, 'Asia/Tokyo', 'ja-JP');
+        expect(ja).toBe('2026-04-27 19:00 JST');
+
+        const en = formatUsageResetAt('2026-04-27T10:00:00.000Z', false, 'Asia/Tokyo', 'en-CA');
+        expect(en).toBe('2026-04-27 19:00 GMT+9');
+    });
+
+    it('compact mode drops the locale-dependent timezone abbreviation', () => {
+        const ja = formatUsageResetAt('2026-04-27T10:00:00.000Z', true, 'Asia/Tokyo', 'ja-JP');
+        expect(ja).toBe('04-27 19:00');
+    });
+
+    it('still produces a valid output even with a permissive/unknown locale', () => {
+        // Intl.DateTimeFormat is lenient about locale strings (canonicalizes
+        // or falls back to system default). We just verify the output shape
+        // is intact — locale handling is delegated to the runtime ICU data.
+        const result = formatUsageResetAt('2026-04-27T10:00:00.000Z', false, 'Asia/Tokyo', 'xx-XX');
+        expect(result).toMatch(/^2026-04-27 19:00 \S+$/);
+    });
+
     it('formats duration with days in compact style when >= 24h', () => {
         expect(formatUsageDuration(25 * 60 * 60 * 1000, true)).toBe('1d1h');
         expect(formatUsageDuration(36.5 * 60 * 60 * 1000, true)).toBe('1d12h30m');

--- a/src/utils/__tests__/usage.test.ts
+++ b/src/utils/__tests__/usage.test.ts
@@ -164,6 +164,30 @@ describe('usage window helpers', () => {
         expect(formatUsageResetAt('not-a-date')).toBeNull();
     });
 
+    it('formats reset timestamps in a specific IANA timezone', () => {
+        const result = formatUsageResetAt('2026-04-27T10:00:00.000Z', false, 'Asia/Tokyo');
+        expect(result).toMatch(/^2026-04-27 19:00 /);
+        const compactResult = formatUsageResetAt('2026-04-27T10:00:00.000Z', true, 'Asia/Tokyo');
+        expect(compactResult).toBe('04-27 19:00');
+    });
+
+    it('keeps UTC behavior when timezone is undefined or "UTC"', () => {
+        expect(formatUsageResetAt('2026-03-12T08:30:00.000Z')).toBe('2026-03-12 08:30 UTC');
+        expect(formatUsageResetAt('2026-03-12T08:30:00.000Z', false, 'UTC')).toBe('2026-03-12 08:30 UTC');
+        expect(formatUsageResetAt('2026-03-12T08:30:00.000Z', true, 'UTC')).toBe('03-12 08:30Z');
+    });
+
+    it('falls back to UTC when timezone is invalid', () => {
+        const result = formatUsageResetAt('2026-03-12T08:30:00.000Z', false, 'Not/A_Real_Zone');
+        expect(result).toBe('2026-03-12 08:30 UTC');
+    });
+
+    it('renders the system local timezone when timezone is "local"', () => {
+        const result = formatUsageResetAt('2026-03-12T08:30:00.000Z', false, 'local');
+        expect(result).not.toBeNull();
+        expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2} \S+$/);
+    });
+
     it('formats duration with days in compact style when >= 24h', () => {
         expect(formatUsageDuration(25 * 60 * 60 * 1000, true)).toBe('1d1h');
         expect(formatUsageDuration(36.5 * 60 * 60 * 1000, true)).toBe('1d12h30m');

--- a/src/utils/__tests__/usage.test.ts
+++ b/src/utils/__tests__/usage.test.ts
@@ -184,6 +184,12 @@ describe('usage window helpers', () => {
         expect(compactResult).toBe('04-27 7:00 PM');
     });
 
+    it('normalizes lowercase 12-hour day periods from locale data', () => {
+        const result = formatUsageResetAt('2026-04-27T10:00:00.000Z', false, 'Asia/Tokyo', 'en-GB', true);
+
+        expect(result).toMatch(/^2026-04-27 7:00 PM /);
+    });
+
     it('keeps UTC behavior when timezone is undefined or "UTC"', () => {
         expect(formatUsageResetAt('2026-03-12T08:30:00.000Z')).toBe('2026-03-12 08:30 UTC');
         expect(formatUsageResetAt('2026-03-12T08:30:00.000Z', false, 'UTC')).toBe('2026-03-12 08:30 UTC');
@@ -202,11 +208,11 @@ describe('usage window helpers', () => {
     });
 
     it('uses the supplied locale to choose the timezone abbreviation', () => {
-        // ja-JP returns 'JST' for Asia/Tokyo, en-CA returns 'GMT+9'
+        // ja-JP returns 'JST' for Asia/Tokyo, en-US returns 'GMT+9'
         const ja = formatUsageResetAt('2026-04-27T10:00:00.000Z', false, 'Asia/Tokyo', 'ja-JP');
         expect(ja).toBe('2026-04-27 19:00 JST');
 
-        const en = formatUsageResetAt('2026-04-27T10:00:00.000Z', false, 'Asia/Tokyo', 'en-CA');
+        const en = formatUsageResetAt('2026-04-27T10:00:00.000Z', false, 'Asia/Tokyo', 'en-US');
         expect(en).toBe('2026-04-27 19:00 GMT+9');
     });
 

--- a/src/utils/__tests__/usage.test.ts
+++ b/src/utils/__tests__/usage.test.ts
@@ -159,6 +159,12 @@ describe('usage window helpers', () => {
         expect(formatUsageResetAt('2026-03-12T08:30:00.000Z', true)).toBe('03-12 08:30Z');
     });
 
+    it('formats reset timestamps with a 12-hour clock when requested', () => {
+        expect(formatUsageResetAt('2026-03-12T08:30:00.000Z', false, 'UTC', true)).toBe('2026-03-12 8:30 AM UTC');
+        expect(formatUsageResetAt('2026-03-12T20:30:00.000Z', false, 'UTC', true)).toBe('2026-03-12 8:30 PM UTC');
+        expect(formatUsageResetAt('2026-03-12T08:30:00.000Z', true, 'UTC', true)).toBe('03-12 8:30 AMZ');
+    });
+
     it('returns null for invalid reset timestamps in date mode', () => {
         expect(formatUsageResetAt(undefined)).toBeNull();
         expect(formatUsageResetAt('not-a-date')).toBeNull();
@@ -169,6 +175,13 @@ describe('usage window helpers', () => {
         expect(result).toMatch(/^2026-04-27 19:00 /);
         const compactResult = formatUsageResetAt('2026-04-27T10:00:00.000Z', true, 'Asia/Tokyo');
         expect(compactResult).toBe('04-27 19:00');
+    });
+
+    it('formats reset timestamps with a 12-hour clock in a specific IANA timezone', () => {
+        const result = formatUsageResetAt('2026-04-27T10:00:00.000Z', false, 'Asia/Tokyo', true);
+        expect(result).toMatch(/^2026-04-27 7:00 PM /);
+        const compactResult = formatUsageResetAt('2026-04-27T10:00:00.000Z', true, 'Asia/Tokyo', true);
+        expect(compactResult).toBe('04-27 7:00 PM');
     });
 
     it('keeps UTC behavior when timezone is undefined or "UTC"', () => {

--- a/src/utils/fuzzy.ts
+++ b/src/utils/fuzzy.ts
@@ -1,0 +1,281 @@
+export interface MatchSegment {
+    text: string;
+    matched: boolean;
+}
+
+export interface FuzzySearchRecord<T> {
+    item: T;
+    name: string;
+    type: string;
+    description: string;
+    searchText: string;
+    sortText: string;
+    secondarySortText: string;
+}
+
+function isWordStart(text: string, position: number): boolean {
+    return position === 0
+        || text[position - 1] === ' '
+        || text[position - 1] === '-'
+        || text[position - 1] === '_'
+        || text[position - 1] === '/';
+}
+
+function findSubsequencePositions(text: string, query: string): number[] | null {
+    let qi = 0;
+    const positions: number[] = [];
+
+    for (let ti = 0; ti < text.length && qi < query.length; ti++) {
+        if (text[ti] === query[qi]) {
+            positions.push(ti);
+            qi++;
+        }
+    }
+
+    return qi < query.length ? null : positions;
+}
+
+function findInitialismMatch(text: string, query: string): { positions: number[]; score: number } | null {
+    const wordStartPositions: number[] = [];
+
+    for (let i = 0; i < text.length; i++) {
+        if (isWordStart(text, i)) {
+            wordStartPositions.push(i);
+        }
+    }
+
+    const initials = wordStartPositions.map(position => text[position]).join('');
+    const matchedInitials = findSubsequencePositions(initials, query);
+
+    if (matchedInitials === null) {
+        return null;
+    }
+
+    const first = matchedInitials[0];
+    const last = matchedInitials[matchedInitials.length - 1];
+
+    if (first === undefined || last === undefined) {
+        return null;
+    }
+
+    const positions: number[] = [];
+
+    for (const initialIndex of matchedInitials) {
+        const position = wordStartPositions[initialIndex];
+        if (position === undefined) {
+            return null;
+        }
+        positions.push(position);
+    }
+
+    return {
+        positions,
+        score: (last - first) + first
+    };
+}
+
+function computeFuzzyScore(text: string, query: string): number | null {
+    const CONSECUTIVE_BONUS_RATE = 5;
+    const WORD_START_BONUS_RATE = 20;
+    const FULL_INITIALISM_BONUS = 40;
+    const positions = findSubsequencePositions(text, query);
+
+    if (positions === null) {
+        return null;
+    }
+
+    const first = positions[0];
+    const last = positions[positions.length - 1];
+
+    if (first === undefined || last === undefined) {
+        return null;
+    }
+
+    const span = last - first;
+    let consecutiveBonus = 0;
+    let wordStartMatches = 0;
+
+    let previousPosition: number | null = null;
+
+    positions.forEach((position) => {
+        if (previousPosition !== null && position === previousPosition + 1) {
+            consecutiveBonus += CONSECUTIVE_BONUS_RATE;
+        }
+        if (isWordStart(text, position)) {
+            wordStartMatches++;
+        }
+        previousPosition = position;
+    });
+
+    const fullInitialismBonus = wordStartMatches === query.length
+        ? FULL_INITIALISM_BONUS
+        : 0;
+
+    return span
+        + first
+        - consecutiveBonus
+        - (wordStartMatches * WORD_START_BONUS_RATE)
+        - fullInitialismBonus;
+}
+
+export function filterFuzzySearchRecords<T>(records: FuzzySearchRecord<T>[], query: string): T[] {
+    const MATCH_PRIORITY = {
+        NAME_PREFIX_WITH_INITIALISM: 0,
+        NAME_PREFIX: 1,
+        NAME_INITIALISM: 2,
+        NAME_SUBSTRING: 3,
+        TYPE_SUBSTRING: 4,
+        NAME_FUZZY: 5,
+        DESCRIPTION_SUBSTRING: 6,
+        SEARCH_SUBSTRING: 7,
+        TYPE_FUZZY: 8,
+        SEARCH_FUZZY: 9
+    };
+
+    const MATCH_TIER_SIZE = 1000;
+    const normalizedQuery = query.trim().toLowerCase();
+
+    const withScore = records
+        .map((record) => {
+            if (!normalizedQuery) {
+                return {
+                    record,
+                    score: 99
+                };
+            }
+
+            const name = record.name.toLowerCase();
+            const description = record.description.toLowerCase();
+            const type = record.type.toLowerCase();
+            const searchText = record.searchText.toLowerCase();
+            const nameInitialism = findInitialismMatch(name, normalizedQuery);
+
+            if (name.startsWith(normalizedQuery) && nameInitialism !== null) {
+                return { record, score: MATCH_PRIORITY.NAME_PREFIX_WITH_INITIALISM * MATCH_TIER_SIZE + nameInitialism.score };
+            }
+            if (name.startsWith(normalizedQuery)) {
+                return { record, score: MATCH_PRIORITY.NAME_PREFIX * MATCH_TIER_SIZE };
+            }
+            if (nameInitialism !== null) {
+                return { record, score: MATCH_PRIORITY.NAME_INITIALISM * MATCH_TIER_SIZE + nameInitialism.score };
+            }
+            if (name.includes(normalizedQuery)) {
+                return { record, score: MATCH_PRIORITY.NAME_SUBSTRING * MATCH_TIER_SIZE };
+            }
+            if (type.includes(normalizedQuery)) {
+                return { record, score: MATCH_PRIORITY.TYPE_SUBSTRING * MATCH_TIER_SIZE };
+            }
+
+            const nameFuzzy = computeFuzzyScore(name, normalizedQuery);
+            if (nameFuzzy !== null) {
+                return { record, score: MATCH_PRIORITY.NAME_FUZZY * MATCH_TIER_SIZE + nameFuzzy };
+            }
+            if (description.includes(normalizedQuery)) {
+                return { record, score: MATCH_PRIORITY.DESCRIPTION_SUBSTRING * MATCH_TIER_SIZE };
+            }
+            if (searchText.includes(normalizedQuery)) {
+                return { record, score: MATCH_PRIORITY.SEARCH_SUBSTRING * MATCH_TIER_SIZE };
+            }
+            const typeFuzzy = computeFuzzyScore(type, normalizedQuery);
+            if (typeFuzzy !== null) {
+                return { record, score: MATCH_PRIORITY.TYPE_FUZZY * MATCH_TIER_SIZE + typeFuzzy };
+            }
+            const searchFuzzy = computeFuzzyScore(searchText, normalizedQuery);
+            if (searchFuzzy !== null) {
+                return { record, score: MATCH_PRIORITY.SEARCH_FUZZY * MATCH_TIER_SIZE + searchFuzzy };
+            }
+
+            return null;
+        })
+        .filter((item): item is { record: FuzzySearchRecord<T>; score: number } => item !== null);
+
+    return withScore
+        .sort((a, b) => {
+            if (a.score !== b.score) {
+                return a.score - b.score;
+            }
+
+            const bySortText = a.record.sortText.localeCompare(b.record.sortText);
+            if (bySortText !== 0) {
+                return bySortText;
+            }
+
+            return a.record.secondarySortText.localeCompare(b.record.secondarySortText);
+        })
+        .map(item => item.record.item);
+}
+
+export function getMatchSegments(text: string, query: string): MatchSegment[] {
+    if (!query.trim()) {
+        return [{ text, matched: false }];
+    }
+
+    const normalizedQuery = query.trim().toLowerCase();
+    const normalizedText = text.toLowerCase();
+
+    const initialismPositions = findInitialismMatch(normalizedText, normalizedQuery)?.positions;
+    if (initialismPositions !== undefined) {
+        const posSet = new Set(initialismPositions);
+        const segments: MatchSegment[] = [];
+        let current = '';
+        let currentMatched = posSet.has(0);
+
+        for (let i = 0; i < text.length; i++) {
+            const isMatched = posSet.has(i);
+            if (isMatched !== currentMatched && current) {
+                segments.push({ text: current, matched: currentMatched });
+                current = text[i] ?? '';
+                currentMatched = isMatched;
+            } else {
+                current += text[i] ?? '';
+            }
+        }
+
+        if (current) {
+            segments.push({ text: current, matched: currentMatched });
+        }
+
+        return segments;
+    }
+
+    const substringIdx = normalizedText.indexOf(normalizedQuery);
+    if (substringIdx !== -1) {
+        const end = substringIdx + normalizedQuery.length;
+        const segments: MatchSegment[] = [];
+        if (substringIdx > 0) {
+            segments.push({ text: text.slice(0, substringIdx), matched: false });
+        }
+        segments.push({ text: text.slice(substringIdx, end), matched: true });
+        if (end < text.length) {
+            segments.push({ text: text.slice(end), matched: false });
+        }
+        return segments;
+    }
+
+    const positions = findSubsequencePositions(normalizedText, normalizedQuery);
+    if (positions === null) {
+        return [{ text, matched: false }];
+    }
+
+    const posSet = new Set(positions);
+    const segments: MatchSegment[] = [];
+    let current = '';
+    let currentMatched = posSet.has(0);
+
+    for (let i = 0; i < text.length; i++) {
+        const isMatched = posSet.has(i);
+        if (isMatched !== currentMatched && current) {
+            segments.push({ text: current, matched: currentMatched });
+            current = text[i] ?? '';
+            currentMatched = isMatched;
+        } else {
+            current += text[i] ?? '';
+        }
+    }
+
+    if (current) {
+        segments.push({ text: current, matched: currentMatched });
+    }
+
+    return segments;
+}

--- a/src/utils/locales.ts
+++ b/src/utils/locales.ts
@@ -1,0 +1,175 @@
+import {
+    filterFuzzySearchRecords,
+    getMatchSegments,
+    type FuzzySearchRecord,
+    type MatchSegment
+} from './fuzzy';
+
+export const DEFAULT_RESET_LOCALE = 'en-US';
+
+export interface LocaleOption {
+    value: string;
+    displayName: string;
+    description: string;
+    searchText: string;
+    sortText: string;
+}
+
+interface CommonLocale {
+    value: string;
+    description: string;
+    searchText: string;
+}
+
+const COMMON_LOCALES: CommonLocale[] = [
+    { value: 'en-US', description: 'English (United States)', searchText: 'english united states usa us america' },
+    { value: 'en-CA', description: 'English (Canada)', searchText: 'english canada canadian ca' },
+    { value: 'en-GB', description: 'English (United Kingdom)', searchText: 'english united kingdom great britain uk gb' },
+    { value: 'fr-FR', description: 'French (France)', searchText: 'french france francais' },
+    { value: 'fr-CA', description: 'French (Canada)', searchText: 'french canada canadian quebec francais' },
+    { value: 'de-DE', description: 'German (Germany)', searchText: 'german germany deutsch deutschland' },
+    { value: 'es-ES', description: 'Spanish (Spain)', searchText: 'spanish spain espanol espana' },
+    { value: 'es-MX', description: 'Spanish (Mexico)', searchText: 'spanish mexico mexican espanol' },
+    { value: 'ja-JP', description: 'Japanese (Japan)', searchText: 'japanese japan nihongo' },
+    { value: 'ko-KR', description: 'Korean (South Korea)', searchText: 'korean korea hangul' },
+    { value: 'zh-CN', description: 'Chinese (China, Simplified)', searchText: 'chinese china simplified mandarin' },
+    { value: 'zh-TW', description: 'Chinese (Taiwan, Traditional)', searchText: 'chinese taiwan traditional mandarin' },
+    { value: 'pt-BR', description: 'Portuguese (Brazil)', searchText: 'portuguese brazil brasil portugues' },
+    { value: 'it-IT', description: 'Italian (Italy)', searchText: 'italian italy italiano' },
+    { value: 'nl-NL', description: 'Dutch (Netherlands)', searchText: 'dutch netherlands nederland nederlands' },
+    { value: 'sv-SE', description: 'Swedish (Sweden)', searchText: 'swedish sweden svenska' },
+    { value: 'pl-PL', description: 'Polish (Poland)', searchText: 'polish poland polski' },
+    { value: 'ru-RU', description: 'Russian (Russia)', searchText: 'russian russia russkiy' },
+    { value: 'hi-IN', description: 'Hindi (India)', searchText: 'hindi india devanagari' },
+    { value: 'ar-SA', description: 'Arabic (Saudi Arabia)', searchText: 'arabic saudi arabia' }
+];
+
+const DEFAULT_LOCALE_OPTION: LocaleOption = {
+    value: DEFAULT_RESET_LOCALE,
+    displayName: DEFAULT_RESET_LOCALE,
+    description: 'Default reset timestamp locale',
+    searchText: 'default english united states usa us america reset timestamp',
+    sortText: `0000 ${DEFAULT_RESET_LOCALE}`
+};
+
+export function canonicalizeLocale(locale: string): string | null {
+    const trimmed = locale.trim();
+    if (!trimmed) {
+        return null;
+    }
+
+    try {
+        const canonical = Intl.getCanonicalLocales(trimmed)[0];
+        if (!canonical || Intl.DateTimeFormat.supportedLocalesOf([canonical]).length === 0) {
+            return null;
+        }
+
+        return canonical;
+    } catch {
+        return null;
+    }
+}
+
+export function getSystemLocale(): string | null {
+    const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+    return typeof locale === 'string' ? canonicalizeLocale(locale) : null;
+}
+
+export function isValidLocale(locale: string): boolean {
+    return canonicalizeLocale(locale) !== null;
+}
+
+function createSystemLocaleOption(systemLocale: string): LocaleOption {
+    return {
+        value: systemLocale,
+        displayName: `System (${systemLocale})`,
+        description: 'Current system locale',
+        searchText: `system current local machine runtime ${systemLocale}`,
+        sortText: `0001 ${systemLocale}`
+    };
+}
+
+function createCommonLocaleOption(locale: CommonLocale, sortIndex: number): LocaleOption {
+    return {
+        value: locale.value,
+        displayName: locale.value,
+        description: locale.description,
+        searchText: locale.searchText,
+        sortText: `${(sortIndex + 2).toString().padStart(4, '0')} ${locale.value}`
+    };
+}
+
+function createConfiguredLocaleOption(locale: string): LocaleOption {
+    return {
+        value: locale,
+        displayName: locale,
+        description: 'Configured locale',
+        searchText: `configured current ${locale}`,
+        sortText: `0002 ${locale}`
+    };
+}
+
+function createCustomLocaleOption(locale: string): LocaleOption {
+    return {
+        value: locale,
+        displayName: `Use ${locale}`,
+        description: 'Custom locale',
+        searchText: `custom typed ${locale}`,
+        sortText: `0000 ${locale}`
+    };
+}
+
+function appendUniqueLocale(options: LocaleOption[], option: LocaleOption): void {
+    if (!options.some(existing => existing.value === option.value)) {
+        options.push(option);
+    }
+}
+
+export function getLocaleOptions(currentLocale?: string): LocaleOption[] {
+    const options = [DEFAULT_LOCALE_OPTION];
+    const systemLocale = getSystemLocale();
+
+    if (systemLocale && systemLocale !== DEFAULT_RESET_LOCALE) {
+        appendUniqueLocale(options, createSystemLocaleOption(systemLocale));
+    }
+
+    const configuredLocale = currentLocale ? canonicalizeLocale(currentLocale) : null;
+    if (configuredLocale && configuredLocale !== DEFAULT_RESET_LOCALE && configuredLocale !== systemLocale) {
+        appendUniqueLocale(options, createConfiguredLocaleOption(configuredLocale));
+    }
+
+    COMMON_LOCALES
+        .map(createCommonLocaleOption)
+        .forEach((option) => {
+            appendUniqueLocale(options, option);
+        });
+
+    return options;
+}
+
+export function filterLocaleOptions(options: LocaleOption[], query: string): LocaleOption[] {
+    const records: FuzzySearchRecord<LocaleOption>[] = options.map(option => ({
+        item: option,
+        name: option.displayName,
+        type: option.value,
+        description: option.description,
+        searchText: `${option.displayName} ${option.description} ${option.value} ${option.searchText}`,
+        sortText: option.sortText,
+        secondarySortText: option.value
+    }));
+    const matches = filterFuzzySearchRecords(records, query);
+    const canonicalQuery = canonicalizeLocale(query);
+
+    if (!canonicalQuery || options.some(option => option.value === canonicalQuery)) {
+        return matches;
+    }
+
+    return [
+        createCustomLocaleOption(canonicalQuery),
+        ...matches
+    ];
+}
+
+export function getLocaleMatchSegments(text: string, query: string): MatchSegment[] {
+    return getMatchSegments(text, query);
+}

--- a/src/utils/timezones.ts
+++ b/src/utils/timezones.ts
@@ -1,0 +1,125 @@
+import {
+    filterFuzzySearchRecords,
+    getMatchSegments,
+    type FuzzySearchRecord,
+    type MatchSegment
+} from './fuzzy';
+
+export interface TimezoneOption {
+    value: string;
+    displayName: string;
+    description: string;
+    searchText: string;
+    sortText: string;
+}
+
+const UTC_TIMEZONE: TimezoneOption = {
+    value: 'UTC',
+    displayName: 'UTC',
+    description: 'Default UTC reset timestamp',
+    searchText: 'utc default coordinated universal time z',
+    sortText: '0000 UTC'
+};
+
+function getSupportedTimezoneValues(): string[] {
+    const supportedValuesOf = Intl.supportedValuesOf as ((key: 'timeZone') => string[]) | undefined;
+
+    if (typeof supportedValuesOf !== 'function') {
+        return [];
+    }
+
+    try {
+        return supportedValuesOf('timeZone');
+    } catch {
+        return [];
+    }
+}
+
+export function getLocalTimezone(): string | null {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return typeof timezone === 'string' && timezone.length > 0 ? timezone : null;
+}
+
+export function isValidTimezone(timezone: string): boolean {
+    try {
+        Intl.DateTimeFormat('en-US', { timeZone: timezone });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function createLocalTimezoneOption(): TimezoneOption {
+    const localTimezone = getLocalTimezone();
+    const suffix = localTimezone ? ` (${localTimezone})` : '';
+    const searchText = [
+        'local',
+        'system',
+        'machine',
+        'browser',
+        localTimezone ?? ''
+    ].join(' ');
+
+    return {
+        value: 'local',
+        displayName: `Local${suffix}`,
+        description: 'Use this system timezone',
+        searchText,
+        sortText: `0001 Local${suffix}`
+    };
+}
+
+function createIanaTimezoneOption(timezone: string, sortIndex: number): TimezoneOption {
+    return {
+        value: timezone,
+        displayName: timezone,
+        description: 'IANA timezone',
+        searchText: timezone.replace(/[/_-]/g, ' '),
+        sortText: `${(sortIndex + 2).toString().padStart(4, '0')} ${timezone}`
+    };
+}
+
+export function getTimezoneOptions(currentTimezone?: string): TimezoneOption[] {
+    const supportedTimezones = getSupportedTimezoneValues()
+        .filter(timezone => timezone !== 'UTC');
+    const options = [
+        UTC_TIMEZONE,
+        createLocalTimezoneOption(),
+        ...supportedTimezones.map(createIanaTimezoneOption)
+    ];
+    const hasCurrentTimezone = currentTimezone
+        && currentTimezone !== 'UTC'
+        && currentTimezone !== 'local'
+        && options.some(option => option.value === currentTimezone);
+
+    if (!currentTimezone || hasCurrentTimezone || currentTimezone === 'UTC' || currentTimezone === 'local' || !isValidTimezone(currentTimezone)) {
+        return options;
+    }
+
+    return [
+        ...options.slice(0, 2),
+        {
+            ...createIanaTimezoneOption(currentTimezone, 0),
+            description: 'Configured timezone'
+        },
+        ...options.slice(2)
+    ];
+}
+
+export function filterTimezoneOptions(options: TimezoneOption[], query: string): TimezoneOption[] {
+    const records: FuzzySearchRecord<TimezoneOption>[] = options.map(option => ({
+        item: option,
+        name: option.displayName,
+        type: option.value,
+        description: option.description,
+        searchText: `${option.displayName} ${option.description} ${option.value} ${option.searchText}`,
+        sortText: option.sortText,
+        secondarySortText: option.value
+    }));
+
+    return filterFuzzySearchRecords(records, query);
+}
+
+export function getTimezoneMatchSegments(text: string, query: string): MatchSegment[] {
+    return getMatchSegments(text, query);
+}

--- a/src/utils/usage-windows.ts
+++ b/src/utils/usage-windows.ts
@@ -106,12 +106,22 @@ function pad(value: number): string {
     return value.toString().padStart(2, '0');
 }
 
-function formatResetAtUtc(date: Date, compact: boolean): string {
+function formatResetAtUtc(date: Date, compact: boolean, hour12: boolean): string {
     const year = date.getUTCFullYear();
     const month = pad(date.getUTCMonth() + 1);
     const day = pad(date.getUTCDate());
     const hours = pad(date.getUTCHours());
     const minutes = pad(date.getUTCMinutes());
+
+    if (hour12) {
+        const hour = date.getUTCHours();
+        const displayHour = (hour % 12) || 12;
+        const period = hour >= 12 ? 'PM' : 'AM';
+
+        return compact
+            ? `${month}-${day} ${displayHour}:${minutes} ${period}Z`
+            : `${year}-${month}-${day} ${displayHour}:${minutes} ${period} UTC`;
+    }
 
     return compact
         ? `${month}-${day} ${hours}:${minutes}Z`
@@ -124,7 +134,8 @@ function formatResetAtInTimezone(
     date: Date,
     compact: boolean,
     timezone: string | undefined,
-    locale: string
+    locale: string,
+    hour12: boolean
 ): string | null {
     try {
         const formatter = new Intl.DateTimeFormat(locale, {
@@ -134,7 +145,7 @@ function formatResetAtInTimezone(
             day: '2-digit',
             hour: '2-digit',
             minute: '2-digit',
-            hour12: false,
+            hour12,
             timeZoneName: 'short'
         });
         const parts = formatter.formatToParts(date);
@@ -145,10 +156,19 @@ function formatResetAtInTimezone(
         const day = get('day');
         const hour = get('hour');
         const minute = get('minute');
+        const dayPeriod = get('dayPeriod');
         const tzName = get('timeZoneName');
 
         if (!year || !month || !day || !hour || !minute) {
             return null;
+        }
+
+        if (hour12) {
+            const displayHour = hour.startsWith('0') ? hour.slice(1) : hour;
+            const time = `${displayHour}:${minute}${dayPeriod ? ` ${dayPeriod}` : ''}`;
+            return compact
+                ? `${month}-${day} ${time}`
+                : `${year}-${month}-${day} ${time} ${tzName}`;
         }
 
         return compact
@@ -163,7 +183,8 @@ export function formatUsageResetAt(
     resetAt: string | undefined,
     compact = false,
     timezone?: string,
-    locale?: string
+    localeOrHour12?: string | boolean,
+    hour12Arg = false
 ): string | null {
     if (!resetAt) {
         return null;
@@ -175,26 +196,28 @@ export function formatUsageResetAt(
     }
 
     const date = new Date(resetAtMs);
+    const locale = typeof localeOrHour12 === 'string' ? localeOrHour12 : undefined;
+    const hour12 = typeof localeOrHour12 === 'boolean' ? localeOrHour12 : hour12Arg;
 
     if (!timezone || timezone === 'UTC') {
-        return formatResetAtUtc(date, compact);
+        return formatResetAtUtc(date, compact, hour12);
     }
 
     const resolvedTimezone = timezone === 'local' ? undefined : timezone;
     const resolvedLocale = locale && locale.length > 0 ? locale : DEFAULT_TZ_LOCALE;
-    const localized = formatResetAtInTimezone(date, compact, resolvedTimezone, resolvedLocale);
+    const localized = formatResetAtInTimezone(date, compact, resolvedTimezone, resolvedLocale, hour12);
     if (localized) {
         return localized;
     }
 
     if (resolvedLocale !== DEFAULT_TZ_LOCALE) {
-        const fallback = formatResetAtInTimezone(date, compact, resolvedTimezone, DEFAULT_TZ_LOCALE);
+        const fallback = formatResetAtInTimezone(date, compact, resolvedTimezone, DEFAULT_TZ_LOCALE, hour12);
         if (fallback) {
             return fallback;
         }
     }
 
-    return formatResetAtUtc(date, compact);
+    return formatResetAtUtc(date, compact, hour12);
 }
 
 export function getUsageErrorMessage(error: UsageError): string {

--- a/src/utils/usage-windows.ts
+++ b/src/utils/usage-windows.ts
@@ -118,9 +118,16 @@ function formatResetAtUtc(date: Date, compact: boolean): string {
         : `${year}-${month}-${day} ${hours}:${minutes} UTC`;
 }
 
-function formatResetAtInTimezone(date: Date, compact: boolean, timezone: string | undefined): string | null {
+const DEFAULT_TZ_LOCALE = 'en-CA';
+
+function formatResetAtInTimezone(
+    date: Date,
+    compact: boolean,
+    timezone: string | undefined,
+    locale: string
+): string | null {
     try {
-        const formatter = new Intl.DateTimeFormat('en-CA', {
+        const formatter = new Intl.DateTimeFormat(locale, {
             timeZone: timezone,
             year: 'numeric',
             month: '2-digit',
@@ -155,7 +162,8 @@ function formatResetAtInTimezone(date: Date, compact: boolean, timezone: string 
 export function formatUsageResetAt(
     resetAt: string | undefined,
     compact = false,
-    timezone?: string
+    timezone?: string,
+    locale?: string
 ): string | null {
     if (!resetAt) {
         return null;
@@ -173,9 +181,17 @@ export function formatUsageResetAt(
     }
 
     const resolvedTimezone = timezone === 'local' ? undefined : timezone;
-    const localized = formatResetAtInTimezone(date, compact, resolvedTimezone);
+    const resolvedLocale = locale && locale.length > 0 ? locale : DEFAULT_TZ_LOCALE;
+    const localized = formatResetAtInTimezone(date, compact, resolvedTimezone, resolvedLocale);
     if (localized) {
         return localized;
+    }
+
+    if (resolvedLocale !== DEFAULT_TZ_LOCALE) {
+        const fallback = formatResetAtInTimezone(date, compact, resolvedTimezone, DEFAULT_TZ_LOCALE);
+        if (fallback) {
+            return fallback;
+        }
     }
 
     return formatResetAtUtc(date, compact);

--- a/src/utils/usage-windows.ts
+++ b/src/utils/usage-windows.ts
@@ -106,7 +106,57 @@ function pad(value: number): string {
     return value.toString().padStart(2, '0');
 }
 
-export function formatUsageResetAt(resetAt: string | undefined, compact = false): string | null {
+function formatResetAtUtc(date: Date, compact: boolean): string {
+    const year = date.getUTCFullYear();
+    const month = pad(date.getUTCMonth() + 1);
+    const day = pad(date.getUTCDate());
+    const hours = pad(date.getUTCHours());
+    const minutes = pad(date.getUTCMinutes());
+
+    return compact
+        ? `${month}-${day} ${hours}:${minutes}Z`
+        : `${year}-${month}-${day} ${hours}:${minutes} UTC`;
+}
+
+function formatResetAtInTimezone(date: Date, compact: boolean, timezone: string | undefined): string | null {
+    try {
+        const formatter = new Intl.DateTimeFormat('en-CA', {
+            timeZone: timezone,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+            timeZoneName: 'short'
+        });
+        const parts = formatter.formatToParts(date);
+        const get = (type: string): string => parts.find(p => p.type === type)?.value ?? '';
+
+        const year = get('year');
+        const month = get('month');
+        const day = get('day');
+        const hour = get('hour');
+        const minute = get('minute');
+        const tzName = get('timeZoneName');
+
+        if (!year || !month || !day || !hour || !minute) {
+            return null;
+        }
+
+        return compact
+            ? `${month}-${day} ${hour}:${minute}`
+            : `${year}-${month}-${day} ${hour}:${minute} ${tzName}`;
+    } catch {
+        return null;
+    }
+}
+
+export function formatUsageResetAt(
+    resetAt: string | undefined,
+    compact = false,
+    timezone?: string
+): string | null {
     if (!resetAt) {
         return null;
     }
@@ -117,15 +167,18 @@ export function formatUsageResetAt(resetAt: string | undefined, compact = false)
     }
 
     const date = new Date(resetAtMs);
-    const year = date.getUTCFullYear();
-    const month = pad(date.getUTCMonth() + 1);
-    const day = pad(date.getUTCDate());
-    const hours = pad(date.getUTCHours());
-    const minutes = pad(date.getUTCMinutes());
 
-    return compact
-        ? `${month}-${day} ${hours}:${minutes}Z`
-        : `${year}-${month}-${day} ${hours}:${minutes} UTC`;
+    if (!timezone || timezone === 'UTC') {
+        return formatResetAtUtc(date, compact);
+    }
+
+    const resolvedTimezone = timezone === 'local' ? undefined : timezone;
+    const localized = formatResetAtInTimezone(date, compact, resolvedTimezone);
+    if (localized) {
+        return localized;
+    }
+
+    return formatResetAtUtc(date, compact);
 }
 
 export function getUsageErrorMessage(error: UsageError): string {

--- a/src/utils/usage-windows.ts
+++ b/src/utils/usage-windows.ts
@@ -128,7 +128,11 @@ function formatResetAtUtc(date: Date, compact: boolean, hour12: boolean): string
         : `${year}-${month}-${day} ${hours}:${minutes} UTC`;
 }
 
-const DEFAULT_TZ_LOCALE = 'en-CA';
+const DEFAULT_TZ_LOCALE = 'en-US';
+
+function normalizeDayPeriod(dayPeriod: string): string {
+    return dayPeriod.replace(/\./g, '').toUpperCase();
+}
 
 function formatResetAtInTimezone(
     date: Date,
@@ -165,7 +169,8 @@ function formatResetAtInTimezone(
 
         if (hour12) {
             const displayHour = hour.startsWith('0') ? hour.slice(1) : hour;
-            const time = `${displayHour}:${minute}${dayPeriod ? ` ${dayPeriod}` : ''}`;
+            const normalizedDayPeriod = dayPeriod ? normalizeDayPeriod(dayPeriod) : '';
+            const time = `${displayHour}:${minute}${normalizedDayPeriod ? ` ${normalizedDayPeriod}` : ''}`;
             return compact
                 ? `${month}-${day} ${time}`
                 : `${year}-${month}-${day} ${time} ${tzName}`;

--- a/src/utils/widgets.ts
+++ b/src/utils/widgets.ts
@@ -6,9 +6,15 @@ import type {
 } from '../types/Widget';
 
 import {
+    filterFuzzySearchRecords,
+    type FuzzySearchRecord
+} from './fuzzy';
+import {
     LAYOUT_WIDGET_MANIFEST,
     WIDGET_MANIFEST
 } from './widget-manifest';
+
+export { getMatchSegments } from './fuzzy';
 
 // Create widget registry
 const widgetRegistry = new Map<WidgetItemType, Widget>(
@@ -104,274 +110,22 @@ export function getWidgetCatalogCategories(catalog: WidgetCatalogEntry[]): strin
     return Array.from(categories);
 }
 
-function isWordStart(text: string, position: number): boolean {
-    return position === 0
-        || text[position - 1] === ' '
-        || text[position - 1] === '-'
-        || text[position - 1] === '_';
-}
-
-function findSubsequencePositions(text: string, query: string): number[] | null {
-    let qi = 0;
-    const positions: number[] = [];
-
-    for (let ti = 0; ti < text.length && qi < query.length; ti++) {
-        if (text[ti] === query[qi]) {
-            positions.push(ti);
-            qi++;
-        }
-    }
-
-    return qi < query.length ? null : positions;
-}
-
-function findInitialismMatch(text: string, query: string): { positions: number[]; score: number } | null {
-    const wordStartPositions: number[] = [];
-
-    for (let i = 0; i < text.length; i++) {
-        if (isWordStart(text, i)) {
-            wordStartPositions.push(i);
-        }
-    }
-
-    const initials = wordStartPositions.map(position => text[position]).join('');
-    const matchedInitials = findSubsequencePositions(initials, query);
-
-    if (matchedInitials === null) {
-        return null;
-    }
-
-    const first = matchedInitials[0];
-    const last = matchedInitials[matchedInitials.length - 1];
-
-    if (first === undefined || last === undefined) {
-        return null;
-    }
-
-    const positions: number[] = [];
-
-    for (const initialIndex of matchedInitials) {
-        const position = wordStartPositions[initialIndex];
-        if (position === undefined) {
-            return null;
-        }
-        positions.push(position);
-    }
-
-    return {
-        positions,
-        score: (last - first) + first
-    };
-}
-
-function computeFuzzyScore(text: string, query: string): number | null {
-    const CONSECUTIVE_BONUS_RATE = 5;
-    const WORD_START_BONUS_RATE = 20;
-    const FULL_INITIALISM_BONUS = 40;
-    const positions = findSubsequencePositions(text, query);
-
-    if (positions === null) {
-        return null;
-    }
-
-    const first = positions[0];
-    const last = positions[positions.length - 1];
-
-    if (first === undefined || last === undefined) {
-        return null;
-    }
-
-    const span = last - first;
-    let consecutiveBonus = 0;
-    let wordStartMatches = 0;
-
-    let previousPosition: number | null = null;
-
-    positions.forEach((position) => {
-        if (previousPosition !== null && position === previousPosition + 1) {
-            consecutiveBonus += CONSECUTIVE_BONUS_RATE;
-        }
-        if (isWordStart(text, position)) {
-            wordStartMatches++;
-        }
-        previousPosition = position;
-    });
-
-    const fullInitialismBonus = wordStartMatches === query.length
-        ? FULL_INITIALISM_BONUS
-        : 0;
-
-    return span
-        + first
-        - consecutiveBonus
-        - (wordStartMatches * WORD_START_BONUS_RATE)
-        - fullInitialismBonus;
-}
-
 export function filterWidgetCatalog(catalog: WidgetCatalogEntry[], category: string, query: string): WidgetCatalogEntry[] {
-    const MATCH_PRIORITY = {
-        NAME_PREFIX_WITH_INITIALISM: 0,
-        NAME_PREFIX: 1,
-        NAME_INITIALISM: 2,
-        NAME_SUBSTRING: 3,
-        TYPE_SUBSTRING: 4,
-        NAME_FUZZY: 5,
-        DESCRIPTION_SUBSTRING: 6,
-        SEARCH_SUBSTRING: 7,
-        TYPE_FUZZY: 8,
-        SEARCH_FUZZY: 9
-    };
-
-    const MATCH_TIER_SIZE = 1000;
-
-    const normalizedQuery = query.trim().toLowerCase();
-
     const categoryFiltered = category === 'All'
         ? [...catalog]
         : catalog.filter(entry => entry.category === category);
 
-    const withScore = categoryFiltered
-        .map((entry) => {
-            if (!normalizedQuery) {
-                return {
-                    entry,
-                    score: 99
-                };
-            }
+    const records: FuzzySearchRecord<WidgetCatalogEntry>[] = categoryFiltered.map(entry => ({
+        item: entry,
+        name: entry.displayName,
+        type: entry.type,
+        description: entry.description,
+        searchText: entry.searchText,
+        sortText: entry.displayName,
+        secondarySortText: entry.type
+    }));
 
-            const name = entry.displayName.toLowerCase();
-            const description = entry.description.toLowerCase();
-            const type = entry.type.toLowerCase();
-            const nameInitialism = findInitialismMatch(name, normalizedQuery);
-
-            if (name.startsWith(normalizedQuery) && nameInitialism !== null) {
-                return { entry, score: MATCH_PRIORITY.NAME_PREFIX_WITH_INITIALISM * MATCH_TIER_SIZE + nameInitialism.score };
-            }
-            if (name.startsWith(normalizedQuery)) {
-                return { entry, score: MATCH_PRIORITY.NAME_PREFIX * MATCH_TIER_SIZE };
-            }
-            if (nameInitialism !== null) {
-                return { entry, score: MATCH_PRIORITY.NAME_INITIALISM * MATCH_TIER_SIZE + nameInitialism.score };
-            }
-            if (name.includes(normalizedQuery)) {
-                return { entry, score: MATCH_PRIORITY.NAME_SUBSTRING * MATCH_TIER_SIZE };
-            }
-            if (type.includes(normalizedQuery)) {
-                return { entry, score: MATCH_PRIORITY.TYPE_SUBSTRING * MATCH_TIER_SIZE };
-            }
-
-            const nameFuzzy = computeFuzzyScore(name, normalizedQuery);
-            if (nameFuzzy !== null) {
-                return { entry, score: MATCH_PRIORITY.NAME_FUZZY * MATCH_TIER_SIZE + nameFuzzy };
-            }
-            if (description.includes(normalizedQuery)) {
-                return { entry, score: MATCH_PRIORITY.DESCRIPTION_SUBSTRING * MATCH_TIER_SIZE };
-            }
-            if (entry.searchText.includes(normalizedQuery)) {
-                return { entry, score: MATCH_PRIORITY.SEARCH_SUBSTRING * MATCH_TIER_SIZE };
-            }
-            const typeFuzzy = computeFuzzyScore(type, normalizedQuery);
-            if (typeFuzzy !== null) {
-                return { entry, score: MATCH_PRIORITY.TYPE_FUZZY * MATCH_TIER_SIZE + typeFuzzy };
-            }
-            const searchFuzzy = computeFuzzyScore(entry.searchText, normalizedQuery);
-            if (searchFuzzy !== null) {
-                return { entry, score: MATCH_PRIORITY.SEARCH_FUZZY * MATCH_TIER_SIZE + searchFuzzy };
-            }
-
-            return null;
-        })
-        .filter((item): item is { entry: WidgetCatalogEntry; score: number } => item !== null);
-
-    return withScore
-        .sort((a, b) => {
-            if (a.score !== b.score) {
-                return a.score - b.score;
-            }
-
-            const byDisplayName = a.entry.displayName.localeCompare(b.entry.displayName);
-            if (byDisplayName !== 0) {
-                return byDisplayName;
-            }
-
-            return a.entry.type.localeCompare(b.entry.type);
-        })
-        .map(item => item.entry);
-}
-
-export function getMatchSegments(text: string, query: string): { text: string; matched: boolean }[] {
-    if (!query.trim()) {
-        return [{ text, matched: false }];
-    }
-
-    const normalizedQuery = query.trim().toLowerCase();
-    const normalizedText = text.toLowerCase();
-
-    const initialismPositions = findInitialismMatch(normalizedText, normalizedQuery)?.positions;
-    if (initialismPositions !== undefined) {
-        const posSet = new Set(initialismPositions);
-        const segments: { text: string; matched: boolean }[] = [];
-        let current = '';
-        let currentMatched = posSet.has(0);
-
-        for (let i = 0; i < text.length; i++) {
-            const isMatched = posSet.has(i);
-            if (isMatched !== currentMatched && current) {
-                segments.push({ text: current, matched: currentMatched });
-                current = text[i] ?? '';
-                currentMatched = isMatched;
-            } else {
-                current += text[i] ?? '';
-            }
-        }
-
-        if (current) {
-            segments.push({ text: current, matched: currentMatched });
-        }
-
-        return segments;
-    }
-
-    const substringIdx = normalizedText.indexOf(normalizedQuery);
-    if (substringIdx !== -1) {
-        const end = substringIdx + normalizedQuery.length;
-        const segments: { text: string; matched: boolean }[] = [];
-        if (substringIdx > 0) {
-            segments.push({ text: text.slice(0, substringIdx), matched: false });
-        }
-        segments.push({ text: text.slice(substringIdx, end), matched: true });
-        if (end < text.length) {
-            segments.push({ text: text.slice(end), matched: false });
-        }
-        return segments;
-    }
-
-    const positions = findSubsequencePositions(normalizedText, normalizedQuery);
-    if (positions === null) {
-        return [{ text, matched: false }];
-    }
-
-    const posSet = new Set(positions);
-    const segments: { text: string; matched: boolean }[] = [];
-    let current = '';
-    let currentMatched = posSet.has(0);
-
-    for (let i = 0; i < text.length; i++) {
-        const isMatched = posSet.has(i);
-        if (isMatched !== currentMatched && current) {
-            segments.push({ text: current, matched: currentMatched });
-            current = text[i] ?? '';
-            currentMatched = isMatched;
-        } else {
-            current += text[i] ?? '';
-        }
-    }
-
-    if (current) {
-        segments.push({ text: current, matched: currentMatched });
-    }
-
-    return segments;
+    return filterFuzzySearchRecords(records, query);
 }
 
 export function isKnownWidgetType(type: string): boolean {

--- a/src/widgets/BlockResetTimer.ts
+++ b/src/widgets/BlockResetTimer.ts
@@ -19,6 +19,7 @@ import {
     getUsageDisplayMode,
     getUsageDisplayModifierText,
     getUsageProgressBarWidth,
+    getUsageLocale,
     getUsageTimerCustomKeybinds,
     getUsageTimezone,
     isUsageCompact,
@@ -113,7 +114,8 @@ export class BlockResetTimerWidget implements Widget {
 
         if (dateMode) {
             const timezone = getUsageTimezone(item);
-            const resetAt = formatUsageResetAt(usageData.sessionResetAt, compact, timezone);
+            const locale = getUsageLocale(item);
+            const resetAt = formatUsageResetAt(usageData.sessionResetAt, compact, timezone, locale);
             if (resetAt) {
                 return formatRawOrLabeledValue(item, 'Reset: ', resetAt);
             }

--- a/src/widgets/BlockResetTimer.ts
+++ b/src/widgets/BlockResetTimer.ts
@@ -16,6 +16,10 @@ import {
     resolveUsageWindowWithFallback
 } from '../utils/usage';
 
+import {
+    LOCALE_EDITOR_ACTION,
+    renderUsageLocaleEditor
+} from './shared/locale-editor';
 import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
 import {
     TIMEZONE_EDITOR_ACTION,
@@ -148,10 +152,19 @@ export class BlockResetTimerWidget implements Widget {
     }
 
     getCustomKeybinds(item?: WidgetItem): CustomKeybind[] {
-        return getUsageTimerCustomKeybinds(item, { includeDate: true, includeHourFormat: true, includeTimezone: true });
+        return getUsageTimerCustomKeybinds(item, {
+            includeDate: true,
+            includeHourFormat: true,
+            includeLocale: true,
+            includeTimezone: true
+        });
     }
 
     renderEditor(props: WidgetEditorProps): React.ReactElement | null {
+        if (props.action === LOCALE_EDITOR_ACTION) {
+            return renderUsageLocaleEditor(props);
+        }
+
         if (props.action === TIMEZONE_EDITOR_ACTION) {
             return renderUsageTimezoneEditor(props);
         }

--- a/src/widgets/BlockResetTimer.ts
+++ b/src/widgets/BlockResetTimer.ts
@@ -1,9 +1,12 @@
+import type React from 'react';
+
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
 import type {
     CustomKeybind,
     Widget,
     WidgetEditorDisplay,
+    WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
 import {
@@ -15,19 +18,25 @@ import {
 
 import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
 import {
+    TIMEZONE_EDITOR_ACTION,
+    renderUsageTimezoneEditor
+} from './shared/timezone-editor';
+import {
     cycleUsageDisplayMode,
     getUsageDisplayMode,
     getUsageDisplayModifierText,
-    getUsageProgressBarWidth,
     getUsageLocale,
+    getUsageProgressBarWidth,
     getUsageTimerCustomKeybinds,
     getUsageTimezone,
+    isUsage12HourClock,
     isUsageCompact,
     isUsageDateMode,
     isUsageInverted,
     isUsageProgressMode,
     toggleUsageCompact,
     toggleUsageDateMode,
+    toggleUsageHourFormat,
     toggleUsageInverted
 } from './shared/usage-display';
 
@@ -37,6 +46,8 @@ function makeTimerProgressBar(percent: number, width: number): string {
     const emptyWidth = width - filledWidth;
     return '█'.repeat(filledWidth) + '░'.repeat(emptyWidth);
 }
+
+const BLOCK_RESET_PREVIEW_AT = '2026-03-12T08:30:00.000Z';
 
 export class BlockResetTimerWidget implements Widget {
     getDefaultColor(): string { return 'brightBlue'; }
@@ -68,6 +79,10 @@ export class BlockResetTimerWidget implements Widget {
             return toggleUsageDateMode(item);
         }
 
+        if (action === 'toggle-hour-format') {
+            return toggleUsageHourFormat(item);
+        }
+
         return null;
     }
 
@@ -87,7 +102,14 @@ export class BlockResetTimerWidget implements Widget {
             }
 
             if (dateMode) {
-                return formatRawOrLabeledValue(item, 'Reset: ', compact ? '03-12 08:30Z' : '2026-03-12 08:30 UTC');
+                const resetAt = formatUsageResetAt(
+                    BLOCK_RESET_PREVIEW_AT,
+                    compact,
+                    getUsageTimezone(item),
+                    getUsageLocale(item),
+                    isUsage12HourClock(item)
+                );
+                return formatRawOrLabeledValue(item, 'Reset: ', resetAt ?? (compact ? '03-12 08:30Z' : '2026-03-12 08:30 UTC'));
             }
 
             return formatRawOrLabeledValue(item, 'Reset: ', compact ? '4h30m' : '4hr 30m');
@@ -115,7 +137,7 @@ export class BlockResetTimerWidget implements Widget {
         if (dateMode) {
             const timezone = getUsageTimezone(item);
             const locale = getUsageLocale(item);
-            const resetAt = formatUsageResetAt(usageData.sessionResetAt, compact, timezone, locale);
+            const resetAt = formatUsageResetAt(usageData.sessionResetAt, compact, timezone, locale, isUsage12HourClock(item));
             if (resetAt) {
                 return formatRawOrLabeledValue(item, 'Reset: ', resetAt);
             }
@@ -126,7 +148,15 @@ export class BlockResetTimerWidget implements Widget {
     }
 
     getCustomKeybinds(item?: WidgetItem): CustomKeybind[] {
-        return getUsageTimerCustomKeybinds(item, { includeDate: true });
+        return getUsageTimerCustomKeybinds(item, { includeDate: true, includeHourFormat: true, includeTimezone: true });
+    }
+
+    renderEditor(props: WidgetEditorProps): React.ReactElement | null {
+        if (props.action === TIMEZONE_EDITOR_ACTION) {
+            return renderUsageTimezoneEditor(props);
+        }
+
+        return null;
     }
 
     supportsRawValue(): boolean { return true; }

--- a/src/widgets/BlockResetTimer.ts
+++ b/src/widgets/BlockResetTimer.ts
@@ -20,6 +20,7 @@ import {
     getUsageDisplayModifierText,
     getUsageProgressBarWidth,
     getUsageTimerCustomKeybinds,
+    getUsageTimezone,
     isUsageCompact,
     isUsageDateMode,
     isUsageInverted,
@@ -111,7 +112,8 @@ export class BlockResetTimerWidget implements Widget {
         }
 
         if (dateMode) {
-            const resetAt = formatUsageResetAt(usageData.sessionResetAt, compact);
+            const timezone = getUsageTimezone(item);
+            const resetAt = formatUsageResetAt(usageData.sessionResetAt, compact, timezone);
             if (resetAt) {
                 return formatRawOrLabeledValue(item, 'Reset: ', resetAt);
             }

--- a/src/widgets/WeeklyResetTimer.ts
+++ b/src/widgets/WeeklyResetTimer.ts
@@ -18,6 +18,10 @@ import {
 
 import { makeModifierText } from './shared/editor-display';
 import {
+    LOCALE_EDITOR_ACTION,
+    renderUsageLocaleEditor
+} from './shared/locale-editor';
+import {
     isMetadataFlagEnabled,
     toggleMetadataFlag
 } from './shared/metadata';
@@ -30,6 +34,7 @@ import {
     cycleUsageDisplayMode,
     getUsageDisplayMode,
     getUsageLocale,
+    getUsageLocaleModifier,
     getUsageProgressBarWidth,
     getUsageTimerCustomKeybinds,
     getUsageTimezone,
@@ -97,6 +102,11 @@ function getWeeklyResetModifierText(item: WidgetItem): string | undefined {
     const timezoneModifier = getUsageTimezoneModifier(item);
     if (!isUsageProgressMode(displayMode) && dateMode && timezoneModifier) {
         modifiers.push(timezoneModifier);
+    }
+
+    const localeModifier = getUsageLocaleModifier(item);
+    if (!isUsageProgressMode(displayMode) && dateMode && localeModifier) {
+        modifiers.push(localeModifier);
     }
 
     return makeModifierText(modifiers);
@@ -206,7 +216,12 @@ export class WeeklyResetTimerWidget implements Widget {
     }
 
     getCustomKeybinds(item?: WidgetItem): CustomKeybind[] {
-        const keybinds = getUsageTimerCustomKeybinds(item, { includeDate: true, includeHourFormat: true, includeTimezone: true });
+        const keybinds = getUsageTimerCustomKeybinds(item, {
+            includeDate: true,
+            includeHourFormat: true,
+            includeLocale: true,
+            includeTimezone: true
+        });
 
         if (!item || (!isUsageProgressMode(getUsageDisplayMode(item)) && !isUsageDateMode(item))) {
             keybinds.push({ key: 'h', label: '(h)ours only', action: 'toggle-hours' });
@@ -216,6 +231,10 @@ export class WeeklyResetTimerWidget implements Widget {
     }
 
     renderEditor(props: WidgetEditorProps): React.ReactElement | null {
+        if (props.action === LOCALE_EDITOR_ACTION) {
+            return renderUsageLocaleEditor(props);
+        }
+
         if (props.action === TIMEZONE_EDITOR_ACTION) {
             return renderUsageTimezoneEditor(props);
         }

--- a/src/widgets/WeeklyResetTimer.ts
+++ b/src/widgets/WeeklyResetTimer.ts
@@ -23,6 +23,7 @@ import {
     cycleUsageDisplayMode,
     getUsageDisplayMode,
     getUsageProgressBarWidth,
+    getUsageLocale,
     getUsageTimerCustomKeybinds,
     getUsageTimezone,
     isUsageCompact,
@@ -162,7 +163,8 @@ export class WeeklyResetTimerWidget implements Widget {
 
         if (dateMode) {
             const timezone = getUsageTimezone(item);
-            const resetAt = formatUsageResetAt(usageData.weeklyResetAt, compact, timezone);
+            const locale = getUsageLocale(item);
+            const resetAt = formatUsageResetAt(usageData.weeklyResetAt, compact, timezone, locale);
             if (resetAt) {
                 return formatRawOrLabeledValue(item, 'Weekly Reset: ', resetAt);
             }

--- a/src/widgets/WeeklyResetTimer.ts
+++ b/src/widgets/WeeklyResetTimer.ts
@@ -1,9 +1,12 @@
+import type React from 'react';
+
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
 import type {
     CustomKeybind,
     Widget,
     WidgetEditorDisplay,
+    WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
 import {
@@ -20,18 +23,25 @@ import {
 } from './shared/metadata';
 import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
 import {
+    TIMEZONE_EDITOR_ACTION,
+    renderUsageTimezoneEditor
+} from './shared/timezone-editor';
+import {
     cycleUsageDisplayMode,
     getUsageDisplayMode,
-    getUsageProgressBarWidth,
     getUsageLocale,
+    getUsageProgressBarWidth,
     getUsageTimerCustomKeybinds,
     getUsageTimezone,
+    getUsageTimezoneModifier,
+    isUsage12HourClock,
     isUsageCompact,
     isUsageDateMode,
     isUsageInverted,
     isUsageProgressMode,
     toggleUsageCompact,
     toggleUsageDateMode,
+    toggleUsageHourFormat,
     toggleUsageInverted
 } from './shared/usage-display';
 
@@ -43,6 +53,7 @@ function makeTimerProgressBar(percent: number, width: number): string {
 }
 
 const WEEKLY_PREVIEW_DURATION_MS = 36.5 * 60 * 60 * 1000;
+const WEEKLY_RESET_PREVIEW_AT = '2026-03-15T08:30:00.000Z';
 
 function isWeeklyResetHoursOnly(item: WidgetItem): boolean {
     return isMetadataFlagEnabled(item, 'hours');
@@ -74,9 +85,18 @@ function getWeeklyResetModifierText(item: WidgetItem): string | undefined {
 
         if (dateMode) {
             modifiers.push('date');
+
+            if (isUsage12HourClock(item)) {
+                modifiers.push('12hr');
+            }
         } else if (isWeeklyResetHoursOnly(item)) {
             modifiers.push('hours only');
         }
+    }
+
+    const timezoneModifier = getUsageTimezoneModifier(item);
+    if (!isUsageProgressMode(displayMode) && dateMode && timezoneModifier) {
+        modifiers.push(timezoneModifier);
     }
 
     return makeModifierText(modifiers);
@@ -112,6 +132,10 @@ export class WeeklyResetTimerWidget implements Widget {
             return toggleUsageDateMode(item);
         }
 
+        if (action === 'toggle-hour-format') {
+            return toggleUsageHourFormat(item);
+        }
+
         if (action === 'toggle-hours') {
             return toggleWeeklyResetHoursOnly(item);
         }
@@ -136,7 +160,14 @@ export class WeeklyResetTimerWidget implements Widget {
             }
 
             if (dateMode) {
-                return formatRawOrLabeledValue(item, 'Weekly Reset: ', compact ? '03-15 08:30Z' : '2026-03-15 08:30 UTC');
+                const resetAt = formatUsageResetAt(
+                    WEEKLY_RESET_PREVIEW_AT,
+                    compact,
+                    getUsageTimezone(item),
+                    getUsageLocale(item),
+                    isUsage12HourClock(item)
+                );
+                return formatRawOrLabeledValue(item, 'Weekly Reset: ', resetAt ?? (compact ? '03-15 08:30Z' : '2026-03-15 08:30 UTC'));
             }
 
             return formatRawOrLabeledValue(item, 'Weekly Reset: ', formatUsageDuration(WEEKLY_PREVIEW_DURATION_MS, compact, useDays));
@@ -164,7 +195,7 @@ export class WeeklyResetTimerWidget implements Widget {
         if (dateMode) {
             const timezone = getUsageTimezone(item);
             const locale = getUsageLocale(item);
-            const resetAt = formatUsageResetAt(usageData.weeklyResetAt, compact, timezone, locale);
+            const resetAt = formatUsageResetAt(usageData.weeklyResetAt, compact, timezone, locale, isUsage12HourClock(item));
             if (resetAt) {
                 return formatRawOrLabeledValue(item, 'Weekly Reset: ', resetAt);
             }
@@ -175,13 +206,21 @@ export class WeeklyResetTimerWidget implements Widget {
     }
 
     getCustomKeybinds(item?: WidgetItem): CustomKeybind[] {
-        const keybinds = getUsageTimerCustomKeybinds(item, { includeDate: true });
+        const keybinds = getUsageTimerCustomKeybinds(item, { includeDate: true, includeHourFormat: true, includeTimezone: true });
 
         if (!item || (!isUsageProgressMode(getUsageDisplayMode(item)) && !isUsageDateMode(item))) {
             keybinds.push({ key: 'h', label: '(h)ours only', action: 'toggle-hours' });
         }
 
         return keybinds;
+    }
+
+    renderEditor(props: WidgetEditorProps): React.ReactElement | null {
+        if (props.action === TIMEZONE_EDITOR_ACTION) {
+            return renderUsageTimezoneEditor(props);
+        }
+
+        return null;
     }
 
     supportsRawValue(): boolean { return true; }

--- a/src/widgets/WeeklyResetTimer.ts
+++ b/src/widgets/WeeklyResetTimer.ts
@@ -24,6 +24,7 @@ import {
     getUsageDisplayMode,
     getUsageProgressBarWidth,
     getUsageTimerCustomKeybinds,
+    getUsageTimezone,
     isUsageCompact,
     isUsageDateMode,
     isUsageInverted,
@@ -160,7 +161,8 @@ export class WeeklyResetTimerWidget implements Widget {
         }
 
         if (dateMode) {
-            const resetAt = formatUsageResetAt(usageData.weeklyResetAt, compact);
+            const timezone = getUsageTimezone(item);
+            const resetAt = formatUsageResetAt(usageData.weeklyResetAt, compact, timezone);
             if (resetAt) {
                 return formatRawOrLabeledValue(item, 'Weekly Reset: ', resetAt);
             }

--- a/src/widgets/__tests__/BlockResetTimer.test.ts
+++ b/src/widgets/__tests__/BlockResetTimer.test.ts
@@ -126,28 +126,28 @@ describe('BlockResetTimerWidget', () => {
         mockFormatUsageResetAt.mockReturnValue('2026-03-12 08:30 UTC');
 
         expect(render(widget,
-            { id: 'reset', type: 'reset-timer', metadata: { absolute: 'true', timezone: 'Asia/Tokyo', hour12: 'true' } },
+            { id: 'reset', type: 'reset-timer', metadata: { absolute: 'true', timezone: 'Asia/Tokyo', locale: 'ja-JP', hour12: 'true' } },
             { usageData: { sessionResetAt: '2026-03-12T08:30:00.000Z' } }
         )).toBe('Reset: 2026-03-12 08:30 UTC');
-        expect(mockFormatUsageResetAt).toHaveBeenCalledWith('2026-03-12T08:30:00.000Z', false, 'Asia/Tokyo', undefined, true);
+        expect(mockFormatUsageResetAt).toHaveBeenCalledWith('2026-03-12T08:30:00.000Z', false, 'Asia/Tokyo', 'ja-JP', true);
     });
 
-    it('shows configured hour format and timezone in editor display only in timestamp mode', () => {
+    it('shows configured timestamp settings in editor display only in timestamp mode', () => {
         const widget = new BlockResetTimerWidget();
 
         expect(widget.getEditorDisplay({
             id: 'reset',
             type: 'reset-timer',
-            metadata: { timezone: 'America/New_York', hour12: 'true' }
+            metadata: { timezone: 'America/New_York', locale: 'ja-JP', hour12: 'true' }
         }).modifierText).toBeUndefined();
         expect(widget.getEditorDisplay({
             id: 'reset',
             type: 'reset-timer',
-            metadata: { absolute: 'true', timezone: 'America/New_York', hour12: 'true' }
-        }).modifierText).toBe('(date, 12hr, tz: America/New_York)');
+            metadata: { absolute: 'true', timezone: 'America/New_York', locale: 'ja-JP', hour12: 'true' }
+        }).modifierText).toBe('(date, 12hr, tz: America/New_York, locale: ja-JP)');
     });
 
-    it('shows hour format and timezone keybinds only in timestamp mode', () => {
+    it('shows timestamp keybinds only in timestamp mode', () => {
         const widget = new BlockResetTimerWidget();
 
         expect(widget.getCustomKeybinds({
@@ -159,7 +159,8 @@ describe('BlockResetTimerWidget', () => {
             { key: 's', label: '(s)hort time', action: 'toggle-compact' },
             { key: 't', label: '(t)imestamp', action: 'toggle-date' },
             { key: 'h', label: '12/24 (h)our', action: 'toggle-hour-format' },
-            { key: 'z', label: 'time(z)one', action: 'edit-timezone' }
+            { key: 'z', label: 'time(z)one', action: 'edit-timezone' },
+            { key: 'l', label: '(l)ocale', action: 'edit-locale' }
         ]);
     });
 

--- a/src/widgets/__tests__/BlockResetTimer.test.ts
+++ b/src/widgets/__tests__/BlockResetTimer.test.ts
@@ -126,9 +126,56 @@ describe('BlockResetTimerWidget', () => {
         mockFormatUsageResetAt.mockReturnValue('2026-03-12 08:30 UTC');
 
         expect(render(widget,
-            { id: 'reset', type: 'reset-timer', metadata: { absolute: 'true' } },
+            { id: 'reset', type: 'reset-timer', metadata: { absolute: 'true', timezone: 'Asia/Tokyo', hour12: 'true' } },
             { usageData: { sessionResetAt: '2026-03-12T08:30:00.000Z' } }
         )).toBe('Reset: 2026-03-12 08:30 UTC');
+        expect(mockFormatUsageResetAt).toHaveBeenCalledWith('2026-03-12T08:30:00.000Z', false, 'Asia/Tokyo', undefined, true);
+    });
+
+    it('shows configured hour format and timezone in editor display only in timestamp mode', () => {
+        const widget = new BlockResetTimerWidget();
+
+        expect(widget.getEditorDisplay({
+            id: 'reset',
+            type: 'reset-timer',
+            metadata: { timezone: 'America/New_York', hour12: 'true' }
+        }).modifierText).toBeUndefined();
+        expect(widget.getEditorDisplay({
+            id: 'reset',
+            type: 'reset-timer',
+            metadata: { absolute: 'true', timezone: 'America/New_York', hour12: 'true' }
+        }).modifierText).toBe('(date, 12hr, tz: America/New_York)');
+    });
+
+    it('shows hour format and timezone keybinds only in timestamp mode', () => {
+        const widget = new BlockResetTimerWidget();
+
+        expect(widget.getCustomKeybinds({
+            id: 'reset',
+            type: 'reset-timer',
+            metadata: { absolute: 'true' }
+        })).toEqual([
+            { key: 'p', label: '(p)rogress toggle', action: 'toggle-progress' },
+            { key: 's', label: '(s)hort time', action: 'toggle-compact' },
+            { key: 't', label: '(t)imestamp', action: 'toggle-date' },
+            { key: 'h', label: '12/24 (h)our', action: 'toggle-hour-format' },
+            { key: 'z', label: 'time(z)one', action: 'edit-timezone' }
+        ]);
+    });
+
+    it('toggles hour format metadata', () => {
+        const widget = new BlockResetTimerWidget();
+        const baseItem: WidgetItem = {
+            id: 'reset',
+            type: 'reset-timer',
+            metadata: { absolute: 'true' }
+        };
+
+        const hour12 = widget.handleEditorAction('toggle-hour-format', baseItem);
+        const cleared = widget.handleEditorAction('toggle-hour-format', hour12 ?? baseItem);
+
+        expect(hour12?.metadata?.hour12).toBe('true');
+        expect(cleared?.metadata?.hour12).toBe('false');
     });
 
     runUsageTimerEditorSuite({
@@ -142,6 +189,10 @@ describe('BlockResetTimerWidget', () => {
         ],
         supportsDateMode: true,
         expectedModifierText: '(medium bar, inverted)',
+        expectedProgressKeybinds: [
+            { key: 'p', label: '(p)rogress toggle', action: 'toggle-progress' },
+            { key: 'v', label: 'in(v)ert fill', action: 'toggle-invert' }
+        ],
         modifierItem: {
             id: 'reset',
             type: 'reset-timer',

--- a/src/widgets/__tests__/WeeklyResetTimer.test.ts
+++ b/src/widgets/__tests__/WeeklyResetTimer.test.ts
@@ -157,9 +157,25 @@ describe('WeeklyResetTimerWidget', () => {
         mockFormatUsageResetAt.mockReturnValue('2026-03-15 08:30 UTC');
 
         expect(render(widget,
-            { id: 'weekly-reset', type: 'weekly-reset-timer', metadata: { absolute: 'true' } },
+            { id: 'weekly-reset', type: 'weekly-reset-timer', metadata: { absolute: 'true', timezone: 'Asia/Tokyo', hour12: 'true' } },
             { usageData: { weeklyResetAt: '2026-03-15T08:30:00.000Z' } }
         )).toBe('Weekly Reset: 2026-03-15 08:30 UTC');
+        expect(mockFormatUsageResetAt).toHaveBeenCalledWith('2026-03-15T08:30:00.000Z', false, 'Asia/Tokyo', undefined, true);
+    });
+
+    it('shows configured hour format and timezone in editor display only in timestamp mode', () => {
+        const widget = new WeeklyResetTimerWidget();
+
+        expect(widget.getEditorDisplay({
+            id: 'weekly-reset',
+            type: 'weekly-reset-timer',
+            metadata: { timezone: 'America/New_York', hour12: 'true' }
+        }).modifierText).toBeUndefined();
+        expect(widget.getEditorDisplay({
+            id: 'weekly-reset',
+            type: 'weekly-reset-timer',
+            metadata: { absolute: 'true', timezone: 'America/New_York', hour12: 'true' }
+        }).modifierText).toBe('(date, 12hr, tz: America/New_York)');
     });
 
     it('toggles hours-only metadata and shows hours-only modifier text', () => {
@@ -176,6 +192,21 @@ describe('WeeklyResetTimerWidget', () => {
             ...baseItem,
             metadata: { hours: 'true' }
         }).modifierText).toBe('(hours only)');
+    });
+
+    it('toggles hour format metadata', () => {
+        const widget = new WeeklyResetTimerWidget();
+        const baseItem: WidgetItem = {
+            id: 'weekly-reset',
+            type: 'weekly-reset-timer',
+            metadata: { absolute: 'true' }
+        };
+
+        const hour12 = widget.handleEditorAction('toggle-hour-format', baseItem);
+        const cleared = widget.handleEditorAction('toggle-hour-format', hour12 ?? baseItem);
+
+        expect(hour12?.metadata?.hour12).toBe('true');
+        expect(cleared?.metadata?.hour12).toBe('false');
     });
 
     it('clears compact and hours-only metadata when cycling into progress mode', () => {
@@ -220,7 +251,9 @@ describe('WeeklyResetTimerWidget', () => {
         })).toEqual([
             { key: 'p', label: '(p)rogress toggle', action: 'toggle-progress' },
             { key: 's', label: '(s)hort time', action: 'toggle-compact' },
-            { key: 't', label: '(t)imestamp', action: 'toggle-date' }
+            { key: 't', label: '(t)imestamp', action: 'toggle-date' },
+            { key: 'h', label: '12/24 (h)our', action: 'toggle-hour-format' },
+            { key: 'z', label: 'time(z)one', action: 'edit-timezone' }
         ]);
     });
 
@@ -236,6 +269,10 @@ describe('WeeklyResetTimerWidget', () => {
         ],
         supportsDateMode: true,
         expectedModifierText: '(medium bar, inverted)',
+        expectedProgressKeybinds: [
+            { key: 'p', label: '(p)rogress toggle', action: 'toggle-progress' },
+            { key: 'v', label: 'in(v)ert fill', action: 'toggle-invert' }
+        ],
         modifierItem: {
             id: 'weekly-reset',
             type: 'weekly-reset-timer',

--- a/src/widgets/__tests__/WeeklyResetTimer.test.ts
+++ b/src/widgets/__tests__/WeeklyResetTimer.test.ts
@@ -157,25 +157,25 @@ describe('WeeklyResetTimerWidget', () => {
         mockFormatUsageResetAt.mockReturnValue('2026-03-15 08:30 UTC');
 
         expect(render(widget,
-            { id: 'weekly-reset', type: 'weekly-reset-timer', metadata: { absolute: 'true', timezone: 'Asia/Tokyo', hour12: 'true' } },
+            { id: 'weekly-reset', type: 'weekly-reset-timer', metadata: { absolute: 'true', timezone: 'Asia/Tokyo', locale: 'ja-JP', hour12: 'true' } },
             { usageData: { weeklyResetAt: '2026-03-15T08:30:00.000Z' } }
         )).toBe('Weekly Reset: 2026-03-15 08:30 UTC');
-        expect(mockFormatUsageResetAt).toHaveBeenCalledWith('2026-03-15T08:30:00.000Z', false, 'Asia/Tokyo', undefined, true);
+        expect(mockFormatUsageResetAt).toHaveBeenCalledWith('2026-03-15T08:30:00.000Z', false, 'Asia/Tokyo', 'ja-JP', true);
     });
 
-    it('shows configured hour format and timezone in editor display only in timestamp mode', () => {
+    it('shows configured timestamp settings in editor display only in timestamp mode', () => {
         const widget = new WeeklyResetTimerWidget();
 
         expect(widget.getEditorDisplay({
             id: 'weekly-reset',
             type: 'weekly-reset-timer',
-            metadata: { timezone: 'America/New_York', hour12: 'true' }
+            metadata: { timezone: 'America/New_York', locale: 'ja-JP', hour12: 'true' }
         }).modifierText).toBeUndefined();
         expect(widget.getEditorDisplay({
             id: 'weekly-reset',
             type: 'weekly-reset-timer',
-            metadata: { absolute: 'true', timezone: 'America/New_York', hour12: 'true' }
-        }).modifierText).toBe('(date, 12hr, tz: America/New_York)');
+            metadata: { absolute: 'true', timezone: 'America/New_York', locale: 'ja-JP', hour12: 'true' }
+        }).modifierText).toBe('(date, 12hr, tz: America/New_York, locale: ja-JP)');
     });
 
     it('toggles hours-only metadata and shows hours-only modifier text', () => {
@@ -253,7 +253,8 @@ describe('WeeklyResetTimerWidget', () => {
             { key: 's', label: '(s)hort time', action: 'toggle-compact' },
             { key: 't', label: '(t)imestamp', action: 'toggle-date' },
             { key: 'h', label: '12/24 (h)our', action: 'toggle-hour-format' },
-            { key: 'z', label: 'time(z)one', action: 'edit-timezone' }
+            { key: 'z', label: 'time(z)one', action: 'edit-timezone' },
+            { key: 'l', label: '(l)ocale', action: 'edit-locale' }
         ]);
     });
 

--- a/src/widgets/shared/__tests__/locale-editor.test.tsx
+++ b/src/widgets/shared/__tests__/locale-editor.test.tsx
@@ -1,0 +1,201 @@
+import { render } from 'ink';
+import { PassThrough } from 'node:stream';
+import React from 'react';
+import stripAnsi from 'strip-ansi';
+import {
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import type { WidgetItem } from '../../../types/Widget';
+import { canonicalizeLocale } from '../../../utils/locales';
+import {
+    LOCALE_EDITOR_ACTION,
+    UsageLocaleEditor
+} from '../locale-editor';
+
+class MockTtyStream extends PassThrough {
+    isTTY = true;
+    columns = 120;
+    rows = 40;
+
+    setRawMode() {
+        return this;
+    }
+
+    ref() {
+        return this;
+    }
+
+    unref() {
+        return this;
+    }
+}
+
+interface CapturedWriteStream extends NodeJS.WriteStream { getOutput: () => string }
+
+function createMockStdin(): NodeJS.ReadStream {
+    return new MockTtyStream() as unknown as NodeJS.ReadStream;
+}
+
+function createMockStdout(): CapturedWriteStream {
+    const stream = new MockTtyStream();
+    const chunks: string[] = [];
+
+    stream.on('data', (chunk: Buffer | string) => {
+        chunks.push(chunk.toString());
+    });
+
+    return Object.assign(stream as unknown as NodeJS.WriteStream, {
+        getOutput() {
+            return chunks.join('');
+        }
+    });
+}
+
+function flushInk() {
+    return new Promise((resolve) => {
+        setTimeout(resolve, 25);
+    });
+}
+
+function renderEditor(widget: WidgetItem, onComplete = vi.fn(), onCancel = vi.fn()) {
+    const stdin = createMockStdin();
+    const stdout = createMockStdout();
+    const stderr = createMockStdout();
+    const instance = render(
+        React.createElement(UsageLocaleEditor, {
+            widget,
+            onComplete,
+            onCancel,
+            action: LOCALE_EDITOR_ACTION
+        }),
+        {
+            stdin,
+            stdout,
+            stderr,
+            debug: true,
+            exitOnCtrlC: false,
+            patchConsole: false
+        }
+    );
+
+    return {
+        instance,
+        stdin,
+        stdout,
+        stderr,
+        onComplete,
+        onCancel
+    };
+}
+
+function cleanupEditor(rendered: ReturnType<typeof renderEditor>): void {
+    rendered.instance.unmount();
+    rendered.instance.cleanup();
+    rendered.stdin.destroy();
+    rendered.stdout.destroy();
+    rendered.stderr.destroy();
+}
+
+function getPlainOutput(output: string): string {
+    return stripAnsi(output).replace(/\r\n/g, '\n');
+}
+
+describe('UsageLocaleEditor', () => {
+    it('adds spacing between the locale list and result count', async () => {
+        const rendered = renderEditor({ id: 'reset', type: 'reset-timer' });
+
+        try {
+            await flushInk();
+
+            const output = getPlainOutput(rendered.stdout.getOutput());
+            expect(output).toMatch(/\n\nShowing \d+-\d+ of \d+/);
+        } finally {
+            cleanupEditor(rendered);
+        }
+    });
+
+    it('searches common locales and saves the selected locale', async () => {
+        const rendered = renderEditor({ id: 'reset', type: 'reset-timer' });
+
+        try {
+            await flushInk();
+            rendered.stdin.write('japan');
+            await flushInk();
+
+            expect(rendered.stdout.getOutput()).toContain('ja-JP');
+
+            rendered.stdin.write('\r');
+            await flushInk();
+
+            const updated = rendered.onComplete.mock.calls[0]?.[0] as WidgetItem | undefined;
+            expect(updated?.metadata?.locale).toBe('ja-JP');
+        } finally {
+            cleanupEditor(rendered);
+        }
+    });
+
+    it('selecting the default locale clears locale metadata', async () => {
+        const rendered = renderEditor({
+            id: 'reset',
+            type: 'reset-timer',
+            metadata: { locale: 'ja-JP' }
+        });
+
+        try {
+            await flushInk();
+            rendered.stdin.write('en-us');
+            await flushInk();
+            rendered.stdin.write('\r');
+            await flushInk();
+
+            const updated = rendered.onComplete.mock.calls[0]?.[0] as WidgetItem | undefined;
+            expect(updated?.metadata?.locale).toBeUndefined();
+        } finally {
+            cleanupEditor(rendered);
+        }
+    });
+
+    it('accepts a valid custom locale from the search query', async () => {
+        const customLocale = canonicalizeLocale('en-AU');
+        if (!customLocale) {
+            return;
+        }
+
+        const rendered = renderEditor({ id: 'reset', type: 'reset-timer' });
+
+        try {
+            await flushInk();
+            rendered.stdin.write('en-au');
+            await flushInk();
+
+            expect(rendered.stdout.getOutput()).toContain(`Use ${customLocale}`);
+
+            rendered.stdin.write('\r');
+            await flushInk();
+
+            const updated = rendered.onComplete.mock.calls[0]?.[0] as WidgetItem | undefined;
+            expect(updated?.metadata?.locale).toBe(customLocale);
+        } finally {
+            cleanupEditor(rendered);
+        }
+    });
+
+    it('cancels without saving', async () => {
+        const rendered = renderEditor({ id: 'reset', type: 'reset-timer' });
+
+        try {
+            await flushInk();
+            rendered.stdin.write('\u001B');
+            await flushInk();
+
+            expect(rendered.onCancel).toHaveBeenCalledOnce();
+            expect(rendered.onComplete).not.toHaveBeenCalled();
+        } finally {
+            cleanupEditor(rendered);
+        }
+    });
+});

--- a/src/widgets/shared/__tests__/timezone-editor.test.tsx
+++ b/src/widgets/shared/__tests__/timezone-editor.test.tsx
@@ -1,0 +1,179 @@
+import { render } from 'ink';
+import { PassThrough } from 'node:stream';
+import React from 'react';
+import stripAnsi from 'strip-ansi';
+import {
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import type { WidgetItem } from '../../../types/Widget';
+import {
+    TIMEZONE_EDITOR_ACTION,
+    UsageTimezoneEditor
+} from '../timezone-editor';
+
+class MockTtyStream extends PassThrough {
+    isTTY = true;
+    columns = 120;
+    rows = 40;
+
+    setRawMode() {
+        return this;
+    }
+
+    ref() {
+        return this;
+    }
+
+    unref() {
+        return this;
+    }
+}
+
+interface CapturedWriteStream extends NodeJS.WriteStream { getOutput: () => string }
+
+function createMockStdin(): NodeJS.ReadStream {
+    return new MockTtyStream() as unknown as NodeJS.ReadStream;
+}
+
+function createMockStdout(): CapturedWriteStream {
+    const stream = new MockTtyStream();
+    const chunks: string[] = [];
+
+    stream.on('data', (chunk: Buffer | string) => {
+        chunks.push(chunk.toString());
+    });
+
+    return Object.assign(stream as unknown as NodeJS.WriteStream, {
+        getOutput() {
+            return chunks.join('');
+        }
+    });
+}
+
+function flushInk() {
+    return new Promise((resolve) => {
+        setTimeout(resolve, 25);
+    });
+}
+
+function renderEditor(widget: WidgetItem, onComplete = vi.fn(), onCancel = vi.fn()) {
+    const stdin = createMockStdin();
+    const stdout = createMockStdout();
+    const stderr = createMockStdout();
+    const instance = render(
+        React.createElement(UsageTimezoneEditor, {
+            widget,
+            onComplete,
+            onCancel,
+            action: TIMEZONE_EDITOR_ACTION
+        }),
+        {
+            stdin,
+            stdout,
+            stderr,
+            debug: true,
+            exitOnCtrlC: false,
+            patchConsole: false
+        }
+    );
+
+    return {
+        instance,
+        stdin,
+        stdout,
+        stderr,
+        onComplete,
+        onCancel
+    };
+}
+
+function cleanupEditor(rendered: ReturnType<typeof renderEditor>): void {
+    rendered.instance.unmount();
+    rendered.instance.cleanup();
+    rendered.stdin.destroy();
+    rendered.stdout.destroy();
+    rendered.stderr.destroy();
+}
+
+function getPlainOutput(output: string): string {
+    return stripAnsi(output).replace(/\r\n/g, '\n');
+}
+
+describe('UsageTimezoneEditor', () => {
+    it('adds spacing between the timezone list and result count', async () => {
+        const rendered = renderEditor({ id: 'reset', type: 'reset-timer' });
+
+        try {
+            await flushInk();
+
+            const output = getPlainOutput(rendered.stdout.getOutput());
+            expect(output).toMatch(/IANA timezone\n\nShowing \d+-\d+ of \d+/);
+        } finally {
+            cleanupEditor(rendered);
+        }
+    });
+
+    it('searches native timezones and saves the selected timezone', async () => {
+        if (typeof Intl.supportedValuesOf !== 'function') {
+            return;
+        }
+
+        const rendered = renderEditor({ id: 'reset', type: 'reset-timer' });
+
+        try {
+            await flushInk();
+            rendered.stdin.write('tokyo');
+            await flushInk();
+
+            expect(rendered.stdout.getOutput()).toContain('Asia/Tokyo');
+
+            rendered.stdin.write('\r');
+            await flushInk();
+
+            const updated = rendered.onComplete.mock.calls[0]?.[0] as WidgetItem | undefined;
+            expect(updated?.metadata?.timezone).toBe('Asia/Tokyo');
+        } finally {
+            cleanupEditor(rendered);
+        }
+    });
+
+    it('selecting UTC clears timezone metadata', async () => {
+        const rendered = renderEditor({
+            id: 'reset',
+            type: 'reset-timer',
+            metadata: { timezone: 'Asia/Tokyo' }
+        });
+
+        try {
+            await flushInk();
+            rendered.stdin.write('utc');
+            await flushInk();
+            rendered.stdin.write('\r');
+            await flushInk();
+
+            const updated = rendered.onComplete.mock.calls[0]?.[0] as WidgetItem | undefined;
+            expect(updated?.metadata?.timezone).toBeUndefined();
+        } finally {
+            cleanupEditor(rendered);
+        }
+    });
+
+    it('cancels without saving', async () => {
+        const rendered = renderEditor({ id: 'reset', type: 'reset-timer' });
+
+        try {
+            await flushInk();
+            rendered.stdin.write('\u001B');
+            await flushInk();
+
+            expect(rendered.onCancel).toHaveBeenCalledOnce();
+            expect(rendered.onComplete).not.toHaveBeenCalled();
+        } finally {
+            cleanupEditor(rendered);
+        }
+    });
+});

--- a/src/widgets/shared/locale-editor.tsx
+++ b/src/widgets/shared/locale-editor.tsx
@@ -1,0 +1,184 @@
+import {
+    Box,
+    Text,
+    useInput
+} from 'ink';
+import React, {
+    useMemo,
+    useState
+} from 'react';
+
+import type { WidgetEditorProps } from '../../types/Widget';
+import { shouldInsertInput } from '../../utils/input-guards';
+import {
+    DEFAULT_RESET_LOCALE,
+    canonicalizeLocale,
+    filterLocaleOptions,
+    getLocaleMatchSegments,
+    getLocaleOptions,
+    type LocaleOption
+} from '../../utils/locales';
+
+import {
+    getUsageLocale,
+    setUsageLocale
+} from './usage-display';
+
+export const LOCALE_EDITOR_ACTION = 'edit-locale';
+
+const MAX_VISIBLE_OPTIONS = 10;
+
+function getInitialSelectedIndex(options: LocaleOption[], currentLocale: string | undefined): number {
+    const selectedValue = currentLocale ? canonicalizeLocale(currentLocale) : DEFAULT_RESET_LOCALE;
+    const selectedIndex = options.findIndex(option => option.value === selectedValue);
+    return selectedIndex === -1 ? 0 : selectedIndex;
+}
+
+function getVisibleRange(selectedIndex: number, totalOptions: number): { start: number; end: number } {
+    if (totalOptions <= MAX_VISIBLE_OPTIONS) {
+        return { start: 0, end: totalOptions };
+    }
+
+    const halfWindow = Math.floor(MAX_VISIBLE_OPTIONS / 2);
+    const maxStart = totalOptions - MAX_VISIBLE_OPTIONS;
+    const start = Math.min(Math.max(0, selectedIndex - halfWindow), maxStart);
+    return { start, end: start + MAX_VISIBLE_OPTIONS };
+}
+
+export function renderUsageLocaleEditor(props: WidgetEditorProps): React.ReactElement {
+    return <UsageLocaleEditor {...props} />;
+}
+
+export const UsageLocaleEditor: React.FC<WidgetEditorProps> = ({ widget, onComplete, onCancel, action }) => {
+    const currentLocale = getUsageLocale(widget);
+    const options = useMemo(() => getLocaleOptions(currentLocale), [currentLocale]);
+    const [query, setQuery] = useState('');
+    const [selectedIndex, setSelectedIndex] = useState(() => getInitialSelectedIndex(options, currentLocale));
+
+    const filteredOptions = filterLocaleOptions(options, query);
+    const clampedSelectedIndex = filteredOptions.length === 0
+        ? 0
+        : Math.min(selectedIndex, filteredOptions.length - 1);
+    const selectedOption = filteredOptions[clampedSelectedIndex];
+    const visibleRange = getVisibleRange(clampedSelectedIndex, filteredOptions.length);
+    const visibleOptions = filteredOptions.slice(visibleRange.start, visibleRange.end);
+    const currentLabel = currentLocale ?? DEFAULT_RESET_LOCALE;
+
+    useInput((input, key) => {
+        if (action !== LOCALE_EDITOR_ACTION) {
+            return;
+        }
+
+        if (key.return) {
+            if (selectedOption) {
+                onComplete(setUsageLocale(widget, selectedOption.value));
+            }
+            return;
+        }
+
+        if (key.escape) {
+            onCancel();
+            return;
+        }
+
+        if (key.upArrow || key.downArrow) {
+            if (filteredOptions.length === 0) {
+                return;
+            }
+
+            setSelectedIndex((previous) => {
+                const current = Math.min(previous, filteredOptions.length - 1);
+                if (key.downArrow) {
+                    return current + 1 > filteredOptions.length - 1 ? 0 : current + 1;
+                }
+                return current - 1 < 0 ? filteredOptions.length - 1 : current - 1;
+            });
+            return;
+        }
+
+        if (key.backspace || key.delete) {
+            setQuery(previous => previous.slice(0, -1));
+            setSelectedIndex(0);
+            return;
+        }
+
+        if (shouldInsertInput(input, key)) {
+            setQuery(previous => previous + input);
+            setSelectedIndex(0);
+        }
+    });
+
+    if (action !== LOCALE_EDITOR_ACTION) {
+        return <Text>Unknown editor mode</Text>;
+    }
+
+    return (
+        <Box flexDirection='column'>
+            <Box>
+                <Text bold>Locale</Text>
+                <Text dimColor>
+                    {' '}
+                    Current:
+                    {' '}
+                    {currentLabel}
+                </Text>
+            </Box>
+            <Box>
+                <Text dimColor>Search: </Text>
+                <Text color='cyan'>{query || '(none)'}</Text>
+            </Box>
+            <Text dimColor>Type to search, Up/Down select, Enter save, ESC cancel</Text>
+            <Box marginTop={1} flexDirection='column'>
+                {filteredOptions.length === 0 ? (
+                    <Text dimColor>No locales match the search.</Text>
+                ) : (
+                    visibleOptions.map((option, visibleIndex) => {
+                        const actualIndex = visibleRange.start + visibleIndex;
+                        const isSelected = actualIndex === clampedSelectedIndex;
+                        const segments = getLocaleMatchSegments(option.displayName, query);
+
+                        return (
+                            <Box key={option.value} flexDirection='row' flexWrap='nowrap'>
+                                <Box width={3}>
+                                    <Text color={isSelected ? 'green' : undefined}>
+                                        {isSelected ? '> ' : '  '}
+                                    </Text>
+                                </Box>
+                                {segments.map((segment, index) => (
+                                    <Text
+                                        key={index}
+                                        color={isSelected ? 'green' : (segment.matched ? 'yellowBright' : undefined)}
+                                        bold={isSelected ? true : segment.matched}
+                                    >
+                                        {segment.text}
+                                    </Text>
+                                ))}
+                                <Text dimColor>
+                                    {' '}
+                                    -
+                                    {' '}
+                                    {option.description}
+                                </Text>
+                            </Box>
+                        );
+                    })
+                )}
+            </Box>
+            {filteredOptions.length > MAX_VISIBLE_OPTIONS && (
+                <Box marginTop={1}>
+                    <Text dimColor>
+                        Showing
+                        {' '}
+                        {visibleRange.start + 1}
+                        -
+                        {visibleRange.end}
+                        {' '}
+                        of
+                        {' '}
+                        {filteredOptions.length}
+                    </Text>
+                </Box>
+            )}
+        </Box>
+    );
+};

--- a/src/widgets/shared/timezone-editor.tsx
+++ b/src/widgets/shared/timezone-editor.tsx
@@ -1,0 +1,182 @@
+import {
+    Box,
+    Text,
+    useInput
+} from 'ink';
+import React, {
+    useMemo,
+    useState
+} from 'react';
+
+import type { WidgetEditorProps } from '../../types/Widget';
+import { shouldInsertInput } from '../../utils/input-guards';
+import {
+    filterTimezoneOptions,
+    getTimezoneMatchSegments,
+    getTimezoneOptions,
+    type TimezoneOption
+} from '../../utils/timezones';
+
+import {
+    getUsageTimezone,
+    setUsageTimezone
+} from './usage-display';
+
+export const TIMEZONE_EDITOR_ACTION = 'edit-timezone';
+
+const MAX_VISIBLE_OPTIONS = 10;
+
+function getInitialSelectedIndex(options: TimezoneOption[], currentTimezone: string | undefined): number {
+    const selectedValue = currentTimezone ?? 'UTC';
+    const selectedIndex = options.findIndex(option => option.value === selectedValue);
+    return selectedIndex === -1 ? 0 : selectedIndex;
+}
+
+function getVisibleRange(selectedIndex: number, totalOptions: number): { start: number; end: number } {
+    if (totalOptions <= MAX_VISIBLE_OPTIONS) {
+        return { start: 0, end: totalOptions };
+    }
+
+    const halfWindow = Math.floor(MAX_VISIBLE_OPTIONS / 2);
+    const maxStart = totalOptions - MAX_VISIBLE_OPTIONS;
+    const start = Math.min(Math.max(0, selectedIndex - halfWindow), maxStart);
+    return { start, end: start + MAX_VISIBLE_OPTIONS };
+}
+
+export function renderUsageTimezoneEditor(props: WidgetEditorProps): React.ReactElement {
+    return <UsageTimezoneEditor {...props} />;
+}
+
+export const UsageTimezoneEditor: React.FC<WidgetEditorProps> = ({ widget, onComplete, onCancel, action }) => {
+    const currentTimezone = getUsageTimezone(widget);
+    const options = useMemo(() => getTimezoneOptions(currentTimezone), [currentTimezone]);
+    const [query, setQuery] = useState('');
+    const [selectedIndex, setSelectedIndex] = useState(() => getInitialSelectedIndex(options, currentTimezone));
+
+    const filteredOptions = filterTimezoneOptions(options, query);
+    const clampedSelectedIndex = filteredOptions.length === 0
+        ? 0
+        : Math.min(selectedIndex, filteredOptions.length - 1);
+    const selectedOption = filteredOptions[clampedSelectedIndex];
+    const visibleRange = getVisibleRange(clampedSelectedIndex, filteredOptions.length);
+    const visibleOptions = filteredOptions.slice(visibleRange.start, visibleRange.end);
+    const currentLabel = currentTimezone ?? 'UTC';
+
+    useInput((input, key) => {
+        if (action !== TIMEZONE_EDITOR_ACTION) {
+            return;
+        }
+
+        if (key.return) {
+            if (selectedOption) {
+                onComplete(setUsageTimezone(widget, selectedOption.value));
+            }
+            return;
+        }
+
+        if (key.escape) {
+            onCancel();
+            return;
+        }
+
+        if (key.upArrow || key.downArrow) {
+            if (filteredOptions.length === 0) {
+                return;
+            }
+
+            setSelectedIndex((previous) => {
+                const current = Math.min(previous, filteredOptions.length - 1);
+                if (key.downArrow) {
+                    return current + 1 > filteredOptions.length - 1 ? 0 : current + 1;
+                }
+                return current - 1 < 0 ? filteredOptions.length - 1 : current - 1;
+            });
+            return;
+        }
+
+        if (key.backspace || key.delete) {
+            setQuery(previous => previous.slice(0, -1));
+            setSelectedIndex(0);
+            return;
+        }
+
+        if (shouldInsertInput(input, key)) {
+            setQuery(previous => previous + input);
+            setSelectedIndex(0);
+        }
+    });
+
+    if (action !== TIMEZONE_EDITOR_ACTION) {
+        return <Text>Unknown editor mode</Text>;
+    }
+
+    return (
+        <Box flexDirection='column'>
+            <Box>
+                <Text bold>Timezone</Text>
+                <Text dimColor>
+                    {' '}
+                    Current:
+                    {' '}
+                    {currentLabel}
+                </Text>
+            </Box>
+            <Box>
+                <Text dimColor>Search: </Text>
+                <Text color='cyan'>{query || '(none)'}</Text>
+            </Box>
+            <Text dimColor>Type to search, Up/Down select, Enter save, ESC cancel</Text>
+            <Box marginTop={1} flexDirection='column'>
+                {filteredOptions.length === 0 ? (
+                    <Text dimColor>No timezones match the search.</Text>
+                ) : (
+                    visibleOptions.map((option, visibleIndex) => {
+                        const actualIndex = visibleRange.start + visibleIndex;
+                        const isSelected = actualIndex === clampedSelectedIndex;
+                        const segments = getTimezoneMatchSegments(option.displayName, query);
+
+                        return (
+                            <Box key={option.value} flexDirection='row' flexWrap='nowrap'>
+                                <Box width={3}>
+                                    <Text color={isSelected ? 'green' : undefined}>
+                                        {isSelected ? '> ' : '  '}
+                                    </Text>
+                                </Box>
+                                {segments.map((segment, index) => (
+                                    <Text
+                                        key={index}
+                                        color={isSelected ? 'green' : (segment.matched ? 'yellowBright' : undefined)}
+                                        bold={isSelected ? true : segment.matched}
+                                    >
+                                        {segment.text}
+                                    </Text>
+                                ))}
+                                <Text dimColor>
+                                    {' '}
+                                    -
+                                    {' '}
+                                    {option.description}
+                                </Text>
+                            </Box>
+                        );
+                    })
+                )}
+            </Box>
+            {filteredOptions.length > MAX_VISIBLE_OPTIONS && (
+                <Box marginTop={1}>
+                    <Text dimColor>
+                        Showing
+                        {' '}
+                        {visibleRange.start + 1}
+                        -
+                        {visibleRange.end}
+                        {' '}
+                        of
+                        {' '}
+                        {filteredOptions.length}
+                    </Text>
+                </Box>
+            )}
+        </Box>
+    );
+};

--- a/src/widgets/shared/usage-display.ts
+++ b/src/widgets/shared/usage-display.ts
@@ -2,6 +2,10 @@ import type {
     CustomKeybind,
     WidgetItem
 } from '../../types/Widget';
+import {
+    DEFAULT_RESET_LOCALE,
+    canonicalizeLocale
+} from '../../utils/locales';
 
 import { makeModifierText } from './editor-display';
 import {
@@ -20,6 +24,7 @@ const COMPACT_TOGGLE_KEYBIND: CustomKeybind = { key: 's', label: '(s)hort time',
 const DATE_TOGGLE_KEYBIND: CustomKeybind = { key: 't', label: '(t)imestamp', action: 'toggle-date' };
 const HOUR_FORMAT_TOGGLE_KEYBIND: CustomKeybind = { key: 'h', label: '12/24 (h)our', action: 'toggle-hour-format' };
 const TIMEZONE_KEYBIND: CustomKeybind = { key: 'z', label: 'time(z)one', action: 'edit-timezone' };
+const LOCALE_KEYBIND: CustomKeybind = { key: 'l', label: '(l)ocale', action: 'edit-locale' };
 
 export function getUsageDisplayMode(item: WidgetItem): UsageDisplayMode {
     const mode = item.metadata?.display;
@@ -74,6 +79,11 @@ export function getUsageLocale(item: WidgetItem): string | undefined {
     return typeof locale === 'string' && locale.length > 0 ? locale : undefined;
 }
 
+export function getUsageLocaleModifier(item: WidgetItem): string | undefined {
+    const locale = getUsageLocale(item);
+    return locale ? `locale: ${locale}` : undefined;
+}
+
 export function getUsageTimezoneModifier(item: WidgetItem): string | undefined {
     const timezone = getUsageTimezone(item);
     return timezone ? `tz: ${timezone}` : undefined;
@@ -89,6 +99,21 @@ export function setUsageTimezone(item: WidgetItem, timezone: string): WidgetItem
         metadata: {
             ...item.metadata,
             timezone
+        }
+    };
+}
+
+export function setUsageLocale(item: WidgetItem, locale: string): WidgetItem {
+    const canonicalLocale = canonicalizeLocale(locale);
+    if (!canonicalLocale || canonicalLocale === DEFAULT_RESET_LOCALE) {
+        return removeMetadataKeys(item, ['locale']);
+    }
+
+    return {
+        ...item,
+        metadata: {
+            ...item.metadata,
+            locale: canonicalLocale
         }
     };
 }
@@ -146,6 +171,11 @@ export function getUsageDisplayModifierText(
     const timezoneModifier = getUsageTimezoneModifier(item);
     if (options.includeDate && !isUsageProgressMode(mode) && isUsageDateMode(item) && timezoneModifier) {
         modifiers.push(timezoneModifier);
+    }
+
+    const localeModifier = getUsageLocaleModifier(item);
+    if (options.includeDate && !isUsageProgressMode(mode) && isUsageDateMode(item) && localeModifier) {
+        modifiers.push(localeModifier);
     }
 
     return makeModifierText(modifiers);
@@ -206,6 +236,7 @@ export function getUsagePercentCustomKeybinds(item?: WidgetItem): CustomKeybind[
 interface UsageTimerCustomKeybindOptions {
     includeDate?: boolean;
     includeHourFormat?: boolean;
+    includeLocale?: boolean;
     includeTimezone?: boolean;
 }
 
@@ -232,6 +263,10 @@ export function getUsageTimerCustomKeybinds(
 
         if (options.includeTimezone) {
             keybinds.push(TIMEZONE_KEYBIND);
+        }
+
+        if (options.includeLocale) {
+            keybinds.push(LOCALE_KEYBIND);
         }
     }
 

--- a/src/widgets/shared/usage-display.ts
+++ b/src/widgets/shared/usage-display.ts
@@ -63,6 +63,11 @@ export function getUsageTimezone(item: WidgetItem): string | undefined {
     return typeof tz === 'string' && tz.length > 0 ? tz : undefined;
 }
 
+export function getUsageLocale(item: WidgetItem): string | undefined {
+    const locale = item.metadata?.locale;
+    return typeof locale === 'string' && locale.length > 0 ? locale : undefined;
+}
+
 export function toggleUsageCompact(item: WidgetItem): WidgetItem {
     return toggleMetadataFlag(item, 'compact');
 }

--- a/src/widgets/shared/usage-display.ts
+++ b/src/widgets/shared/usage-display.ts
@@ -18,6 +18,8 @@ const PROGRESS_TOGGLE_KEYBIND: CustomKeybind = { key: 'p', label: '(p)rogress to
 const INVERT_TOGGLE_KEYBIND: CustomKeybind = { key: 'v', label: 'in(v)ert fill', action: 'toggle-invert' };
 const COMPACT_TOGGLE_KEYBIND: CustomKeybind = { key: 's', label: '(s)hort time', action: 'toggle-compact' };
 const DATE_TOGGLE_KEYBIND: CustomKeybind = { key: 't', label: '(t)imestamp', action: 'toggle-date' };
+const HOUR_FORMAT_TOGGLE_KEYBIND: CustomKeybind = { key: 'h', label: '12/24 (h)our', action: 'toggle-hour-format' };
+const TIMEZONE_KEYBIND: CustomKeybind = { key: 'z', label: 'time(z)one', action: 'edit-timezone' };
 
 export function getUsageDisplayMode(item: WidgetItem): UsageDisplayMode {
     const mode = item.metadata?.display;
@@ -58,6 +60,10 @@ export function isUsageDateMode(item: WidgetItem): boolean {
     return isMetadataFlagEnabled(item, 'absolute');
 }
 
+export function isUsage12HourClock(item: WidgetItem): boolean {
+    return isMetadataFlagEnabled(item, 'hour12');
+}
+
 export function getUsageTimezone(item: WidgetItem): string | undefined {
     const tz = item.metadata?.timezone;
     return typeof tz === 'string' && tz.length > 0 ? tz : undefined;
@@ -68,12 +74,35 @@ export function getUsageLocale(item: WidgetItem): string | undefined {
     return typeof locale === 'string' && locale.length > 0 ? locale : undefined;
 }
 
+export function getUsageTimezoneModifier(item: WidgetItem): string | undefined {
+    const timezone = getUsageTimezone(item);
+    return timezone ? `tz: ${timezone}` : undefined;
+}
+
+export function setUsageTimezone(item: WidgetItem, timezone: string): WidgetItem {
+    if (timezone === 'UTC') {
+        return removeMetadataKeys(item, ['timezone']);
+    }
+
+    return {
+        ...item,
+        metadata: {
+            ...item.metadata,
+            timezone
+        }
+    };
+}
+
 export function toggleUsageCompact(item: WidgetItem): WidgetItem {
     return toggleMetadataFlag(item, 'compact');
 }
 
 export function toggleUsageDateMode(item: WidgetItem): WidgetItem {
     return toggleMetadataFlag(item, 'absolute');
+}
+
+export function toggleUsageHourFormat(item: WidgetItem): WidgetItem {
+    return toggleMetadataFlag(item, 'hour12');
 }
 
 interface UsageDisplayModifierOptions {
@@ -108,6 +137,15 @@ export function getUsageDisplayModifierText(
 
     if (options.includeDate && !isUsageProgressMode(mode) && isUsageDateMode(item)) {
         modifiers.push('date');
+    }
+
+    if (options.includeDate && !isUsageProgressMode(mode) && isUsageDateMode(item) && isUsage12HourClock(item)) {
+        modifiers.push('12hr');
+    }
+
+    const timezoneModifier = getUsageTimezoneModifier(item);
+    if (options.includeDate && !isUsageProgressMode(mode) && isUsageDateMode(item) && timezoneModifier) {
+        modifiers.push(timezoneModifier);
     }
 
     return makeModifierText(modifiers);
@@ -165,7 +203,11 @@ export function getUsagePercentCustomKeybinds(item?: WidgetItem): CustomKeybind[
     return keybinds;
 }
 
-interface UsageTimerCustomKeybindOptions { includeDate?: boolean }
+interface UsageTimerCustomKeybindOptions {
+    includeDate?: boolean;
+    includeHourFormat?: boolean;
+    includeTimezone?: boolean;
+}
 
 export function getUsageTimerCustomKeybinds(
     item?: WidgetItem,
@@ -180,6 +222,16 @@ export function getUsageTimerCustomKeybinds(
 
         if (options.includeDate) {
             keybinds.push(DATE_TOGGLE_KEYBIND);
+        }
+    }
+
+    if (item && isUsageDateMode(item) && !isUsageProgressMode(getUsageDisplayMode(item))) {
+        if (options.includeHourFormat) {
+            keybinds.push(HOUR_FORMAT_TOGGLE_KEYBIND);
+        }
+
+        if (options.includeTimezone) {
+            keybinds.push(TIMEZONE_KEYBIND);
         }
     }
 

--- a/src/widgets/shared/usage-display.ts
+++ b/src/widgets/shared/usage-display.ts
@@ -58,6 +58,11 @@ export function isUsageDateMode(item: WidgetItem): boolean {
     return isMetadataFlagEnabled(item, 'absolute');
 }
 
+export function getUsageTimezone(item: WidgetItem): string | undefined {
+    const tz = item.metadata?.timezone;
+    return typeof tz === 'string' && tz.length > 0 ? tz : undefined;
+}
+
 export function toggleUsageCompact(item: WidgetItem): WidgetItem {
     return toggleMetadataFlag(item, 'compact');
 }


### PR DESCRIPTION
Closes #337.

Adds an optional `timezone` metadata key to `BlockResetTimer` and `WeeklyResetTimer`. When provided, the reset timestamp (already exposed in date mode via #220) is rendered through `Intl.DateTimeFormat` in the specified timezone instead of UTC.

## Motivation

Following #220, reset timers can show absolute timestamps — but only in UTC. For users outside UTC, mentally adding/subtracting offsets every time defeats the point of switching from countdowns to clock times. This change lets each timer widget render in any IANA timezone or the system local timezone.

## Behavior

| `metadata.timezone` value | Behavior |
|---|---|
| (omitted) | Preserves existing UTC output (no behavior change) |
| `\"UTC\"` | Same as omitted |
| `\"local\"` | Uses the system timezone via `Intl.DateTimeFormat()` |
| Any IANA TZ name (e.g. `\"Asia/Tokyo\"`) | Renders in that zone |
| Invalid TZ name | Falls back to UTC (so misconfiguration never blanks the widget) |

## Output examples

| timezone | output (compact=false) | output (compact=true) |
|---|---|---|
| (none) / `UTC` | `2026-03-12 08:30 UTC` | `03-12 08:30Z` |
| `Asia/Tokyo` | `2026-03-12 17:30 GMT+9` | `03-12 17:30` |
| `local` | `2026-03-12 17:30 <tz>` | `03-12 17:30` |

## Sample widget config

\`\`\`json
{
  \"id\": \"weekly-reset\",
  \"type\": \"weekly-reset-timer\",
  \"metadata\": {
    \"absolute\": \"true\",
    \"timezone\": \"Asia/Tokyo\"
  }
}
\`\`\`

## Implementation

- \`formatUsageResetAt\` grows an optional \`timezone\` parameter
- When non-UTC, uses \`Intl.DateTimeFormat\` with the \`timeZone\` option to assemble \`YYYY-MM-DD HH:MM <tzName>\` from \`formatToParts\`
- Both reset timer widgets read \`metadata.timezone\` via a new \`getUsageTimezone(item)\` helper and pass it through
- Invalid \`timeZone\` triggers \`Intl.DateTimeFormat\` to throw; we catch and fall back to the original UTC formatter

## Tests

New cases added to \`src/utils/__tests__/usage.test.ts\`:

- \`formats reset timestamps in a specific IANA timezone\` — Asia/Tokyo, both regular and compact
- \`keeps UTC behavior when timezone is undefined or \"UTC\"\` — backwards compat
- \`falls back to UTC when timezone is invalid\` — misconfiguration safety
- \`renders the system local timezone when timezone is \"local\"\` — pattern-based assertion to stay portable across CI environments

## Verification

\`\`\`bash
bun install
npx tsc --noEmit
npx vitest run src/utils/__tests__/usage.test.ts
npx vitest run src/widgets/__tests__/BlockResetTimer.test.ts src/widgets/__tests__/WeeklyResetTimer.test.ts
bun run build
\`\`\`

All pass locally.

## Notes

- No keybind / TUI configurator changes in this PR — \`timezone\` must currently be set by editing \`settings.json\` directly. A follow-up could add a TUI prompt to pick from common IANA names; happy to do that in a separate PR if desired.
- The output for \`local\` uses whatever short label \`Intl\` yields on the host (e.g. \`GMT+9\` on macOS V8 for Asia/Tokyo, since ICU returns the offset rather than \`JST\`). Improving the label substitution is out of scope here.