### PR TITLE
Modify the display in multi-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ npx -y ccstatusline@latest
 bunx -y ccstatusline@latest
 ```
 
+### Build from source (for custom/forked versions):
+
+```bash
+git clone git@github.com:godlockin/ccstatusline.git
+cd ccstatusline
+./install.sh
+```
+
+`install.sh` builds the project with Bun and automatically wires the local binary into `~/.claude/settings.json`. Restart Claude Code after running it.
+
 <br />
 <details>
 <summary><b>Configure ccstatusline</b></summary>

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIST="$SCRIPT_DIR/dist/ccstatusline.js"
+SETTINGS="$HOME/.claude/settings.json"
+
+echo "==> Installing ccstatusline from $SCRIPT_DIR"
+
+# Build
+echo "==> Building..."
+bun install --frozen-lockfile
+bun run build
+
+# Patch settings.json
+if [ ! -f "$SETTINGS" ]; then
+  echo "ERROR: $SETTINGS not found. Is Claude Code installed?"
+  exit 1
+fi
+
+COMMAND="node $DIST"
+
+# Use python3 to safely edit JSON
+python3 - "$SETTINGS" "$COMMAND" <<'EOF'
+import json, sys
+path, cmd = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    s = json.load(f)
+s.setdefault('statusLine', {})
+s['statusLine']['type'] = 'command'
+s['statusLine']['command'] = cmd
+s['statusLine'].setdefault('padding', 0)
+with open(path, 'w') as f:
+    json.dump(s, f, indent=2)
+print(f"  statusLine.command => {cmd}")
+EOF
+
+echo "==> Done. Restart Claude Code to apply."

--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -198,7 +198,7 @@ async function renderMultipleLines(data: StatusJSON) {
                 globalSeparatorIndex,
                 globalPowerlineThemeIndex
             };
-            const line = renderStatusLine(lineItems, settings, lineContext, preRenderedWidgets, preCalculatedMaxWidths);
+            const line = renderStatusLine(lineItems, settings, lineContext, preRenderedWidgets, preCalculatedMaxWidths[i] ?? []);
 
             // Only output the line if it has content (not just ANSI codes)
             // Strip ANSI codes to check if there's actual text

--- a/src/tui/components/StatusLinePreview.tsx
+++ b/src/tui/components/StatusLinePreview.tsx
@@ -89,7 +89,7 @@ export const StatusLinePreview: React.FC<StatusLinePreviewProps> = ({ lines, ter
                     globalSeparatorIndex,
                     globalPowerlineThemeIndex,
                     preRenderedWidgets,
-                    preCalculatedMaxWidths
+                    preCalculatedMaxWidths[i] ?? []
                 );
                 result.push(renderResult.line);
                 if (renderResult.wasTruncated) {

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -40,7 +40,7 @@ export const SettingsSchema = z.object({
             [],
             []
         ]), // Ensure max 3 lines
-    flexMode: FlexModeSchema.default('full-minus-40'),
+    flexMode: FlexModeSchema.default('full'),
     compactThreshold: z.number().min(1).max(99).default(60),
     colorLevel: ColorLevelSchema.default(2),
     defaultSeparator: z.string().optional(),

--- a/src/utils/__tests__/renderer-ansi.test.ts
+++ b/src/utils/__tests__/renderer-ansi.test.ts
@@ -55,7 +55,7 @@ function renderLine(
     const preCalculatedMaxWidths = calculateMaxWidthsFromPreRendered(preRenderedLines, settings);
     const preRenderedWidgets = preRenderedLines[0] ?? [];
 
-    return renderStatusLine(widgets, settings, context, preRenderedWidgets, preCalculatedMaxWidths);
+    return renderStatusLine(widgets, settings, context, preRenderedWidgets, preCalculatedMaxWidths[0] ?? []);
 }
 
 describe('renderer ANSI/OSC handling', () => {

--- a/src/utils/__tests__/renderer-flex-width.test.ts
+++ b/src/utils/__tests__/renderer-flex-width.test.ts
@@ -44,7 +44,7 @@ function renderLine(
     const preCalculatedMaxWidths = calculateMaxWidthsFromPreRendered(preRenderedLines, settings);
     const preRenderedWidgets = preRenderedLines[0] ?? [];
 
-    return renderStatusLine(widgets, settings, context, preRenderedWidgets, preCalculatedMaxWidths);
+    return renderStatusLine(widgets, settings, context, preRenderedWidgets, preCalculatedMaxWidths[0] ?? []);
 }
 
 describe('renderer flex width behavior', () => {

--- a/src/utils/__tests__/renderer-powerline-theme.test.ts
+++ b/src/utils/__tests__/renderer-powerline-theme.test.ts
@@ -46,7 +46,7 @@ function renderLine(settings: Settings, globalPowerlineThemeIndex: number): stri
     const preCalculatedMaxWidths = calculateMaxWidthsFromPreRendered(preRenderedLines, settings);
     const preRenderedWidgets = preRenderedLines[0] ?? [];
 
-    return renderStatusLine(widgets, settings, context, preRenderedWidgets, preCalculatedMaxWidths);
+    return renderStatusLine(widgets, settings, context, preRenderedWidgets, preCalculatedMaxWidths[0] ?? []);
 }
 
 describe('renderer powerline theme carry-over', () => {

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -534,16 +534,18 @@ export function preRenderAllWidgets(
     return preRenderedLines;
 }
 
-// Calculate max widths from pre-rendered widgets for alignment
+// Calculate max widths per line from pre-rendered widgets for alignment.
+// Each line gets its own independent widths so a wide cell on one line does
+// not force the same column wider on other lines.
 export function calculateMaxWidthsFromPreRendered(
     preRenderedLines: PreRenderedWidget[][],
     settings: Settings
-): number[] {
-    const maxWidths: number[] = [];
+): number[][] {
     const defaultPadding = settings.defaultPadding ?? '';
     const paddingLength = defaultPadding.length;
 
-    for (const preRenderedLine of preRenderedLines) {
+    return preRenderedLines.map(preRenderedLine => {
+        const lineMaxWidths: number[] = [];
         const filteredWidgets = preRenderedLine.filter(
             w => w.widget.type !== 'separator' && w.widget.type !== 'flex-separator' && w.content
         );
@@ -574,20 +576,20 @@ export function calculateMaxWidthsFromPreRendered(
                 }
             }
 
-            const currentMax = maxWidths[alignmentPos];
+            const currentMax = lineMaxWidths[alignmentPos];
             if (currentMax === undefined) {
-                maxWidths[alignmentPos] = totalWidth;
+                lineMaxWidths[alignmentPos] = totalWidth;
             } else {
-                maxWidths[alignmentPos] = Math.max(currentMax, totalWidth);
+                lineMaxWidths[alignmentPos] = Math.max(currentMax, totalWidth);
             }
 
             // Skip over merged widgets since we've already processed them
             i = j;
             alignmentPos++;
         }
-    }
 
-    return maxWidths;
+        return lineMaxWidths;
+    });
 }
 
 export function renderStatusLineWithInfo(


### PR DESCRIPTION
Reported behavior: on multi-line status bars, a widget with long content (e.g. a long git branch name) would push adjacent columns wider on other lines. Also, out-of-the-box configurations were truncating content on wider terminals due to an overly conservative default.