### PR TITLE
fix: filter all-zero context_window frames to prevent Context Bar 0k flash

### DIFF
--- a/src/utils/__tests__/context-window.test.ts
+++ b/src/utils/__tests__/context-window.test.ts
@@ -72,4 +72,64 @@ describe('getContextWindowMetrics', () => {
             totalTokens: 6000
         });
     });
+
+    describe('all-zero transient frame filtering', () => {
+        it('returns null usage for all-zero frame with current_usage object', () => {
+            const metrics = getContextWindowMetrics({
+                context_window: {
+                    context_window_size: 200000,
+                    total_input_tokens: 0,
+                    total_output_tokens: 0,
+                    current_usage: {
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        cache_creation_input_tokens: 0,
+                        cache_read_input_tokens: 0
+                    },
+                    used_percentage: 0,
+                    remaining_percentage: 100
+                }
+            });
+
+            expect(metrics.windowSize).toBe(200000);
+            expect(metrics.usedTokens).toBeNull();
+            expect(metrics.contextLengthTokens).toBeNull();
+            expect(metrics.usedPercentage).toBeNull();
+            expect(metrics.remainingPercentage).toBeNull();
+            expect(metrics.cachedTokens).toBeNull();
+            expect(metrics.totalTokens).toBeNull();
+        });
+
+        it('returns null usage for all-zero frame with scalar current_usage=0', () => {
+            const metrics = getContextWindowMetrics({
+                context_window: {
+                    context_window_size: 200000,
+                    current_usage: 0,
+                    used_percentage: 0
+                }
+            });
+
+            expect(metrics.usedTokens).toBeNull();
+            expect(metrics.contextLengthTokens).toBeNull();
+            expect(metrics.usedPercentage).toBeNull();
+        });
+
+        it('preserves non-zero usage even when used_percentage is 0', () => {
+            const metrics = getContextWindowMetrics({
+                context_window: {
+                    context_window_size: 200000,
+                    current_usage: {
+                        input_tokens: 100,
+                        output_tokens: 0,
+                        cache_creation_input_tokens: 0,
+                        cache_read_input_tokens: 0
+                    },
+                    used_percentage: 0
+                }
+            });
+
+            expect(metrics.usedTokens).toBe(100);
+            expect(metrics.usedPercentage).toBe(0);
+        });
+    });
 });

--- a/src/utils/context-window.ts
+++ b/src/utils/context-window.ts
@@ -79,6 +79,25 @@ export function getContextWindowMetrics(data?: StatusJSON): ContextWindowMetrics
             ? clampPercentage((usedTokens / windowSize) * 100)
             : null;
 
+    // Treat all-zero usage frames as missing data — Claude Code occasionally
+    // emits transient frames where used_percentage is 0 and all token counts
+    // are 0 mid-session. Returning null forces callers to fall through to
+    // transcript-based metrics instead of flashing "0k".
+    const isAllZero = usedPercentage === 0 && (usedTokens === null || usedTokens === 0);
+    if (isAllZero) {
+        return {
+            windowSize,
+            usedTokens: null,
+            contextLengthTokens: null,
+            usedPercentage: null,
+            remainingPercentage: null,
+            totalInputTokens,
+            totalOutputTokens,
+            cachedTokens: null,
+            totalTokens: null
+        };
+    }
+
     const remainingPercentage = rawRemainingPercentage !== null
         ? clampPercentage(rawRemainingPercentage)
         : usedPercentage !== null


### PR DESCRIPTION
## Problem

Claude Code occasionally emits transient `context_window` status JSON frames where all usage fields are zero mid-session:

```json
{
  "context_window_size": 200000,
  "total_input_tokens": 0,
  "total_output_tokens": 0,
  "current_usage": { "input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0 },
  "used_percentage": 0,
  "remaining_percentage": 100
}
```

These all-zero frames cause the Context Bar widget to briefly flash `0k/200k (0%)` before the next valid frame restores the correct display. With `refreshInterval: 10`, the statusline polls frequently enough to sample these intermediate frames.

Observed in practice: a burst of 7-30 consecutive all-zero frames within a single second, all with identical zero content, while the actual session has ~111k tokens in use.

## Solution

Filter all-zero usage frames at the data source layer in `getContextWindowMetrics()`. When `used_percentage === 0` AND `usedTokens` is 0 or null, return `null` for all usage fields (`usedTokens`, `contextLengthTokens`, `usedPercentage`, `remainingPercentage`, `cachedTokens`, `totalTokens`). Keep `windowSize`, `totalInputTokens`, and `totalOutputTokens` intact since those are independently valid.

When the Context Bar widget receives `null` for `contextLengthTokens`, it falls through to `tokenMetrics.contextLength` (parsed from the session transcript JSONL file), which contains the real token count. This eliminates the 0k flash without any caching or state management overhead.

## Why this approach

- **No new files or caches**: Uses the existing transcript-based fallback path that already works
- **Minimal change**: 19 lines of logic + 60 lines of tests, all in `context-window.ts`
- **Data source filtering**: Fixes the problem at the root rather than patching each consumer
- **Preserves legitimate zero**: If `used_percentage` is 0 but `current_usage.input_tokens > 0`, the data is preserved (not a true all-zero frame)

## Test plan

- [x] New unit tests: all-zero frame with `current_usage` object, scalar `current_usage=0`, and non-zero usage with `used_percentage=0`
- [x] Existing tests pass (6/6 in context-window, 1304/1304 full suite)
- [x] Manual testing: deployed locally, confirmed 0k flash no longer appears while progress bar maintains correct display via transcript fallback