### PR TITLE
fix(terminal): use stty -F/-f to read tty size in detached spawn

### DIFF
--- a/src/utils/__tests__/terminal.test.ts
+++ b/src/utils/__tests__/terminal.test.ts
@@ -46,7 +46,7 @@ describe('terminal utils', () => {
                 return 'ttys001\n';
             }
 
-            if (command === `stty size < /dev/ttys001 | awk '{print $2}'`) {
+            if (command === `stty -F /dev/ttys001 size 2>/dev/null | awk '{print $2}'`) {
                 return '120\n';
             }
 
@@ -57,7 +57,7 @@ describe('terminal utils', () => {
         expect(mockExecSync.mock.calls.map(([command]) => command)).toEqual([
             `ps -o ppid= -p ${process.pid}`,
             'ps -o tty= -p 1234',
-            `stty size < /dev/ttys001 | awk '{print $2}'`
+            `stty -F /dev/ttys001 size 2>/dev/null | awk '{print $2}'`
         ]);
     });
 
@@ -79,7 +79,7 @@ describe('terminal utils', () => {
                 return ' ttys009 \n';
             }
 
-            if (command === `stty size < /dev/ttys009 | awk '{print $2}'`) {
+            if (command === `stty -F /dev/ttys009 size 2>/dev/null | awk '{print $2}'`) {
                 return '104\n';
             }
 
@@ -87,6 +87,32 @@ describe('terminal utils', () => {
         });
 
         expect(getTerminalWidth()).toBe(104);
+    });
+
+    it('falls back through stty variants when the first form returns no value', () => {
+        // Simulates BSD/macOS, where `stty -F` exits with an error and yields
+        // empty output via the `2>/dev/null | awk` pipeline; `stty -f` succeeds.
+        mockExecSync.mockImplementation((command: string) => {
+            if (command === `ps -o ppid= -p ${process.pid}`) {
+                return '1234\n';
+            }
+
+            if (command === 'ps -o tty= -p 1234') {
+                return 'ttys003\n';
+            }
+
+            if (command === `stty -F /dev/ttys003 size 2>/dev/null | awk '{print $2}'`) {
+                return '\n';
+            }
+
+            if (command === `stty -f /dev/ttys003 size 2>/dev/null | awk '{print $2}'`) {
+                return '142\n';
+            }
+
+            throw new Error(`Unexpected command: ${command}`);
+        });
+
+        expect(getTerminalWidth()).toBe(142);
     });
 
     it('falls back to tput cols when ancestor probing fails', () => {
@@ -107,7 +133,9 @@ describe('terminal utils', () => {
                 return 'ttys001\n';
             }
 
-            if (command === `stty size < /dev/ttys001 | awk '{print $2}'`) {
+            if (command === `stty -F /dev/ttys001 size 2>/dev/null | awk '{print $2}'`
+                || command === `stty -f /dev/ttys001 size 2>/dev/null | awk '{print $2}'`
+                || command === `stty size < /dev/ttys001 2>/dev/null | awk '{print $2}'`) {
                 return 'not-a-number\n';
             }
 
@@ -143,7 +171,7 @@ describe('terminal utils', () => {
                 return 'ttys010\n';
             }
 
-            if (command === `stty size < /dev/ttys010 | awk '{print $2}'`) {
+            if (command === `stty -F /dev/ttys010 size 2>/dev/null | awk '{print $2}'`) {
                 return '80\n';
             }
 

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -119,20 +119,35 @@ function getTTYForProcess(pid: number): string | null {
 }
 
 function getWidthForTTY(tty: string): number | null {
-    try {
-        const width = execSync(
-            `stty size < /dev/${tty} | awk '{print $2}'`,
-            {
+    // The shell-redirect form (`stty size < /dev/${tty}`) fails with ENOTTY
+    // when the calling process has no controlling terminal — the case under
+    // Claude Code >= 2.1.139, which spawns statusline/hooks without terminal
+    // access. `stty -F` / `-f` ask stty to open the device itself (with
+    // O_NOCTTY semantics) and succeed regardless of controlling-tty status.
+    const devicePath = `/dev/${tty}`;
+    const attempts = [
+        `stty -F ${devicePath} size`,   // GNU coreutils (Linux)
+        `stty -f ${devicePath} size`,   // BSD stty (macOS, *BSD)
+        `stty size < ${devicePath}`     // legacy fallback
+    ];
+
+    for (const cmd of attempts) {
+        try {
+            const width = execSync(`${cmd} 2>/dev/null | awk '{print $2}'`, {
                 encoding: 'utf8',
                 stdio: ['pipe', 'pipe', 'ignore'],
                 shell: '/bin/sh'
+            }).trim();
+            const parsed = parsePositiveInteger(width);
+            if (parsed !== null) {
+                return parsed;
             }
-        ).trim();
-
-        return parsePositiveInteger(width);
-    } catch {
-        return null;
+        } catch {
+            // try next strategy
+        }
     }
+
+    return null;
 }
 
 // Get terminal width


### PR DESCRIPTION
## Summary

Fixes the TTY-width probe under Claude Code ≥ 2.1.139, which [spawns the statusline without a controlling terminal](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21139):

> Fixed a bug where a hook writing to the terminal could corrupt an on-screen interactive prompt; **hooks now run without terminal access.**

The existing `stty size < /dev/${tty}` form fails with `ENOTTY` in that context.

Closes #376.

## Change

`src/utils/terminal.ts` — `getWidthForTTY` now tries three variants in order; first positive integer wins:

1. `stty -F <path> size` (GNU coreutils, Linux)
2. `stty -f <path> size` (BSD, macOS)
3. `stty size < <path>` (legacy fallback)

## Test plan

- New unit test for the BSD fallback case (`-F` errors, `-f` succeeds)
- Existing probe tests updated for the new command shape
- All 1303 tests pass; lint clean
- Live-verified on Linux + Claude Code 2.1.140: detection goes from null → real terminal width
