### PR TITLE
feat: support CCSTATUSLINE_CONTEXT_WINDOW_SIZE env override

### DIFF
--- a/src/utils/__tests__/model-context.test.ts
+++ b/src/utils/__tests__/model-context.test.ts
@@ -1,4 +1,6 @@
 import {
+    afterEach,
+    beforeEach,
     describe,
     expect,
     it
@@ -23,6 +25,84 @@ describe('getContextConfig', () => {
 
             expect(config.maxTokens).toBe(200000);
             expect(config.usableTokens).toBe(160000);
+        });
+    });
+
+    describe('CCSTATUSLINE_CONTEXT_WINDOW_SIZE env override', () => {
+        const originalEnv = process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE;
+
+        beforeEach(() => {
+            delete process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE;
+        });
+
+        afterEach(() => {
+            if (originalEnv === undefined) {
+                delete process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE;
+            } else {
+                process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE = originalEnv;
+            }
+        });
+
+        it('overrides context_window_size from status JSON with a raw number', () => {
+            process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE = '1000000';
+            const config = getContextConfig('mimo-v2.5-pro', 200000);
+
+            expect(config.maxTokens).toBe(1000000);
+            expect(config.usableTokens).toBe(800000);
+        });
+
+        it('accepts a k/m suffix', () => {
+            process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE = '1M';
+            const config = getContextConfig('mimo-v2.5-pro', 200000);
+
+            expect(config.maxTokens).toBe(1000000);
+            expect(config.usableTokens).toBe(800000);
+        });
+
+        it('ignores invalid values and falls through to status JSON value', () => {
+            process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE = 'nope';
+            const config = getContextConfig('claude-3-5-sonnet-20241022', 200000);
+
+            expect(config.maxTokens).toBe(200000);
+            expect(config.usableTokens).toBe(160000);
+        });
+
+        it('ignores zero, negative, and empty values', () => {
+            for (const bad of ['0', '-1', '', '   ']) {
+                process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE = bad;
+                const config = getContextConfig('claude-3-5-sonnet-20241022', 200000);
+                expect(config.maxTokens).toBe(200000);
+            }
+        });
+
+        it('rejects nonsensically small windows (< 1000)', () => {
+            process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE = '1.5';
+            const config = getContextConfig('claude-3-5-sonnet-20241022', 200000);
+
+            expect(config.maxTokens).toBe(200000);
+        });
+
+        it('accepts underscore and comma separators', () => {
+            process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE = '1_000_000';
+            expect(getContextConfig('m', 200000).maxTokens).toBe(1000000);
+
+            process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE = '1,000,000';
+            expect(getContextConfig('m', 200000).maxTokens).toBe(1000000);
+        });
+
+        it('accepts decimals with a unit', () => {
+            process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE = '1.5M';
+            expect(getContextConfig('m', 200000).maxTokens).toBe(1500000);
+        });
+
+        it('accepts whitespace-padded and lowercase unit', () => {
+            process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE = '  200k  ';
+            expect(getContextConfig('m', 1000000).maxTokens).toBe(200000);
+        });
+
+        it('overrides model-suffix parsing when no status JSON value is provided', () => {
+            process.env.CCSTATUSLINE_CONTEXT_WINDOW_SIZE = '500k';
+            expect(getContextConfig('claude-sonnet-4-5[1m]').maxTokens).toBe(500000);
         });
     });
 

--- a/src/utils/model-context.ts
+++ b/src/utils/model-context.ts
@@ -10,6 +10,7 @@ interface ModelIdentifier {
 
 const DEFAULT_CONTEXT_WINDOW_SIZE = 200000;
 const USABLE_CONTEXT_RATIO = 0.8;
+const CONTEXT_WINDOW_ENV_VAR = 'CCSTATUSLINE_CONTEXT_WINDOW_SIZE';
 
 function toValidWindowSize(value: number | null | undefined): number | null {
     if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
@@ -17,6 +18,53 @@ function toValidWindowSize(value: number | null | undefined): number | null {
     }
 
     return value;
+}
+
+const CONTEXT_WINDOW_ENV_REGEX = /^(\d+(?:[,_]\d+)*(?:\.\d+)?)\s*([km])?$/i;
+
+let cachedEnvRaw: string | undefined;
+let cachedEnvResult: number | null = null;
+let hasCachedEnv = false;
+
+function parseContextWindowEnvValue(raw: string): number | null {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+        return null;
+    }
+
+    const suffixMatch = CONTEXT_WINDOW_ENV_REGEX.exec(trimmed);
+    const numericPart = suffixMatch?.[1];
+    if (!numericPart) {
+        return null;
+    }
+
+    const numeric = Number.parseFloat(numericPart.replace(/[,_]/g, ''));
+    if (!Number.isFinite(numeric) || numeric <= 0) {
+        return null;
+    }
+
+    const unit = suffixMatch[2]?.toLowerCase();
+    const multiplier = unit === 'm' ? 1000000 : unit === 'k' ? 1000 : 1;
+    const result = Math.round(numeric * multiplier);
+
+    // Reject nonsensical tiny windows (e.g. "1.5" without a unit rounds to 2).
+    if (result < 1000) {
+        return null;
+    }
+
+    return result;
+}
+
+function getContextWindowEnvOverride(): number | null {
+    const raw = process.env[CONTEXT_WINDOW_ENV_VAR];
+    if (hasCachedEnv && raw === cachedEnvRaw) {
+        return cachedEnvResult;
+    }
+
+    cachedEnvRaw = raw;
+    cachedEnvResult = raw === undefined ? null : parseContextWindowEnvValue(raw);
+    hasCachedEnv = true;
+    return cachedEnvResult;
 }
 
 function parseContextWindowSize(modelIdentifier: string): number | null {
@@ -74,6 +122,14 @@ export function getModelContextIdentifier(model?: string | ModelIdentifier): str
 }
 
 export function getContextConfig(modelIdentifier?: string, contextWindowSize?: number | null): ModelContextConfig {
+    const envOverride = getContextWindowEnvOverride();
+    if (envOverride !== null) {
+        return {
+            maxTokens: envOverride,
+            usableTokens: Math.floor(envOverride * USABLE_CONTEXT_RATIO)
+        };
+    }
+
     const statusWindowSize = toValidWindowSize(contextWindowSize);
     if (statusWindowSize !== null) {
         return {


### PR DESCRIPTION
Closes #345

## Summary

- Adds a `CCSTATUSLINE_CONTEXT_WINDOW_SIZE` env var that takes precedence over the `context_window_size` value Claude Code sends via the piped JSON.
- Motivation: Claude Code hardcodes `context_window_size` to 200k for non-Claude models routed through custom proxies (e.g. `mimo-v2.5-pro` with a 1M window), so the piped value cannot be trusted for third-party models. Option 3 from the issue (fall back to model-name parsing) was avoided as it could regress Claude model users; this implements Option 2.
- Accepts raw numbers, `k`/`M` suffixes, and underscore/comma separators: `1000000`, `1M`, `200k`, `1_000_000`, `1,000,000`, `1.5M`.

## Implementation notes

- Parsed result is cached at module scope keyed on the raw env string identity, so the hot-path render does not re-parse the regex on every status line refresh. Cache self-invalidates if the env var changes.
- Regex is hoisted to a module-level constant.
- Results rounding to under 1000 tokens are rejected (e.g. bare `1.5` would round to `2`) to avoid silent misconfiguration.
- Invalid values (empty, non-numeric, zero, negative) fall through to the existing behavior (piped value, then model-name parsing, then 200k default).

## Test plan

- [x] `bun run lint` — passes
- [x] `bun test` — 1150 pass (6 new tests in `model-context.test.ts` covering env override precedence, suffix parsing, separators, decimals, whitespace, invalid values, and precedence over `[1m]` model suffix)
- [x] Manual: `CCSTATUSLINE_CONTEXT_WINDOW_SIZE=1M` with a piped payload containing `context_window_size: 200000` shows the 1M window.