### PR TITLE
fix(renderer): collapse separators around empty widgets

### DIFF
--- a/src/utils/__tests__/renderer-separator-collapse.test.ts
+++ b/src/utils/__tests__/renderer-separator-collapse.test.ts
@@ -1,0 +1,150 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import {
+    DEFAULT_SETTINGS,
+    type Settings
+} from '../../types/Settings';
+import type { WidgetItem } from '../../types/Widget';
+import { renderStatusLine } from '../renderer';
+
+interface PreRenderedWidget {
+    content: string;
+    plainLength: number;
+    widget: WidgetItem;
+}
+
+function createSettings(overrides: Partial<Settings> = {}): Settings {
+    return {
+        ...DEFAULT_SETTINGS,
+        ...overrides,
+        powerline: {
+            ...DEFAULT_SETTINGS.powerline,
+            ...(overrides.powerline ?? {})
+        }
+    };
+}
+
+function makePreRendered(widgets: WidgetItem[], contentByIndex: Record<number, string>): PreRenderedWidget[] {
+    return widgets.map((widget, i) => {
+        const content = contentByIndex[i] ?? '';
+        return { content, plainLength: content.length, widget };
+    });
+}
+
+function render(
+    widgets: WidgetItem[],
+    contentByIndex: Record<number, string>,
+    settingsOverrides: Partial<Settings> = {}
+): string {
+    const settings = createSettings({ colorLevel: 0, ...settingsOverrides });
+    const context: RenderContext = { isPreview: false, terminalWidth: 200 };
+    const preRenderedWidgets = makePreRendered(widgets, contentByIndex);
+    return renderStatusLine(widgets, settings, context, preRenderedWidgets, []);
+}
+
+const T = (id: string): WidgetItem => ({ id, type: 'custom-text' });
+const SEP: WidgetItem = { id: 'sep', type: 'separator' };
+
+describe('renderer separator collapse around empty widgets', () => {
+    it('emits exactly one separator between content widgets (regression baseline)', () => {
+        const widgets = [T('a'), SEP, T('b')];
+        const out = render(widgets, { 0: 'A', 2: 'B' });
+        expect((out.match(/\|/g) ?? []).length).toBe(1);
+    });
+
+    it('drops the trailing separator when the widget after it renders empty', () => {
+        const widgets = [T('a'), SEP, T('b'), SEP, T('c')];
+        // 'b' renders empty; the separator after 'b' (before 'c') must be dropped
+        const out = render(widgets, { 0: 'A', 2: '', 4: 'C' });
+        expect((out.match(/\|/g) ?? []).length).toBe(1);
+        expect(out).toContain('A');
+        expect(out).toContain('C');
+    });
+
+    it('collapses multiple consecutive empty widgets into a single separator', () => {
+        const widgets = [T('a'), SEP, T('b'), SEP, T('c'), SEP, T('d')];
+        // both 'b' and 'c' render empty
+        const out = render(widgets, { 0: 'A', 2: '', 4: '', 6: 'D' });
+        expect((out.match(/\|/g) ?? []).length).toBe(1);
+    });
+
+    it('suppresses a leading separator when no prior widget has rendered (existing behavior)', () => {
+        const widgets = [T('a'), SEP, T('b')];
+        // 'a' renders empty; the separator after it should not emit
+        const out = render(widgets, { 0: '', 2: 'B' });
+        expect(out).not.toMatch(/\|/);
+    });
+
+    it('drops separators that follow a sequence of leading empty widgets', () => {
+        const widgets = [T('a'), SEP, T('b'), SEP, T('c')];
+        // both 'a' and 'b' render empty; only 'c' has content
+        const out = render(widgets, { 0: '', 2: '', 4: 'C' });
+        expect(out).not.toMatch(/\|/);
+        expect(out).toContain('C');
+    });
+
+    it('removes trailing separator when the last widget renders empty', () => {
+        const widgets = [T('a'), SEP, T('b')];
+        // 'b' renders empty
+        const out = render(widgets, { 0: 'A', 2: '' });
+        expect(out).not.toMatch(/\|/);
+        expect(out).toContain('A');
+    });
+
+    it('keeps separators between widgets that all rendered content', () => {
+        const widgets = [T('a'), SEP, T('b'), SEP, T('c')];
+        const out = render(widgets, { 0: 'A', 2: 'B', 4: 'C' });
+        expect((out.match(/\|/g) ?? []).length).toBe(2);
+    });
+
+    it('does not affect the auto-separator (defaultSeparator) path', () => {
+        // The auto-separator path operates on the already-filtered `elements`
+        // array (line ~778) — empty widgets never reach it. This test locks in
+        // that the fix doesn't accidentally couple to the auto-separator logic.
+        const widgets = [T('a'), T('b'), T('c')];
+        const out = render(widgets, { 0: 'A', 1: '', 2: 'C' }, { defaultSeparator: '·' });
+
+        // With B empty, exactly one auto-added '·' should appear between A and C.
+        expect((out.match(/·/g) ?? []).length).toBe(1);
+        expect(out).toContain('A');
+        expect(out).toContain('C');
+    });
+
+    it('lets a merge:no-padding widget glue to the next visible widget across an empty middle widget', () => {
+        // Layout: [A(merge:no-padding), B(empty), SEP, C].
+        //
+        // Without the fix, the SEP between B and C would emit (its walkback
+        // would skip past B's empty content and find A with content), so
+        // `elements` would be [A, SEP, C] and A's merge would not reach C
+        // (the separator sits between them in the element chain).
+        //
+        // With the fix, the SEP is suppressed because B (the immediate-prior
+        // non-separator) is empty. `elements` becomes [A, C] and the
+        // omitLeadingPadding check at the C step sees prevElem=A with
+        // merge:'no-padding' — A glues directly to C with no padding or
+        // separator between them.
+        const widgets: WidgetItem[] = [
+            { id: 'a', type: 'custom-text', merge: 'no-padding' },
+            { id: 'b', type: 'custom-text' },
+            SEP,
+            { id: 'c', type: 'custom-text' }
+        ];
+        const out = render(widgets, { 0: 'A', 1: '', 3: 'C' });
+
+        // No separator visible.
+        expect(out).not.toMatch(/\|/);
+        // A and C are present and adjacent (only intra-widget content between
+        // them after stripping ANSI), confirming the merge took effect.
+        const stripped = out.replace(/\[[0-9;]*m/g, '');
+        expect(stripped).toContain('A');
+        expect(stripped).toContain('C');
+        // No whitespace separator between A and C — they are directly adjacent.
+        expect(stripped).toMatch(/A\s*C/);
+        expect(stripped).not.toMatch(/A\s+\S+\s+C/);
+    });
+});

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -668,18 +668,21 @@ export function renderStatusLine(
 
         // Handle separators specially (they're not widgets)
         if (widget.type === 'separator') {
-            // Check if there's any widget before this separator that actually rendered content
-            // Look backwards to find ANY widget that produced content
+            // Look backwards to the immediately-prior non-separator widget and
+            // emit this separator only if that widget actually rendered content.
+            // This collapses separators around hide-capable widgets that rendered
+            // empty (e.g., git-changes with no changes, conditional widgets with
+            // hide-when-zero semantics) and also suppresses a leading separator
+            // when no prior widget has rendered.
             let hasContentBefore = false;
             for (let j = i - 1; j >= 0; j--) {
                 const prevWidget = widgets[j];
-                if (prevWidget && prevWidget.type !== 'separator' && prevWidget.type !== 'flex-separator') {
-                    if (preRenderedWidgets[j]?.content) {
-                        hasContentBefore = true;
-                        break;
-                    }
-                    // Continue looking backwards even if this widget didn't render content
-                }
+                if (!prevWidget)
+                    continue;
+                if (prevWidget.type === 'separator' || prevWidget.type === 'flex-separator')
+                    continue;
+                hasContentBefore = Boolean(preRenderedWidgets[j]?.content);
+                break;
             }
             if (!hasContentBefore)
                 continue;


### PR DESCRIPTION
Spotted this while working on #282.

The status line renderer leaves an empty slot plus a leftover separator wherever a hide-capable widget renders null. The compaction-counter returns null when `count` is 0 and only shows ↻N after a compaction event — but the empty slot still occupied its layout position:

```
Model | branch | +5/-2 |  | Ctx: 42% | /path
```

**Scope**

Affects any widget that conditionally returns null:

- Git widgets with `hideNoGit: 'true'` (`git-branch`, `git-changes`, `git-staged-files`, etc.) in non-git contexts
- `git-conflicts` when there are no conflicts
- `git-pr` when no PR exists
- `compaction-counter` at count 0

Any layout using explicit `{type: "separator"}` items between such widgets is affected.

**Root cause**

The walkback in `renderStatusLine` that decides whether each separator should emit was looking for *any* prior widget with content, walking past empty ones. That correctly hides a leading separator (nothing before it) but leaves the orphan when an empty widget sits in the middle of a line.

**Fix**

Stop the walkback at the first non-separator widget and emit only when that widget actually rendered content.

- Auto-separator (`defaultSeparator`) path was already correct — it filters empty widgets out of its element chain. Not touched.
- Leading-edge behavior preserved.
- A `merge: 'no-padding'` chain that crosses a now-collapsed separator naturally glues to the next visible widget.

**Live-tested**

Layout: model, `git-branch` and `git-changes` (both `hideNoGit: 'true'`), `compaction-counter`, `context-percentage`, `current-working-dir`.

- Separators collapse cleanly when hide-capable widgets hide
- Separators remain when those widgets render content
- No regressions when all widgets are populated

**Tests**

9 new tests in `renderer-separator-collapse.test.ts`:

- Empty-in-the-middle case
- Consecutive empty widgets
- Leading empty (regression guard)
- Merge interaction
- `defaultSeparator` path independence
- All-content happy path

`bun run lint` and `bun test` both clean (955 tests).