### PR TITLE
fix(git): always pass --no-optional-locks to prevent index.lock races

### DIFF
--- a/src/utils/__tests__/git-remote.test.ts
+++ b/src/utils/__tests__/git-remote.test.ts
@@ -229,7 +229,7 @@ describe('git-remote utils', () => {
             getRemoteInfo(remoteName, {});
 
             expect(mockExecFileSync.mock.calls[0]?.[0]).toBe('git');
-            expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['remote', 'get-url', '--', remoteName]);
+            expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['--no-optional-locks', 'remote', 'get-url', '--', remoteName]);
         });
 
         it('returns null when remote does not exist', () => {

--- a/src/utils/__tests__/git.test.ts
+++ b/src/utils/__tests__/git.test.ts
@@ -99,7 +99,7 @@ describe('git utils', () => {
 
             expect(result).toBe('feature/worktree');
             expect(mockExecFileSync.mock.calls[0]?.[0]).toBe('git');
-            expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['branch', '--show-current']);
+            expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['--no-optional-locks', 'branch', '--show-current']);
             expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
                 encoding: 'utf8',
                 stdio: ['pipe', 'pipe', 'ignore'],

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -47,8 +47,13 @@ export function runGitArgs(args: string[], context: RenderContext, cacheCommand?
         return gitCommandCache.get(cacheKey) ?? null;
     }
 
+    // --no-optional-locks prevents read-only commands (diff, status, rev-list, ...)
+    // from racing on .git/index.lock when another git process is writing it.
+    // See https://git-scm.com/docs/git#Documentation/git.txt---no-optional-locks
+    const gitArgs = ['--no-optional-locks', ...args];
+
     try {
-        const output = execFileSync('git', args, {
+        const output = execFileSync('git', gitArgs, {
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],
             ...(cwd ? { cwd } : {})
@@ -108,7 +113,7 @@ export interface GitStatus {
 }
 
 export function getGitStatus(context: RenderContext): GitStatus {
-    const output = runGit('--no-optional-locks status --porcelain -z', context);
+    const output = runGit('status --porcelain -z', context);
 
     if (!output) {
         return { staged: false, unstaged: false, untracked: false, conflicts: false };
@@ -146,7 +151,7 @@ export function getGitStatus(context: RenderContext): GitStatus {
 }
 
 export function getGitFileStatusCounts(context: RenderContext): GitFileStatusCounts {
-    const output = runGit('--no-optional-locks status --porcelain -z', context);
+    const output = runGit('status --porcelain -z', context);
 
     if (!output) {
         return { staged: 0, unstaged: 0, untracked: 0 };

--- a/src/widgets/__tests__/GitBranch.test.ts
+++ b/src/widgets/__tests__/GitBranch.test.ts
@@ -75,14 +75,14 @@ describe('GitBranchWidget', () => {
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('⎇ feature/worktree');
         expect(mockExecFileSync.mock.calls[0]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['rev-parse', '--is-inside-work-tree']);
+        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--is-inside-work-tree']);
         expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],
             cwd: '/tmp/worktree'
         });
         expect(mockExecFileSync.mock.calls[1]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['branch', '--show-current']);
+        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['--no-optional-locks', 'branch', '--show-current']);
         expect(mockExecFileSync.mock.calls[1]?.[2]).toEqual({
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],

--- a/src/widgets/__tests__/GitRootDir.test.ts
+++ b/src/widgets/__tests__/GitRootDir.test.ts
@@ -74,14 +74,14 @@ describe('GitRootDirWidget', () => {
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('my-repo');
         expect(mockExecFileSync.mock.calls[0]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['rev-parse', '--is-inside-work-tree']);
+        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--is-inside-work-tree']);
         expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],
             cwd: '/tmp/worktree'
         });
         expect(mockExecFileSync.mock.calls[1]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['rev-parse', '--show-toplevel']);
+        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--show-toplevel']);
         expect(mockExecFileSync.mock.calls[1]?.[2]).toEqual({
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],

--- a/src/widgets/__tests__/GitStagedFiles.test.ts
+++ b/src/widgets/__tests__/GitStagedFiles.test.ts
@@ -66,7 +66,7 @@ describe('GitStagedFilesWidget', () => {
         mockExecFileSync.mockReturnValueOnce('M  a.ts\0A  b.ts\0 M c.ts\0?? d.ts\0');
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('S:2');
-        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['rev-parse', '--is-inside-work-tree']);
+        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--is-inside-work-tree']);
         expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],

--- a/src/widgets/__tests__/GitWorktree.test.ts
+++ b/src/widgets/__tests__/GitWorktree.test.ts
@@ -68,14 +68,14 @@ describe('GitWorktreeWidget', () => {
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('𖠰 some-worktree');
         expect(mockExecFileSync.mock.calls[0]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['rev-parse', '--is-inside-work-tree']);
+        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--is-inside-work-tree']);
         expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],
             cwd: '/tmp/worktree'
         });
         expect(mockExecFileSync.mock.calls[1]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['rev-parse', '--git-dir']);
+        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--git-dir']);
         expect(mockExecFileSync.mock.calls[1]?.[2]).toEqual({
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],


### PR DESCRIPTION
## Problem

When the statusline refreshes while the user has a concurrent git op in flight (e.g. `git restore --staged ...`), commands like `git diff --shortstat` race on `.git/index.lock` and the user's command fails with:

```
fatal: Unable to create '/path/.git/index.lock': File exists.
```

`git diff` takes the index lock to refresh stat cache entries; under the default `core.optionalLocks=true` that lock is contended even though diff is read-only from the user's perspective.

## Fix

`runGitArgs` now prepends `--no-optional-locks` to every git invocation, so the statusline can never block or interfere with the user's working git operations. The flag was already applied per-call to `status` (`getGitStatus`, `getGitFileStatusCounts`); those manual prefixes are now redundant and removed.

## Tests

- Arg-order assertions in `git.test.ts`, `git-remote.test.ts`, and four widget tests updated to expect the new prefix.
- `bun test`: 1333 / 1333 pass.
- `bun run lint`: clean.

## Notes

- `--no-optional-locks` is a top-level git option (git 2.15+); no behavioural change for read-only commands beyond skipping the stat-cache refresh.
- Caught locally by a watchdog poll on `.git/index.lock` — culprit identified as `getGitChangeCounts` → `git diff --shortstat`.