### PR TITLE
feat: add Weekly Budget Buffer widget

### DIFF
--- a/src/utils/usage-prefetch.ts
+++ b/src/utils/usage-prefetch.ts
@@ -9,6 +9,7 @@ const USAGE_WIDGET_TYPES = new Set<string>([
     'weekly-usage',
     'weekly-sonnet-usage',
     'weekly-opus-usage',
+    'weekly-budget-buffer',
     'block-timer',
     'reset-timer',
     'weekly-reset-timer'

--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -81,6 +81,7 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'weekly-usage', create: () => new widgets.WeeklyUsageWidget() },
     { type: 'weekly-sonnet-usage', create: () => new widgets.WeeklySonnetUsageWidget() },
     { type: 'weekly-opus-usage', create: () => new widgets.WeeklyOpusUsageWidget() },
+    { type: 'weekly-budget-buffer', create: () => new widgets.WeeklyBudgetBufferWidget() },
     { type: 'reset-timer', create: () => new widgets.BlockResetTimerWidget() },
     { type: 'weekly-reset-timer', create: () => new widgets.WeeklyResetTimerWidget() },
     { type: 'context-bar', create: () => new widgets.ContextBarWidget() },

--- a/src/widgets/WeeklyBudgetBuffer.ts
+++ b/src/widgets/WeeklyBudgetBuffer.ts
@@ -1,0 +1,114 @@
+import { getColorLevelString } from '../types/ColorLevel';
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+import { getColorAnsiCode } from '../utils/colors';
+import {
+    getUsageErrorMessage,
+    resolveWeeklyUsageWindow
+} from '../utils/usage';
+import { SEVEN_DAY_WINDOW_MS } from '../utils/usage-types';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const WINDOW_DAYS = SEVEN_DAY_WINDOW_MS / ONE_DAY_MS;
+const BAR_HALF_WIDTH = 10;
+const POSITIVE_COLOR_DEFAULT = 'green';
+const NEGATIVE_COLOR_DEFAULT = 'red';
+const FG_RESET = '\x1b[39m';
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.max(min, Math.min(max, value));
+}
+
+function formatSignedPercent(value: number): string {
+    const rounded = Math.round(value);
+    return rounded > 0 ? `+${rounded}%` : `${rounded}%`;
+}
+
+function getPositiveColor(item: WidgetItem): string {
+    const value = item.metadata?.positiveColor;
+    return typeof value === 'string' && value.length > 0 ? value : POSITIVE_COLOR_DEFAULT;
+}
+
+function getNegativeColor(item: WidgetItem): string {
+    const value = item.metadata?.negativeColor;
+    return typeof value === 'string' && value.length > 0 ? value : NEGATIVE_COLOR_DEFAULT;
+}
+
+export function computeBudgetBufferPercent(weeklyUsagePercent: number, elapsedPercent: number): number {
+    return (elapsedPercent - weeklyUsagePercent) * WINDOW_DAYS;
+}
+
+export function renderBipolarBar(
+    bufferPercent: number,
+    positiveAnsi: string,
+    negativeAnsi: string
+): string {
+    const clamped = clamp(bufferPercent, -100, 100);
+    const cells = Math.round((Math.abs(clamped) / 100) * BAR_HALF_WIDTH);
+
+    if (clamped < 0 && cells > 0) {
+        const emptyLeft = '░'.repeat(BAR_HALF_WIDTH - cells);
+        const fillLeft = '▓'.repeat(cells);
+        const ansi = negativeAnsi;
+        const reset = ansi ? FG_RESET : '';
+        return `${emptyLeft}${ansi}${fillLeft}${reset}│${'░'.repeat(BAR_HALF_WIDTH)}`;
+    }
+
+    if (clamped > 0 && cells > 0) {
+        const fillRight = '▓'.repeat(cells);
+        const emptyRight = '░'.repeat(BAR_HALF_WIDTH - cells);
+        const ansi = positiveAnsi;
+        const reset = ansi ? FG_RESET : '';
+        return `${'░'.repeat(BAR_HALF_WIDTH)}│${ansi}${fillRight}${reset}${emptyRight}`;
+    }
+
+    return `${'░'.repeat(BAR_HALF_WIDTH)}│${'░'.repeat(BAR_HALF_WIDTH)}`;
+}
+
+export class WeeklyBudgetBufferWidget implements Widget {
+    getDefaultColor(): string { return 'white'; }
+    getDescription(): string { return 'Weekly quota buffer vs. even-spread pace (1 day = 100%)'; }
+    getDisplayName(): string { return 'Weekly Budget Buffer'; }
+    getCategory(): string { return 'Usage'; }
+
+    getEditorDisplay(): WidgetEditorDisplay {
+        return { displayText: this.getDisplayName() };
+    }
+
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
+        const colorLevel = getColorLevelString(settings.colorLevel);
+        const positiveAnsi = getColorAnsiCode(getPositiveColor(item), colorLevel, false);
+        const negativeAnsi = getColorAnsiCode(getNegativeColor(item), colorLevel, false);
+
+        if (context.isPreview) {
+            const previewBuffer = 28;
+            const bar = renderBipolarBar(previewBuffer, positiveAnsi, negativeAnsi);
+            return `Buffer: ${bar} ${formatSignedPercent(previewBuffer)}`;
+        }
+
+        const data = context.usageData ?? {};
+        if (data.error) {
+            return getUsageErrorMessage(data.error);
+        }
+        if (data.weeklyUsage === undefined) {
+            return null;
+        }
+
+        const window = resolveWeeklyUsageWindow(data);
+        if (!window) {
+            return null;
+        }
+
+        const buffer = computeBudgetBufferPercent(data.weeklyUsage, window.elapsedPercent);
+        const bar = renderBipolarBar(buffer, positiveAnsi, negativeAnsi);
+        return `Buffer: ${bar} ${formatSignedPercent(buffer)}`;
+    }
+
+    supportsRawValue(): boolean { return false; }
+    supportsColors(): boolean { return false; }
+}

--- a/src/widgets/__tests__/WeeklyBudgetBuffer.test.ts
+++ b/src/widgets/__tests__/WeeklyBudgetBuffer.test.ts
@@ -1,0 +1,129 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import { DEFAULT_SETTINGS } from '../../types/Settings';
+import type { WidgetItem } from '../../types/Widget';
+import * as usage from '../../utils/usage';
+import type { UsageWindowMetrics } from '../../utils/usage-types';
+import {
+    WeeklyBudgetBufferWidget,
+    computeBudgetBufferPercent,
+    renderBipolarBar
+} from '../WeeklyBudgetBuffer';
+
+const item: WidgetItem = { id: 'b', type: 'weekly-budget-buffer' };
+
+function ctx(weeklyUsage: number | undefined): RenderContext {
+    return { usageData: weeklyUsage === undefined ? {} : { weeklyUsage } };
+}
+
+function makeWindow(elapsedPercent: number): UsageWindowMetrics {
+    const total = 7 * 24 * 60 * 60 * 1000;
+    const elapsedMs = (elapsedPercent / 100) * total;
+    return {
+        sessionDurationMs: total,
+        elapsedMs,
+        remainingMs: total - elapsedMs,
+        elapsedPercent,
+        remainingPercent: 100 - elapsedPercent
+    };
+}
+
+describe('computeBudgetBufferPercent', () => {
+    it('returns zero when usage matches elapsed pace', () => {
+        // 3/5 elapsed of 5-day window, but formula uses 7-day window:
+        // (50% - 50%) * 7 = 0
+        expect(computeBudgetBufferPercent(50, 50)).toBe(0);
+    });
+
+    it('returns +700 when nothing spent at full elapsed', () => {
+        // unrealistic edge: full buffer = 7 days
+        expect(computeBudgetBufferPercent(0, 100)).toBe(700);
+    });
+
+    it('returns negative when overspending', () => {
+        // 50% elapsed, 60% used → -10% * 7 = -70%
+        expect(computeBudgetBufferPercent(60, 50)).toBe(-70);
+    });
+});
+
+describe('renderBipolarBar', () => {
+    it('renders empty bar at zero', () => {
+        const bar = renderBipolarBar(0, '', '');
+        expect(bar).toBe('░░░░░░░░░░│░░░░░░░░░░');
+        expect(bar.length).toBe(21);
+    });
+
+    it('fills right half for positive', () => {
+        const bar = renderBipolarBar(50, '', '');
+        expect(bar).toBe('░░░░░░░░░░│▓▓▓▓▓░░░░░');
+    });
+
+    it('fills left half for negative', () => {
+        const bar = renderBipolarBar(-100, '', '');
+        expect(bar).toBe('▓▓▓▓▓▓▓▓▓▓│░░░░░░░░░░');
+    });
+
+    it('clamps oversized positive to full right', () => {
+        const bar = renderBipolarBar(999, '', '');
+        expect(bar).toBe('░░░░░░░░░░│▓▓▓▓▓▓▓▓▓▓');
+    });
+});
+
+describe('WeeklyBudgetBufferWidget.render', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns null when weeklyUsage missing', () => {
+        const widget = new WeeklyBudgetBufferWidget();
+        expect(widget.render(item, ctx(undefined), DEFAULT_SETTINGS)).toBeNull();
+    });
+
+    it('returns null when no reset window', () => {
+        const widget = new WeeklyBudgetBufferWidget();
+        vi.spyOn(usage, 'resolveWeeklyUsageWindow').mockReturnValue(null);
+        expect(widget.render(item, ctx(20), DEFAULT_SETTINGS)).toBeNull();
+    });
+
+    it('renders zero when on pace', () => {
+        const widget = new WeeklyBudgetBufferWidget();
+        vi.spyOn(usage, 'resolveWeeklyUsageWindow').mockReturnValue(makeWindow(50));
+        const out = widget.render(item, ctx(50), DEFAULT_SETTINGS);
+        expect(out).toContain('0%');
+        expect(out).toContain('│');
+    });
+
+    it('renders signed positive when under pace', () => {
+        const widget = new WeeklyBudgetBufferWidget();
+        vi.spyOn(usage, 'resolveWeeklyUsageWindow').mockReturnValue(makeWindow(50));
+        // (50-40)*7 = +70
+        const out = widget.render(item, ctx(40), DEFAULT_SETTINGS);
+        expect(out).toContain('+70%');
+    });
+
+    it('renders signed negative when over pace', () => {
+        const widget = new WeeklyBudgetBufferWidget();
+        vi.spyOn(usage, 'resolveWeeklyUsageWindow').mockReturnValue(makeWindow(50));
+        // (50-60)*7 = -70
+        const out = widget.render(item, ctx(60), DEFAULT_SETTINGS);
+        expect(out).toContain('-70%');
+    });
+
+    it('renders error message on usage error', () => {
+        const widget = new WeeklyBudgetBufferWidget();
+        const out = widget.render(item, { usageData: { error: 'rate-limited' } }, DEFAULT_SETTINGS);
+        expect(out).toBe('[Rate limited]');
+    });
+});

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -61,6 +61,7 @@ export { SessionUsageWidget } from './SessionUsage';
 export { WeeklyUsageWidget } from './WeeklyUsage';
 export { WeeklySonnetUsageWidget } from './WeeklySonnetUsage';
 export { WeeklyOpusUsageWidget } from './WeeklyOpusUsage';
+export { WeeklyBudgetBufferWidget } from './WeeklyBudgetBuffer';
 export { BlockResetTimerWidget } from './BlockResetTimer';
 export { WeeklyResetTimerWidget } from './WeeklyResetTimer';
 export { ContextBarWidget } from './ContextBar';


### PR DESCRIPTION
## Summary

New `weekly-budget-buffer` widget: a bipolar indicator showing how far ahead or behind even-spread pace your 7-day quota consumption is.

**Formula:** `buffer = (elapsed% − weeklyUsage%) × 7`
where the unit is "% with 1 day worth of quota = 100%".

- **Positive** → under pace (headroom). Filled cells render green.
- **Negative** → over pace. Filled cells render red.
- **Zero** → exactly on pace.

Worked example: 3 days into the 7-day window, 50% of weekly quota spent → `(3/7 × 100 − 50) × 7 ≈ −50%` (half a day behind pace).

## Rendering

`Buffer: ░░░░░░░░░░│▓▓▓▓▓░░░░░ +50%`

21-character bipolar bar (10 cells per side around a `│` centre) plus a signed percentage. Bar is clamped to ±100% for visualisation; the numeric label is not clamped.

## Implementation

- `src/widgets/WeeklyBudgetBuffer.ts` — widget + pure helpers (`computeBudgetBufferPercent`, `renderBipolarBar`).
- Reads `weeklyUsage` and `weeklyResetAt` already plumbed via `RenderContext.usageData`, deriving elapsed via `resolveWeeklyUsageWindow`.
- Inline ANSI for green/red fill cells; `supportsColors()` returns `false` since the widget owns its own colouring. `positiveColor` / `negativeColor` overrides via `metadata` (defaults: `green` / `red`).
- Registered as `weekly-budget-buffer` in `widget-manifest.ts` and added to `USAGE_WIDGET_TYPES` in `usage-prefetch.ts`.

## Test plan

- [x] `bun test src/widgets/__tests__/WeeklyBudgetBuffer.test.ts` — 13 new tests covering formula edge cases, bar rendering (zero / positive / negative / clamping), error/missing-data branches.
- [x] Full suite `bun test` — 1315 pass, 0 fail.
- [x] `bun tsc --noEmit` clean.
- [x] `bun x eslint .` clean.
- [x] `bun run build` bundles successfully.