### PR TITLE
docs: add AIWatch integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ If ccstatusline is useful to you, consider buying me a coffee:
 - [tweakcc](https://github.com/Piebald-AI/tweakcc) - Customize Claude Code themes, thinking verbs, and more.
 - [ccusage](https://github.com/ryoppippi/ccusage) - Track and display Claude Code usage metrics.
 - [codachi](https://github.com/vincent-k2026/codachi) - A tamagotchi-style statusline pet that grows with your context window.
+- [AIWatch](https://ai-watch.dev) - Live status monitor for 30+ AI APIs and apps; pairs with a Custom Command widget to surface provider outages in your status line.
 
 
 ## 🙏 Acknowledgments

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -229,6 +229,24 @@ Create clickable links in terminals that support OSC 8 hyperlinks:
 
 > 📄 **How it works:** The command receives Claude Code's JSON data via stdin, allowing ccusage to access session information, model details, and transcript data for accurate usage tracking.
 
+## Integration Example: AIWatch
+
+[AIWatch](https://ai-watch.dev) monitors the live status of 30+ AI APIs and apps (Claude, GPT, Gemini, …). Surfacing it in your status line answers "is Claude slow because of me, or because the API is degraded?" without leaving the terminal.
+
+1. Add a Custom Command widget
+2. Set command:
+
+   ```bash
+   ( curl -sf --max-time 2 https://ai-watch.dev/api/status/cached | jq -r '[.services[] | select(.status != "operational") | "🔴 " + .name] | .[0:3] | join(" ")' ) 2>/dev/null || true
+   ```
+
+3. Set timeout: `2000` (the `curl` itself caps at 2s; the outer `|| true` keeps the widget silent on any failure)
+4. Leave "preserve colors" off — the output is a plain emoji + name list
+
+When every tracked service is operational the command prints nothing, so the widget renders empty and manual separators collapse around it. The endpoint is JSON, CORS-enabled, and served with a ~5-minute cache.
+
+> 📄 **Variants:** See [ai-watch.dev/#statusline](https://ai-watch.dev/#statusline) for count-only, compact, provider-scoped, and clickable OSC 8 link presets.
+
 ## Smart Truncation
 
 When terminal width is detected, status lines automatically truncate with ellipsis (`...`) if they exceed the available width, preventing line wrapping.


### PR DESCRIPTION
Per #362 — adds the Custom Command example to `docs/USAGE.md` (1) and a Related Projects link in `README.md` (2), the placement you picked.

## Changes
- **`docs/USAGE.md`** — new `## Integration Example: AIWatch` section right after the ccusage one, same 4-step structure (add Custom Command widget → set command → set timeout → preserve-colors note). The one-liner is `curl -sf --max-time 2 https://ai-watch.dev/api/status/cached | jq -r '...'` wrapped in `( ... ) 2>/dev/null || true` so the widget renders empty rather than an error string on any failure, and prints nothing when all services are operational (manual separators collapse around it).
- **`README.md`** — one entry in the Related Projects list, same `- [name](url) - description` format as the existing items.

## Notes
- Docs-only; no source changes. Verified the one-liner against the live endpoint (`https://ai-watch.dev/api/status/cached` → 32 services, `status` ∈ `operational`/`degraded`/`down`) — currently prints `🔴 ChatGPT 🔴 Codex`.
- No screenshot included (the recipe is a plain text command; happy to add one if you'd like a `screenshots/aiwatch.png` to match the ccusage entry).
- Full presets / variants (count-only, compact, provider-scoped, clickable OSC 8) live at https://ai-watch.dev/#statusline so the in-repo recipe stays minimal.

Thanks for the placement guidance!