### PR TITLE
feat: add ProxyBudgetWidget for LiteLLM/OpenRouter/compatible proxies

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -46,6 +46,7 @@ bun run example
 - **Context Length** / **Context Window** / **Context %** / **Context % (usable)** / **Context Bar** - Show current context length, total context window size, used/remaining percentage, usable-window percentage, or a progress bar.
 - **Compaction Counter** - Show how many context compactions have been detected in the current session. It can render as icon plus number, text plus number, or number-only, and can hide while the count is zero.
 - **Session Usage** / **Weekly Usage** / **Weekly Sonnet Usage** / **Weekly Opus Usage** / **Block Timer** / **Block Reset Timer** / **Weekly Reset Timer** - Show usage percentages plus current block/reset timing. The all-models weekly bar covers `seven_day` from the usage API; the per-model variants surface the `seven_day_sonnet` and `seven_day_opus` buckets that Claude Code's own `/usage` panel shows. Session and weekly usage bars can show a time cursor; reset timers can show remaining time, progress, or exact reset date/time with timezone and locale controls.
+- **Proxy Budget** - Show spend vs configured budget from a LiteLLM-compatible proxy (LiteLLM, OpenRouter, Portkey, Helicone, …). Native widget with green/yellow/red threshold tiers and 60s disk cache; opt-in via metadata.
 
 ### Environment, Layout & Custom
 
@@ -230,6 +231,76 @@ Create clickable links in terminals that support OSC 8 hyperlinks:
 ![ccusage integration](https://raw.githubusercontent.com/sirmalloc/ccstatusline/main/screenshots/ccusage.png)
 
 > 📄 **How it works:** The command receives Claude Code's JSON data via stdin, allowing ccusage to access session information, model details, and transcript data for accurate usage tracking.
+
+## Proxy Budget Widget
+
+When Claude Code traffic is routed through a proxy (LiteLLM, OpenRouter, Portkey, Helicone, or anything that exposes a JSON spend/budget endpoint behind a bearer token), the Proxy Budget widget shows your current spend against the proxy-side cap with green/yellow/red threshold tiers.
+
+The widget is configured entirely through `metadata` keys on the widget item. v1 ships two verified presets — `litellm` (the default) and `openrouter` — and lets you point at any other proxy with custom JSON paths.
+
+### Presets
+
+```jsonc
+// LiteLLM (default — no preset key needed)
+"metadata": { }
+
+// OpenRouter (GET /api/v1/key)
+"metadata": { "preset": "openrouter" }
+```
+
+Each preset bundles an endpoint suffix and the JSON paths for spend / cap / reset:
+
+| Preset | Endpoint | Spend path | Cap path | Reset path |
+|---|---|---|---|---|
+| `litellm` (default) | `${baseUrl}/key/info` | `info.spend` | `info.max_budget` | `info.budget_reset_at` |
+| `openrouter` | `${baseUrl}/api/v1/key` | `data.usage` | `data.limit` | `data.limit_reset` |
+
+### Configuration
+
+All settings live in `metadata` (strings; defaults applied at read time):
+
+| Key | Default | Description |
+|---|---|---|
+| `preset` | _(unset → litellm)_ | One of `litellm`, `openrouter`. Sets endpoint suffix + JSON paths. User-supplied per-key values override the preset. |
+| `endpoint` | preset default | Full URL or template with `${baseUrl}` placeholder. |
+| `baseUrlEnv` | `ANTHROPIC_BASE_URL` | Env var holding the proxy base URL. Same env var Claude Code already uses to route, so the typical setup works out of the box. |
+| `tokenEnv` | `ANTHROPIC_AUTH_TOKEN` | Env var holding the bearer token. Value never enters the config file or the disk cache. |
+| `authScheme` | preset default (`bearer`) | `bearer` (Authorization header) or `x-api-key`. |
+| `spendPath` | preset default | Dotted JSON path to current spend. |
+| `budgetPath` | preset default | Dotted JSON path to the budget cap. |
+| `resetAtPath` | preset default | Dotted JSON path to the ISO-8601 reset timestamp. |
+| `warningThreshold` | `80` | Percent at which the segment turns yellow. |
+| `criticalThreshold` | `95` | Percent at which the segment turns red. |
+| `format` | `spend-percent` | `spend-percent` (`$5.00/$100.00 (5%)`), `percent` (`5%`), or `spend` (`$5.00`). |
+| `cacheTtlSec` | `60` | Disk-cache TTL for proxy responses. |
+| `timeoutMs` | `3000` | HTTP timeout. On timeout, non-2xx, or parse error the widget falls back to a stale cache (up to `10 ×` TTL old), then hides. |
+
+### Example
+
+For a LiteLLM proxy already wired into Claude Code via `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN`, no env vars or extra config are needed — add the widget and enable it.
+
+For OpenRouter direct, set:
+
+```sh
+export ANTHROPIC_BASE_URL="https://openrouter.ai"
+export ANTHROPIC_AUTH_TOKEN="sk-or-v1-..."
+```
+
+and configure `"metadata": { "preset": "openrouter" }`.
+
+### Why a native widget vs Custom Command?
+
+The Custom Command widget can run a script that hits the same endpoint, but:
+
+- Spawns a separate shell process per render (~1–3s).
+- Cache, lock-file, and timeout handling have to be reimplemented in the user's script for every install.
+- Threshold-aware coloring, raw-value mode, preview mode, and editor metadata become script bookkeeping rather than first-class widget features.
+
+The native widget pays a one-time integration cost for repeated correctness.
+
+### Out of scope (v1)
+
+Cloud-native cost APIs that don't fit the bearer-token-JSON pattern (AWS Bedrock SigV4 + Cost Explorer, Vertex AI service-account JWT + Cloud Billing, Azure RBAC + Cost Management) need different auth and a multi-call shape. Use this widget for proxies; cloud-native cost reporting is a separate concern.
 
 ## Integration Example: AIWatch
 

--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -41,7 +41,10 @@ import {
     getWidgetSpeedWindowSeconds,
     isWidgetSpeedWindowEnabled
 } from './utils/speed-window';
-import { prefetchUsageDataIfNeeded } from './utils/usage-prefetch';
+import {
+    prefetchProxyBudgetIfNeeded,
+    prefetchUsageDataIfNeeded
+} from './utils/usage-prefetch';
 
 function hasSessionDurationInStatusJson(data: StatusJSON): boolean {
     const durationMs = data.cost?.total_duration_ms;
@@ -127,6 +130,7 @@ async function renderMultipleLines(data: StatusJSON) {
     }
 
     const usageData = await prefetchUsageDataIfNeeded(lines, data);
+    const proxyBudgetData = await prefetchProxyBudgetIfNeeded(lines);
 
     let speedMetrics: SpeedMetrics | null = null;
     let windowedSpeedMetrics: Record<string, SpeedMetrics> | null = null;
@@ -172,6 +176,7 @@ async function renderMultipleLines(data: StatusJSON) {
         speedMetrics,
         windowedSpeedMetrics,
         usageData,
+        proxyBudgetData,
         sessionDuration,
         skillsMetrics,
         compactionData: hasCompactionWidget ? { count: compactionCount } : null,

--- a/src/types/RenderContext.ts
+++ b/src/types/RenderContext.ts
@@ -2,6 +2,7 @@ import type {
     BlockMetrics,
     SkillsMetrics
 } from '../types';
+import type { ProxyBudgetData } from '../utils/proxy-budget-fetch';
 
 import type { SpeedMetrics } from './SpeedMetrics';
 import type { StatusJSON } from './StatusJSON';
@@ -31,6 +32,7 @@ export interface RenderContext {
     speedMetrics?: SpeedMetrics | null;
     windowedSpeedMetrics?: Record<string, SpeedMetrics> | null;
     usageData?: RenderUsageData | null;
+    proxyBudgetData?: ProxyBudgetData | null;
     sessionDuration?: string | null;
     blockMetrics?: BlockMetrics | null;
     skillsMetrics?: SkillsMetrics | null;

--- a/src/utils/__tests__/proxy-budget-fetch.test.ts
+++ b/src/utils/__tests__/proxy-budget-fetch.test.ts
@@ -1,0 +1,208 @@
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as https from 'https';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import {
+    fetchProxyBudget,
+    type ProxyBudgetFetchOptions
+} from '../proxy-budget-fetch';
+
+const BASE_URL_ENV = 'TEST_PROXY_BASE_URL';
+const TOKEN_ENV = 'TEST_PROXY_TOKEN';
+const BASE_URL = 'https://proxy.example.com';
+const TOKEN = 'test-token';
+
+interface MockResponse {
+    status?: number;
+    body?: string;
+    error?: Error;
+    timeout?: boolean;
+}
+
+function mockHttpsRequest(response: MockResponse): {
+    spy: ReturnType<typeof vi.spyOn>;
+    lastHeaders: Record<string, string>;
+} {
+    const captured: Record<string, string> = {};
+    const spy = vi.spyOn(https, 'request').mockImplementation(((opts: unknown, cb?: unknown) => {
+        const headers = (opts as { headers?: Record<string, string> }).headers ?? {};
+        Object.assign(captured, headers);
+        const req = new EventEmitter() as EventEmitter & {
+            end: () => void;
+            destroy: () => void;
+            setTimeout: (ms: number, fn: () => void) => void;
+        };
+        let timeoutFn: (() => void) | null = null;
+        req.setTimeout = (_ms, fn) => { timeoutFn = fn; };
+        req.destroy = () => { /* no-op */ };
+        req.end = () => {
+            setImmediate(() => {
+                if (response.timeout) {
+                    if (timeoutFn)
+                        timeoutFn();
+                    return;
+                }
+                if (response.error) {
+                    req.emit('error', response.error);
+                    return;
+                }
+                const res = new EventEmitter() as EventEmitter & { statusCode: number };
+                res.statusCode = response.status ?? 200;
+                if (typeof cb === 'function') {
+                    (cb as (r: typeof res) => void)(res);
+                }
+                setImmediate(() => {
+                    res.emit('data', Buffer.from(response.body ?? ''));
+                    res.emit('end');
+                });
+            });
+        };
+        return req;
+    }) as never);
+    return { spy, lastHeaders: captured };
+}
+
+function clearCache(): void {
+    const cacheFile = `${process.env.HOME}/.cache/ccstatusline/proxy-budget.json`;
+    const lockFile = `${process.env.HOME}/.cache/ccstatusline/proxy-budget.lock`;
+    try { fs.unlinkSync(cacheFile); } catch { /* ignore */ }
+    try { fs.unlinkSync(lockFile); } catch { /* ignore */ }
+}
+
+function defaultOpts(): ProxyBudgetFetchOptions {
+    return { baseUrlEnv: BASE_URL_ENV, tokenEnv: TOKEN_ENV };
+}
+
+describe('fetchProxyBudget', () => {
+    beforeEach(() => {
+        process.env[BASE_URL_ENV] = BASE_URL;
+        process.env[TOKEN_ENV] = TOKEN;
+        clearCache();
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(process.env, BASE_URL_ENV);
+        Reflect.deleteProperty(process.env, TOKEN_ENV);
+        vi.restoreAllMocks();
+        clearCache();
+    });
+
+    it('resolves spend/budget/percentage from a LiteLLM-shaped /key/info response', async () => {
+        mockHttpsRequest({
+            body: JSON.stringify({
+                info: {
+                    spend: 5,
+                    max_budget: 50,
+                    budget_reset_at: '2026-01-01T00:00:00Z'
+                }
+            })
+        });
+        const data = await fetchProxyBudget(defaultOpts());
+        expect(data).not.toBeNull();
+        expect(data?.spend).toBe(5);
+        expect(data?.budget).toBe(50);
+        expect(data?.percentage).toBeCloseTo(10);
+        expect(data?.resetAt).toBe('2026-01-01T00:00:00Z');
+    });
+
+    it('returns null when tokenEnv is unset, without calling https', async () => {
+        Reflect.deleteProperty(process.env, TOKEN_ENV);
+        const mock = mockHttpsRequest({ body: '{}' });
+        const data = await fetchProxyBudget(defaultOpts());
+        expect(data).toBeNull();
+        expect(mock.spy).not.toHaveBeenCalled();
+    });
+
+    it('supports custom dotted JSON paths (OpenRouter-style shape)', async () => {
+        mockHttpsRequest({ body: JSON.stringify({ data: { usage: 12, limit: 30 } }) });
+        const data = await fetchProxyBudget({
+            ...defaultOpts(),
+            spendPath: 'data.usage',
+            budgetPath: 'data.limit'
+        });
+        expect(data?.spend).toBe(12);
+        expect(data?.budget).toBe(30);
+        expect(data?.percentage).toBeCloseTo(40);
+    });
+
+    it('returns null when a configured field is missing from the response', async () => {
+        mockHttpsRequest({ body: JSON.stringify({ info: { max_budget: 50 } }) });
+        const data = await fetchProxyBudget(defaultOpts());
+        expect(data).toBeNull();
+    });
+
+    it('returns null on non-2xx HTTP status', async () => {
+        mockHttpsRequest({ status: 503, body: '' });
+        const data = await fetchProxyBudget(defaultOpts());
+        expect(data).toBeNull();
+    });
+
+    it('returns null on malformed JSON body', async () => {
+        mockHttpsRequest({ body: 'not json' });
+        const data = await fetchProxyBudget(defaultOpts());
+        expect(data).toBeNull();
+    });
+
+    it('returns null when spend grossly exceeds budget (likely misconfigured spendPath)', async () => {
+        mockHttpsRequest({ body: JSON.stringify({ info: { spend: 99999, max_budget: 50 } }) });
+        const data = await fetchProxyBudget(defaultOpts());
+        expect(data).toBeNull();
+    });
+
+    it('returns null on request timeout', async () => {
+        mockHttpsRequest({ timeout: true });
+        const data = await fetchProxyBudget({ ...defaultOpts(), timeoutMs: 50 });
+        expect(data).toBeNull();
+    });
+
+    it('uses Authorization: Bearer header by default', async () => {
+        const { lastHeaders } = mockHttpsRequest({ body: JSON.stringify({ info: { spend: 1, max_budget: 10 } }) });
+        await fetchProxyBudget(defaultOpts());
+        expect(lastHeaders.Authorization).toBe(`Bearer ${TOKEN}`);
+    });
+
+    it('uses x-api-key header when authScheme is x-api-key', async () => {
+        const { lastHeaders } = mockHttpsRequest({ body: JSON.stringify({ info: { spend: 1, max_budget: 10 } }) });
+        await fetchProxyBudget({ ...defaultOpts(), authScheme: 'x-api-key' });
+        expect(lastHeaders['x-api-key']).toBe(TOKEN);
+        expect(lastHeaders.Authorization).toBeUndefined();
+    });
+
+    it('serves fresh cache on subsequent invocations within TTL without calling https again', async () => {
+        const mock = mockHttpsRequest({ body: JSON.stringify({ info: { spend: 7, max_budget: 50 } }) });
+        const first = await fetchProxyBudget({ ...defaultOpts(), cacheTtlSec: 60 });
+        const second = await fetchProxyBudget({ ...defaultOpts(), cacheTtlSec: 60 });
+        expect(first?.spend).toBe(7);
+        expect(second?.spend).toBe(7);
+        expect(mock.spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to stale cache after a fetch failure when within stale window', async () => {
+        // Seed cache with a real response.
+        mockHttpsRequest({ body: JSON.stringify({ info: { spend: 3, max_budget: 50 } }) });
+        await fetchProxyBudget({ ...defaultOpts(), cacheTtlSec: 1 });
+
+        // Wait > ttl so cache is stale (but well within 10x).
+        await new Promise(resolve => setTimeout(resolve, 1100));
+        vi.restoreAllMocks();
+
+        // Now have the next request fail.
+        mockHttpsRequest({ status: 500, body: '' });
+        const data = await fetchProxyBudget({ ...defaultOpts(), cacheTtlSec: 1 });
+        expect(data?.spend).toBe(3);
+    });
+
+    it('returns null when neither network nor cache yield data', async () => {
+        mockHttpsRequest({ error: new Error('network down') });
+        const data = await fetchProxyBudget(defaultOpts());
+        expect(data).toBeNull();
+    });
+});

--- a/src/utils/__tests__/proxy-budget-fetch.test.ts
+++ b/src/utils/__tests__/proxy-budget-fetch.test.ts
@@ -11,7 +11,9 @@ import {
 } from 'vitest';
 
 import {
+    PROXY_BUDGET_PRESETS,
     fetchProxyBudget,
+    isProxyBudgetPreset,
     type ProxyBudgetFetchOptions
 } from '../proxy-budget-fetch';
 
@@ -204,5 +206,53 @@ describe('fetchProxyBudget', () => {
         mockHttpsRequest({ error: new Error('network down') });
         const data = await fetchProxyBudget(defaultOpts());
         expect(data).toBeNull();
+    });
+
+    it('preset=litellm uses /key/info with info.spend/info.max_budget paths', async () => {
+        mockHttpsRequest({ body: JSON.stringify({ info: { spend: 4, max_budget: 40, budget_reset_at: '2026-02-01T00:00:00Z' } }) });
+        const data = await fetchProxyBudget({ ...defaultOpts(), preset: 'litellm' });
+        expect(data?.spend).toBe(4);
+        expect(data?.budget).toBe(40);
+        expect(data?.percentage).toBeCloseTo(10);
+        expect(data?.resetAt).toBe('2026-02-01T00:00:00Z');
+    });
+
+    it('preset=openrouter resolves /api/v1/key with data.usage/data.limit/data.limit_reset', async () => {
+        mockHttpsRequest({ body: JSON.stringify({ data: { usage: 8, limit: 20, limit_reset: '2026-03-01T00:00:00Z' } }) });
+        const data = await fetchProxyBudget({ ...defaultOpts(), preset: 'openrouter' });
+        expect(data?.spend).toBe(8);
+        expect(data?.budget).toBe(20);
+        expect(data?.percentage).toBeCloseTo(40);
+        expect(data?.resetAt).toBe('2026-03-01T00:00:00Z');
+    });
+
+    it('user-supplied paths override preset defaults', async () => {
+        mockHttpsRequest({ body: JSON.stringify({ custom: { my_spend: 6, my_cap: 60 } }) });
+        const data = await fetchProxyBudget({
+            ...defaultOpts(),
+            preset: 'openrouter',
+            spendPath: 'custom.my_spend',
+            budgetPath: 'custom.my_cap'
+        });
+        expect(data?.spend).toBe(6);
+        expect(data?.budget).toBe(60);
+    });
+
+    it('isProxyBudgetPreset accepts every registered preset key and rejects unknown ones', () => {
+        for (const key of Object.keys(PROXY_BUDGET_PRESETS)) {
+            expect(isProxyBudgetPreset(key)).toBe(true);
+        }
+        expect(isProxyBudgetPreset('bogus-proxy')).toBe(false);
+        expect(isProxyBudgetPreset('')).toBe(false);
+    });
+
+    it('every registered preset has a fully-specified shape', () => {
+        for (const [name, def] of Object.entries(PROXY_BUDGET_PRESETS)) {
+            expect(def.endpoint, name).toMatch(/\$\{baseUrl\}/);
+            expect(def.spendPath, name).toBeTruthy();
+            expect(def.budgetPath, name).toBeTruthy();
+            expect(def.resetAtPath, name).toBeTruthy();
+            expect(['bearer', 'x-api-key']).toContain(def.authScheme);
+        }
     });
 });

--- a/src/utils/proxy-budget-fetch.ts
+++ b/src/utils/proxy-budget-fetch.ts
@@ -20,7 +20,41 @@ export interface ProxyBudgetData {
     resetAt: string | null;
 }
 
+interface ProxyBudgetPresetDef {
+    endpoint: string;
+    spendPath: string;
+    budgetPath: string;
+    resetAtPath: string;
+    authScheme: 'bearer' | 'x-api-key';
+}
+
+// To add a new preset: add a single entry to this object. The type, the
+// runtime validator, and the test matrix all derive from the keys here.
+export const PROXY_BUDGET_PRESETS = {
+    litellm: {
+        endpoint: '${baseUrl}/key/info',
+        spendPath: 'info.spend',
+        budgetPath: 'info.max_budget',
+        resetAtPath: 'info.budget_reset_at',
+        authScheme: 'bearer'
+    },
+    openrouter: {
+        endpoint: '${baseUrl}/api/v1/key',
+        spendPath: 'data.usage',
+        budgetPath: 'data.limit',
+        resetAtPath: 'data.limit_reset',
+        authScheme: 'bearer'
+    }
+} as const satisfies Record<string, ProxyBudgetPresetDef>;
+
+export type ProxyBudgetPreset = keyof typeof PROXY_BUDGET_PRESETS;
+
+export function isProxyBudgetPreset(value: string): value is ProxyBudgetPreset {
+    return Object.prototype.hasOwnProperty.call(PROXY_BUDGET_PRESETS, value);
+}
+
 export interface ProxyBudgetFetchOptions {
+    preset?: ProxyBudgetPreset;
     endpoint?: string;
     baseUrlEnv?: string;
     tokenEnv?: string;
@@ -30,6 +64,23 @@ export interface ProxyBudgetFetchOptions {
     resetAtPath?: string;
     cacheTtlSec?: number;
     timeoutMs?: number;
+}
+
+function resolveWithPreset(opts: ProxyBudgetFetchOptions): {
+    endpoint: string | undefined;
+    spendPath: string;
+    budgetPath: string;
+    resetAtPath: string;
+    authScheme: 'bearer' | 'x-api-key';
+} {
+    const preset = opts.preset ? PROXY_BUDGET_PRESETS[opts.preset] : PROXY_BUDGET_PRESETS.litellm;
+    return {
+        endpoint: opts.endpoint ?? preset.endpoint,
+        spendPath: opts.spendPath ?? preset.spendPath,
+        budgetPath: opts.budgetPath ?? preset.budgetPath,
+        resetAtPath: opts.resetAtPath ?? preset.resetAtPath,
+        authScheme: opts.authScheme ?? preset.authScheme
+    };
 }
 
 const CachedSchema = z.object({
@@ -188,12 +239,13 @@ export async function fetchProxyBudget(opts: ProxyBudgetFetchOptions = {}): Prom
     const token = process.env[tokenEnv];
     const ttlSec = opts.cacheTtlSec ?? DEFAULT_TTL_SEC;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const resolved = resolveWithPreset(opts);
 
     if (!token) {
         return null;
     }
 
-    const endpoint = resolveEndpoint(opts.endpoint, baseUrl);
+    const endpoint = resolveEndpoint(resolved.endpoint, baseUrl);
     if (!endpoint) {
         return null;
     }
@@ -214,7 +266,7 @@ export async function fetchProxyBudget(opts: ProxyBudgetFetchOptions = {}): Prom
             'Accept': 'application/json',
             'User-Agent': 'ccstatusline'
         };
-        if (opts.authScheme === 'x-api-key') {
+        if (resolved.authScheme === 'x-api-key') {
             headers['x-api-key'] = token;
         } else {
             headers.Authorization = `Bearer ${token}`;
@@ -232,9 +284,9 @@ export async function fetchProxyBudget(opts: ProxyBudgetFetchOptions = {}): Prom
             return readStaleCache(ttlSec * STALE_FALLBACK_MULTIPLIER);
         }
 
-        const spendRaw = pickPath(body, opts.spendPath ?? 'info.spend');
-        const budgetRaw = pickPath(body, opts.budgetPath ?? 'info.max_budget');
-        const resetAtRaw = pickPath(body, opts.resetAtPath ?? 'info.budget_reset_at');
+        const spendRaw = pickPath(body, resolved.spendPath);
+        const budgetRaw = pickPath(body, resolved.budgetPath);
+        const resetAtRaw = pickPath(body, resolved.resetAtPath);
 
         const spend = typeof spendRaw === 'number' && Number.isFinite(spendRaw) ? spendRaw : null;
         const budget = typeof budgetRaw === 'number' && Number.isFinite(budgetRaw) ? budgetRaw : null;

--- a/src/utils/proxy-budget-fetch.ts
+++ b/src/utils/proxy-budget-fetch.ts
@@ -1,0 +1,264 @@
+import * as fs from 'fs';
+import * as http from 'http';
+import * as https from 'https';
+import * as os from 'os';
+import * as path from 'path';
+import { z } from 'zod';
+
+const CACHE_DIR = path.join(os.homedir(), '.cache', 'ccstatusline');
+const CACHE_FILE = path.join(CACHE_DIR, 'proxy-budget.json');
+const LOCK_FILE = path.join(CACHE_DIR, 'proxy-budget.lock');
+const DEFAULT_TTL_SEC = 60;
+const DEFAULT_TIMEOUT_MS = 3000;
+const STALE_FALLBACK_MULTIPLIER = 10;
+const SANITY_BUDGET_MULTIPLIER = 2;
+
+export interface ProxyBudgetData {
+    spend: number;
+    budget: number;
+    percentage: number;
+    resetAt: string | null;
+}
+
+export interface ProxyBudgetFetchOptions {
+    endpoint?: string;
+    baseUrlEnv?: string;
+    tokenEnv?: string;
+    authScheme?: 'bearer' | 'x-api-key';
+    spendPath?: string;
+    budgetPath?: string;
+    resetAtPath?: string;
+    cacheTtlSec?: number;
+    timeoutMs?: number;
+}
+
+const CachedSchema = z.object({
+    data: z.object({
+        spend: z.number(),
+        budget: z.number(),
+        percentage: z.number(),
+        resetAt: z.string().nullable()
+    }),
+    timestamp: z.number()
+});
+
+function ensureCacheDir(): void {
+    if (!fs.existsSync(CACHE_DIR)) {
+        fs.mkdirSync(CACHE_DIR, { recursive: true });
+    }
+}
+
+function pickPath(obj: unknown, path: string): unknown {
+    return path.split('.').reduce<unknown>((acc, key) => {
+        if (acc && typeof acc === 'object' && key in (acc as Record<string, unknown>)) {
+            return (acc as Record<string, unknown>)[key];
+        }
+        return undefined;
+    }, obj);
+}
+
+function readCacheIfFresh(ttlSec: number): ProxyBudgetData | null {
+    try {
+        const parsed = CachedSchema.safeParse(JSON.parse(fs.readFileSync(CACHE_FILE, 'utf8')));
+        if (!parsed.success)
+            return null;
+        const ageSec = (Date.now() - parsed.data.timestamp) / 1000;
+        if (ageSec < ttlSec)
+            return parsed.data.data;
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+function readStaleCache(maxAgeSec: number): ProxyBudgetData | null {
+    try {
+        const parsed = CachedSchema.safeParse(JSON.parse(fs.readFileSync(CACHE_FILE, 'utf8')));
+        if (!parsed.success)
+            return null;
+        const ageSec = (Date.now() - parsed.data.timestamp) / 1000;
+        if (ageSec < maxAgeSec)
+            return parsed.data.data;
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+function writeCache(data: ProxyBudgetData): void {
+    try {
+        ensureCacheDir();
+        fs.writeFileSync(CACHE_FILE, JSON.stringify({ data, timestamp: Date.now() }));
+    } catch {
+        // Best-effort cache write; ignore failures
+    }
+}
+
+function resolveEndpoint(endpoint: string | undefined, baseUrl: string | undefined): string | null {
+    if (endpoint && endpoint.length > 0) {
+        if (endpoint.includes('${baseUrl}')) {
+            if (!baseUrl)
+                return null;
+            return endpoint.replace('${baseUrl}', baseUrl.replace(/\/+$/, ''));
+        }
+        return endpoint;
+    }
+    if (!baseUrl)
+        return null;
+    return `${baseUrl.replace(/\/+$/, '')}/key/info`;
+}
+
+function isProxyLocked(now: number): boolean {
+    try {
+        const stat = fs.statSync(LOCK_FILE);
+        const lockMtimeSec = Math.floor(stat.mtimeMs / 1000);
+        return now - lockMtimeSec < 5;
+    } catch {
+        return false;
+    }
+}
+
+function writeLock(): void {
+    try {
+        ensureCacheDir();
+        fs.writeFileSync(LOCK_FILE, JSON.stringify({ ts: Date.now() }));
+    } catch {
+        // Ignore lock-file errors
+    }
+}
+
+function clearLock(): void {
+    try {
+        fs.unlinkSync(LOCK_FILE);
+    } catch {
+        // Ignore
+    }
+}
+
+async function performHttpGet(
+    url: string,
+    headers: Record<string, string>,
+    timeoutMs: number
+): Promise<{ status: number; body: string } | null> {
+    return new Promise((resolve) => {
+        let parsedUrl: URL;
+        try {
+            parsedUrl = new URL(url);
+        } catch {
+            resolve(null);
+            return;
+        }
+
+        const isHttps = parsedUrl.protocol === 'https:';
+        const lib = isHttps ? https : http;
+        const req = lib.request(
+            {
+                hostname: parsedUrl.hostname,
+                port: parsedUrl.port || (isHttps ? 443 : 80),
+                path: `${parsedUrl.pathname}${parsedUrl.search}`,
+                method: 'GET',
+                headers
+            },
+            (res) => {
+                const chunks: Buffer[] = [];
+                res.on('data', (chunk: Buffer) => chunks.push(chunk));
+                res.on('end', () => {
+                    resolve({
+                        status: res.statusCode ?? 0,
+                        body: Buffer.concat(chunks).toString('utf8')
+                    });
+                });
+                res.on('error', () => { resolve(null); });
+            }
+        );
+
+        req.setTimeout(timeoutMs, () => {
+            req.destroy();
+            resolve(null);
+        });
+        req.on('error', () => { resolve(null); });
+        req.end();
+    });
+}
+
+export async function fetchProxyBudget(opts: ProxyBudgetFetchOptions = {}): Promise<ProxyBudgetData | null> {
+    const baseUrlEnv = opts.baseUrlEnv ?? 'ANTHROPIC_BASE_URL';
+    const tokenEnv = opts.tokenEnv ?? 'ANTHROPIC_AUTH_TOKEN';
+    const baseUrl = process.env[baseUrlEnv];
+    const token = process.env[tokenEnv];
+    const ttlSec = opts.cacheTtlSec ?? DEFAULT_TTL_SEC;
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    if (!token) {
+        return null;
+    }
+
+    const endpoint = resolveEndpoint(opts.endpoint, baseUrl);
+    if (!endpoint) {
+        return null;
+    }
+
+    const fresh = readCacheIfFresh(ttlSec);
+    if (fresh) {
+        return fresh;
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    if (isProxyLocked(now)) {
+        return readStaleCache(ttlSec * STALE_FALLBACK_MULTIPLIER);
+    }
+
+    writeLock();
+    try {
+        const headers: Record<string, string> = {
+            'Accept': 'application/json',
+            'User-Agent': 'ccstatusline'
+        };
+        if (opts.authScheme === 'x-api-key') {
+            headers['x-api-key'] = token;
+        } else {
+            headers.Authorization = `Bearer ${token}`;
+        }
+
+        const response = await performHttpGet(endpoint, headers, timeoutMs);
+        if (!response || response.status < 200 || response.status >= 300) {
+            return readStaleCache(ttlSec * STALE_FALLBACK_MULTIPLIER);
+        }
+
+        let body: unknown;
+        try {
+            body = JSON.parse(response.body);
+        } catch {
+            return readStaleCache(ttlSec * STALE_FALLBACK_MULTIPLIER);
+        }
+
+        const spendRaw = pickPath(body, opts.spendPath ?? 'info.spend');
+        const budgetRaw = pickPath(body, opts.budgetPath ?? 'info.max_budget');
+        const resetAtRaw = pickPath(body, opts.resetAtPath ?? 'info.budget_reset_at');
+
+        const spend = typeof spendRaw === 'number' && Number.isFinite(spendRaw) ? spendRaw : null;
+        const budget = typeof budgetRaw === 'number' && Number.isFinite(budgetRaw) ? budgetRaw : null;
+        const resetAt = typeof resetAtRaw === 'string' ? resetAtRaw : null;
+
+        if (spend === null || budget === null) {
+            return readStaleCache(ttlSec * STALE_FALLBACK_MULTIPLIER);
+        }
+        if (budget <= 0) {
+            return null;
+        }
+        if (spend > budget * SANITY_BUDGET_MULTIPLIER) {
+            return null;
+        }
+
+        const data: ProxyBudgetData = {
+            spend,
+            budget,
+            percentage: Math.min(100, (spend / budget) * 100),
+            resetAt
+        };
+        writeCache(data);
+        return data;
+    } finally {
+        clearLock();
+    }
+}

--- a/src/utils/usage-prefetch.ts
+++ b/src/utils/usage-prefetch.ts
@@ -5,7 +5,10 @@ import type {
     ProxyBudgetData,
     ProxyBudgetFetchOptions
 } from './proxy-budget-fetch';
-import { fetchProxyBudget } from './proxy-budget-fetch';
+import {
+    fetchProxyBudget,
+    isProxyBudgetPreset
+} from './proxy-budget-fetch';
 import type { UsageData } from './usage';
 import { fetchUsageData } from './usage';
 
@@ -151,6 +154,9 @@ function getProxyBudgetOptionsFromLines(lines: WidgetItem[][]): ProxyBudgetFetch
                 continue;
             const md = item.metadata ?? {};
             const opts: ProxyBudgetFetchOptions = {};
+            if (md.preset && isProxyBudgetPreset(md.preset)) {
+                opts.preset = md.preset;
+            }
             if (md.endpoint)
                 opts.endpoint = md.endpoint;
             if (md.baseUrlEnv)

--- a/src/utils/usage-prefetch.ts
+++ b/src/utils/usage-prefetch.ts
@@ -1,6 +1,11 @@
 import type { StatusJSON } from '../types/StatusJSON';
 import type { WidgetItem } from '../types/Widget';
 
+import type {
+    ProxyBudgetData,
+    ProxyBudgetFetchOptions
+} from './proxy-budget-fetch';
+import { fetchProxyBudget } from './proxy-budget-fetch';
 import type { UsageData } from './usage';
 import { fetchUsageData } from './usage';
 
@@ -131,6 +136,58 @@ function getRequiredUsageFields(perModelRequirements: PerModelUsageRequirements)
     }
 
     return requiredFields;
+}
+
+const PROXY_BUDGET_WIDGET_TYPE = 'proxy-budget';
+
+export function hasProxyBudgetWidget(lines: WidgetItem[][]): boolean {
+    return lines.some(line => line.some(item => item.type === PROXY_BUDGET_WIDGET_TYPE));
+}
+
+function getProxyBudgetOptionsFromLines(lines: WidgetItem[][]): ProxyBudgetFetchOptions {
+    for (const line of lines) {
+        for (const item of line) {
+            if (item.type !== PROXY_BUDGET_WIDGET_TYPE)
+                continue;
+            const md = item.metadata ?? {};
+            const opts: ProxyBudgetFetchOptions = {};
+            if (md.endpoint)
+                opts.endpoint = md.endpoint;
+            if (md.baseUrlEnv)
+                opts.baseUrlEnv = md.baseUrlEnv;
+            if (md.tokenEnv)
+                opts.tokenEnv = md.tokenEnv;
+            if (md.authScheme === 'bearer' || md.authScheme === 'x-api-key') {
+                opts.authScheme = md.authScheme;
+            }
+            if (md.spendPath)
+                opts.spendPath = md.spendPath;
+            if (md.budgetPath)
+                opts.budgetPath = md.budgetPath;
+            if (md.resetAtPath)
+                opts.resetAtPath = md.resetAtPath;
+            if (md.cacheTtlSec) {
+                const n = Number.parseInt(md.cacheTtlSec, 10);
+                if (Number.isFinite(n) && n > 0)
+                    opts.cacheTtlSec = n;
+            }
+            if (md.timeoutMs) {
+                const n = Number.parseInt(md.timeoutMs, 10);
+                if (Number.isFinite(n) && n > 0)
+                    opts.timeoutMs = n;
+            }
+            return opts;
+        }
+    }
+    return {};
+}
+
+export async function prefetchProxyBudgetIfNeeded(lines: WidgetItem[][]): Promise<ProxyBudgetData | null> {
+    if (!hasProxyBudgetWidget(lines)) {
+        return null;
+    }
+    const opts = getProxyBudgetOptionsFromLines(lines);
+    return fetchProxyBudget(opts);
 }
 
 export async function prefetchUsageDataIfNeeded(lines: WidgetItem[][], data?: StatusJSON): Promise<UsageData | null> {

--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -92,7 +92,8 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'worktree-name', create: () => new widgets.GitWorktreeNameWidget() },
     { type: 'worktree-branch', create: () => new widgets.GitWorktreeBranchWidget() },
     { type: 'worktree-original-branch', create: () => new widgets.GitWorktreeOriginalBranchWidget() },
-    { type: 'compaction-counter', create: () => new widgets.CompactionCounterWidget() }
+    { type: 'compaction-counter', create: () => new widgets.CompactionCounterWidget() },
+    { type: 'proxy-budget', create: () => new widgets.ProxyBudgetWidget() }
 ];
 
 export const LAYOUT_WIDGET_MANIFEST: LayoutWidgetManifestEntry[] = [

--- a/src/widgets/ProxyBudget.ts
+++ b/src/widgets/ProxyBudget.ts
@@ -1,0 +1,107 @@
+import chalk from 'chalk';
+
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+
+const DEFAULT_WARNING_THRESHOLD = 80;
+const DEFAULT_CRITICAL_THRESHOLD = 95;
+const DEFAULT_FORMAT = 'spend-percent';
+const VALID_FORMATS = new Set(['spend-percent', 'percent', 'spend']);
+
+function readThreshold(item: WidgetItem, key: string, fallback: number): number {
+    const raw = item.metadata?.[key];
+    if (!raw)
+        return fallback;
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isFinite(n) || n < 0 || n > 100)
+        return fallback;
+    return n;
+}
+
+function readFormat(item: WidgetItem): string {
+    const raw = item.metadata?.format;
+    if (raw && VALID_FORMATS.has(raw))
+        return raw;
+    return DEFAULT_FORMAT;
+}
+
+function formatValue(spend: number, budget: number, percentage: number, format: string): string {
+    const spendStr = `$${spend.toFixed(2)}`;
+    const pctStr = `${percentage.toFixed(0)}%`;
+    const budgetStr = `$${budget.toFixed(2)}`;
+    if (format === 'percent')
+        return pctStr;
+    if (format === 'spend')
+        return spendStr;
+    return `${spendStr}/${budgetStr} (${pctStr})`;
+}
+
+function applyTier(text: string, percentage: number, warning: number, critical: number): string {
+    if (percentage >= critical)
+        return chalk.red(text);
+    if (percentage >= warning)
+        return chalk.yellow(text);
+    return chalk.green(text);
+}
+
+function endpointHostHint(item: WidgetItem): string | undefined {
+    const preset = item.metadata?.preset;
+    const endpoint = item.metadata?.endpoint;
+    if (endpoint) {
+        try {
+            return new URL(endpoint.replace('${baseUrl}', 'https://example.com')).hostname;
+        } catch {
+            return undefined;
+        }
+    }
+    if (preset)
+        return preset;
+    return undefined;
+}
+
+export class ProxyBudgetWidget implements Widget {
+    getDefaultColor(): string { return 'green'; }
+    getDescription(): string { return 'Spend vs budget from a LiteLLM / OpenRouter / compatible proxy endpoint'; }
+    getDisplayName(): string { return 'Proxy Budget'; }
+    getCategory(): string { return 'Usage'; }
+
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
+        const hint = endpointHostHint(item);
+        return {
+            displayText: this.getDisplayName(),
+            modifierText: hint ? `(${hint})` : undefined
+        };
+    }
+
+    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+        if (context.isPreview) {
+            const previewText = formatValue(12.34, 100, 45, readFormat(item));
+            const labeled = item.rawValue ? previewText : `Budget: ${previewText}`;
+            return chalk.green(labeled);
+        }
+
+        const data = context.proxyBudgetData;
+        if (!data) {
+            return null;
+        }
+
+        const warning = readThreshold(item, 'warningThreshold', DEFAULT_WARNING_THRESHOLD);
+        const critical = readThreshold(item, 'criticalThreshold', DEFAULT_CRITICAL_THRESHOLD);
+        const format = readFormat(item);
+        const value = formatValue(data.spend, data.budget, data.percentage, format);
+        const labeled = item.rawValue ? value : `Budget: ${value}`;
+        return applyTier(labeled, data.percentage, warning, critical);
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(): boolean { return true; }
+
+    getNumericValue(context: RenderContext, _item: WidgetItem): number | null {
+        return context.proxyBudgetData?.percentage ?? null;
+    }
+}

--- a/src/widgets/__tests__/ProxyBudget.test.ts
+++ b/src/widgets/__tests__/ProxyBudget.test.ts
@@ -1,0 +1,142 @@
+import chalk from 'chalk';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import { DEFAULT_SETTINGS } from '../../types/Settings';
+import type { WidgetItem } from '../../types/Widget';
+import type { ProxyBudgetData } from '../../utils/proxy-budget-fetch';
+import { ProxyBudgetWidget } from '../ProxyBudget';
+
+const originalChalkLevel = chalk.level;
+
+function widget(): ProxyBudgetWidget {
+    return new ProxyBudgetWidget();
+}
+
+function item(overrides: Partial<WidgetItem> = {}): WidgetItem {
+    return {
+        id: 'pb',
+        type: 'proxy-budget',
+        ...overrides
+    };
+}
+
+function ctx(data: ProxyBudgetData | null, isPreview = false): RenderContext {
+    return {
+        proxyBudgetData: data,
+        isPreview
+    };
+}
+
+function render(w: ProxyBudgetWidget, it: WidgetItem, c: RenderContext): string | null {
+    return w.render(it, c, DEFAULT_SETTINGS);
+}
+
+describe('ProxyBudgetWidget', () => {
+    beforeEach(() => {
+        // Force chalk to emit ANSI so tier assertions can inspect SGR codes.
+        chalk.level = 1;
+    });
+
+    afterEach(() => {
+        chalk.level = originalChalkLevel;
+    });
+
+    it('returns null when context.proxyBudgetData is null', () => {
+        expect(render(widget(), item(), ctx(null))).toBeNull();
+    });
+
+    it('renders spend/cap/percentage in green below the warning threshold (default 80)', () => {
+        const out = render(widget(), item(), ctx({ spend: 5, budget: 100, percentage: 5, resetAt: null }));
+        expect(out).not.toBeNull();
+        expect(out).toContain('$5.00');
+        expect(out).toContain('$100.00');
+        expect(out).toContain('(5%)');
+        expect(out).toBe(chalk.green('Budget: $5.00/$100.00 (5%)'));
+    });
+
+    it('uses yellow at the warning threshold', () => {
+        const out = render(widget(), item(), ctx({ spend: 80, budget: 100, percentage: 80, resetAt: null }));
+        expect(out).toBe(chalk.yellow('Budget: $80.00/$100.00 (80%)'));
+    });
+
+    it('uses red at the critical threshold', () => {
+        const out = render(widget(), item(), ctx({ spend: 96, budget: 100, percentage: 96, resetAt: null }));
+        expect(out).toBe(chalk.red('Budget: $96.00/$100.00 (96%)'));
+    });
+
+    it('respects custom warningThreshold and criticalThreshold from metadata', () => {
+        const customItem = item({ metadata: { warningThreshold: '50', criticalThreshold: '75' } });
+        const yellow = render(widget(), customItem, ctx({ spend: 55, budget: 100, percentage: 55, resetAt: null }));
+        const red = render(widget(), customItem, ctx({ spend: 80, budget: 100, percentage: 80, resetAt: null }));
+        expect(yellow).toBe(chalk.yellow('Budget: $55.00/$100.00 (55%)'));
+        expect(red).toBe(chalk.red('Budget: $80.00/$100.00 (80%)'));
+    });
+
+    it('renders format=percent (no $ amounts)', () => {
+        const out = render(widget(), item({ metadata: { format: 'percent' } }), ctx({ spend: 25, budget: 100, percentage: 25, resetAt: null }));
+        expect(out).toBe(chalk.green('Budget: 25%'));
+    });
+
+    it('renders format=spend (no percentage)', () => {
+        const out = render(widget(), item({ metadata: { format: 'spend' } }), ctx({ spend: 25, budget: 100, percentage: 25, resetAt: null }));
+        expect(out).toBe(chalk.green('Budget: $25.00'));
+    });
+
+    it('honors item.rawValue by stripping the "Budget:" label', () => {
+        const out = render(widget(), item({ rawValue: true }), ctx({ spend: 5, budget: 100, percentage: 5, resetAt: null }));
+        expect(out).toBe(chalk.green('$5.00/$100.00 (5%)'));
+    });
+
+    it('returns a hardcoded preview when context.isPreview is true', () => {
+        const out = render(widget(), item(), ctx(null, true));
+        expect(out).toContain('$12.34');
+        expect(out).toContain('(45%)');
+        expect(out).toContain('Budget:');
+    });
+
+    it('preview honors item.rawValue', () => {
+        const out = render(widget(), item({ rawValue: true }), ctx(null, true));
+        expect(out).not.toContain('Budget:');
+        expect(out).toContain('$12.34');
+    });
+
+    it('invalid format metadata falls back to spend-percent', () => {
+        const out = render(widget(), item({ metadata: { format: 'nonsense' } }), ctx({ spend: 5, budget: 100, percentage: 5, resetAt: null }));
+        expect(out).toBe(chalk.green('Budget: $5.00/$100.00 (5%)'));
+    });
+
+    it('out-of-range thresholds fall back to defaults', () => {
+        const customItem = item({ metadata: { warningThreshold: '999', criticalThreshold: '-5' } });
+        const out = render(widget(), customItem, ctx({ spend: 50, budget: 100, percentage: 50, resetAt: null }));
+        expect(out).toBe(chalk.green('Budget: $50.00/$100.00 (50%)'));
+    });
+
+    it('getEditorDisplay shows preset name in modifier when set', () => {
+        const display = widget().getEditorDisplay(item({ metadata: { preset: 'openrouter' } }));
+        expect(display.displayText).toBe('Proxy Budget');
+        expect(display.modifierText).toBe('(openrouter)');
+    });
+
+    it('getNumericValue returns the percentage', () => {
+        const value = widget().getNumericValue(ctx({ spend: 30, budget: 100, percentage: 30, resetAt: null }), item());
+        expect(value).toBe(30);
+    });
+
+    it('getNumericValue returns null when no data', () => {
+        const value = widget().getNumericValue(ctx(null), item());
+        expect(value).toBeNull();
+    });
+
+    it('supportsRawValue and supportsColors are both true', () => {
+        const w = widget();
+        expect(w.supportsRawValue()).toBe(true);
+        expect(w.supportsColors()).toBe(true);
+    });
+});

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -74,3 +74,4 @@ export { GitWorktreeBranchWidget } from './GitWorktreeBranch';
 export { GitWorktreeOriginalBranchWidget } from './GitWorktreeOriginalBranch';
 export { CompactionCounterWidget } from './CompactionCounter';
 export { VoiceStatusWidget } from './VoiceStatus';
+export { ProxyBudgetWidget } from './ProxyBudget';


### PR DESCRIPTION
## Summary

Adds a new opt-in `proxy-budget` widget that displays spend-vs-cap from a LiteLLM-compatible HTTP proxy, with green/yellow/red threshold tiers. Ships with two verified presets out of the box (LiteLLM and OpenRouter) plus full path-driven configuration for any other bearer-token JSON endpoint (Portkey, Helicone, custom proxies). Defaults to Claude Code's existing `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` env vars so the typical setup needs zero config.

Happy to rename, restructure, or close if scope doesn't fit. The implementation is included so the design is concrete to react to.

## Display

Live render with the widget at the end of line 2 (`Budget: $616.72/$1000.00 (62%)` in green):

![ProxyBudgetWidget rendering](https://raw.githubusercontent.com/sagy101/ccstatusline/assets/proxyBudget-ccstatusline.png)

Format options via `metadata.format`:

| Format | Output |
|---|---|
| `spend-percent` (default) | `Budget: $5.00/$100.00 (5%)` |
| `percent` | `Budget: 5%` |
| `spend` | `Budget: $5.00` |

Color tiers (default 80% warning / 95% critical, configurable):

| Range | Color |
|---|---|
| `< warning` | green |
| `warning..critical` | yellow |
| `>= critical` | red |

## Presets

Two verified presets ship in this PR. Both auth via `Authorization: Bearer <token>` from the env var named by `tokenEnv`.

| Preset | Endpoint | Spend path | Cap path | Reset path |
|---|---|---|---|---|
| `litellm` (default) | `${baseUrl}/key/info` | `info.spend` | `info.max_budget` | `info.budget_reset_at` |
| `openrouter` | `${baseUrl}/api/v1/key` | `data.usage` | `data.limit` | `data.limit_reset` |

The presets live in `PROXY_BUDGET_PRESETS` in `src/utils/proxy-budget-fetch.ts`. Adding a new one is a single object entry — the exported `ProxyBudgetPreset` type, the `isProxyBudgetPreset` runtime guard, the metadata validator in `usage-prefetch.ts`, and the test matrix all derive from the registry keys. A test iterates the registry to assert every entry has a fully-specified shape, so adding a malformed preset fails the suite immediately.

OpenRouter shape verified against [openrouter.ai/docs/api/api-reference/api-keys/get-current-key](https://openrouter.ai/docs/api/api-reference/api-keys/get-current-key).

## Implementation notes

- **Data flow.** Adds `prefetchProxyBudgetIfNeeded` to `src/utils/usage-prefetch.ts`, called once per render in `src/ccstatusline.ts` (mirrors the existing `prefetchUsageDataIfNeeded` pattern for Anthropic usage). Result attached to `RenderContext.proxyBudgetData`; the widget reads synchronously.
- **HTTP / cache.** New `src/utils/proxy-budget-fetch.ts` uses Node stdlib `https` (no new deps). Caches at `~/.cache/ccstatusline/proxy-budget.json` with default 60s TTL, plus stale-cache fallback up to 10× TTL on transient failures. Lock file pattern adapted from `src/utils/usage-fetch.ts`. Sanity guard (`spend > 2 × budget`) returns null to suppress display when the proxy returns nonsense.
- **Configuration via metadata.** All settings live in `WidgetItem.metadata: Record<string, string>` (preset, endpoint, baseUrlEnv, tokenEnv, authScheme, JSON paths, thresholds, cacheTtlSec, timeoutMs, format). v1 ships without a custom Ink editor — users configure in JSON. Matches early `custom-command` behavior; a `renderEditor` can be added in a follow-up if requested.
- **Color tiers via embedded chalk.** `render()` returns a chalk-wrapped string (`chalk.green/yellow/red`). The renderer at `src/utils/renderer.ts:756` wraps with its own outer SGR but the embedded codes survive intact — same mechanism that already works for any colored content. No changes needed in the renderer.
- **Forward compat.** Implements the optional `getNumericValue` returning the percentage so future threshold-aware features in the renderer can consume it without re-implementing the widget.
- **Tokens come from env, never from config.** `tokenEnv` (default `ANTHROPIC_AUTH_TOKEN`) selects the variable name; the value never touches `settings.json`, the disk cache, error logs, or anywhere else.
- **Defaults match Claude Code conventions.** `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` are the env vars Claude Code itself sets when routing through any proxy. The typical setup needs nothing in metadata beyond `"enabled": true`.

## Why a native widget vs `CustomCommand`?

The existing `CustomCommand` widget can run a shell script that hits the same endpoint, but:

1. **Subprocess overhead per render.** Status line refreshes ~every 1-3s; spawning a separate shell each time plus serializing JSON over stdin is meaningful overhead compared to a sync read of `context.proxyBudgetData`.
2. **Cache and lock-file reimplementation.** Each user installing the CustomCommand recipe has to reimplement the 60s TTL, stale fallback, and concurrent-fetch locking themselves in shell.
3. **Loss of typed config and first-class features.** Threshold-aware tier colors, raw-value mode, preview mode, editor display, and `getNumericValue` all become script bookkeeping instead of native widget features.

The native widget pays a one-time integration cost for repeated correctness.

## Files changed

- `src/utils/proxy-budget-fetch.ts` (new) — fetch, cache, lock, sanity guard, preset registry, dotted JSON path resolver
- `src/utils/usage-prefetch.ts` — new `hasProxyBudgetWidget` / `prefetchProxyBudgetIfNeeded` exports
- `src/types/RenderContext.ts` — new `proxyBudgetData?` field
- `src/ccstatusline.ts` — two lines: call prefetch, attach to context
- `src/widgets/ProxyBudget.ts` (new) — the widget class
- `src/widgets/index.ts` — re-export
- `src/utils/widget-manifest.ts` — manifest entry `proxy-budget` in Usage cluster
- `src/utils/__tests__/proxy-budget-fetch.test.ts` (new) — 18 cases (LiteLLM happy path, OpenRouter preset, custom paths, missing env, non-2xx, malformed JSON, missing field, sanity guard, timeout, bearer/x-api-key headers, fresh/stale cache, network down, registry guard + shape)
- `src/widgets/__tests__/ProxyBudget.test.ts` (new) — 16 cases (null data, tier boundaries, custom thresholds, format variants, raw mode, preview mode, invalid format/threshold fallback, editor display, getNumericValue, supportsRawValue/supportsColors)
- `docs/USAGE.md` — new "Proxy Budget Widget" section under existing widget docs

## Test plan

- [x] `bun tsc --noEmit` clean
- [x] `bun run lint` clean (eslint, 0 warnings)
- [x] `bun test` — 1288 / 1288 passing (1254 baseline + 34 new)
- [x] `bun run build` produces `dist/ccstatusline.js` cleanly
- [x] Smoke-tested against a live LiteLLM proxy (built binary piped sample hook JSON):
  - Cold cache: fetches and renders `Budget: $X.XX/$Y.YY (NN%)` in green; cache written to `~/.cache/ccstatusline/proxy-budget.json`
  - Warm cache: ~0.25s end-to-end, no network call (verified via wall-clock timing)
  - Missing token: segment silently absent, no errors on stdout
  - Black-hole IP (`https://10.255.255.1`): widget hides, lock file cleaned up
- [x] Visually verified end-to-end inside Claude Code with a full layout (model, thinking-effort, context bar, tokens, session-clock, cwd, git-branch, git-status, proxy-budget) — see screenshot above

## Scope notes

**Out of scope for v1:** cloud-native cost APIs that don't fit the bearer-token-JSON pattern (AWS Bedrock SigV4 + Cost Explorer, Vertex AI service-account JWT + Cloud Billing, Azure RBAC + Cost Management). Documented in `docs/USAGE.md` under the widget's "Out of scope" note. Future: separate provider-specific widgets if there's demand.
