### PR TITLE
feat: add remote control status widget

### DIFF
--- a/src/utils/claude-settings.ts
+++ b/src/utils/claude-settings.ts
@@ -455,3 +455,72 @@ export function getVoiceConfig(cwd: string = process.cwd()): { enabled: boolean 
     }
     return anyFileExisted ? { enabled: false } : null;
 }
+
+const RemoteSessionFileSchema = z.object({
+    sessionId: z.string().optional(),
+    bridgeSessionId: z.string().nullable().optional()
+});
+
+/**
+ * Reads the per-PID session manifests Claude Code writes to `<config>/sessions/<pid>.json`
+ * and returns whether the session matching `sessionId` currently has a remote-control
+ * bridge attached.
+ *
+ * Claude Code writes one file per running interactive session. The `bridgeSessionId`
+ * field is populated when remote control (e.g. the mobile/web bridge) is connected
+ * for that session. Matching by `sessionId` ensures the result reflects the *current*
+ * session rather than any other concurrent Claude Code process.
+ *
+ * Claude Code's observed behavior on disconnect: the field is set to `null` (not removed)
+ * and the file is rewritten within ~1s, so the on-disconnect transition is reflected
+ * promptly at the next status-line refresh.
+ *
+ * - Returns `null` when the sessions directory is missing or no manifest matches —
+ *   widgets should hide themselves in that case rather than render a misleading "off".
+ * - Returns `{ enabled: false }` when the manifest exists but `bridgeSessionId` is
+ *   missing, `null`, or empty (disconnected).
+ * - Returns `{ enabled: true }` when a non-empty `bridgeSessionId` is set.
+ */
+export function getRemoteControlStatus(sessionId: string | undefined): { enabled: boolean } | null {
+    if (!sessionId) {
+        return null;
+    }
+
+    const sessionsDir = path.join(getClaudeConfigDir(), 'sessions');
+    let entries: string[];
+    try {
+        entries = fs.readdirSync(sessionsDir);
+    } catch {
+        return null;
+    }
+
+    for (const entry of entries) {
+        if (!entry.endsWith('.json')) {
+            continue;
+        }
+
+        let content: string;
+        try {
+            content = fs.readFileSync(path.join(sessionsDir, entry), 'utf-8');
+        } catch {
+            continue;
+        }
+
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(content);
+        } catch {
+            continue;
+        }
+
+        const result = RemoteSessionFileSchema.safeParse(parsed);
+        if (!result.success || result.data.sessionId !== sessionId) {
+            continue;
+        }
+
+        const bridge = result.data.bridgeSessionId;
+        return { enabled: typeof bridge === 'string' && bridge.length > 0 };
+    }
+
+    return null;
+}

--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -88,6 +88,7 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'thinking-effort', create: () => new widgets.ThinkingEffortWidget() },
     { type: 'vim-mode', create: () => new widgets.VimModeWidget() },
     { type: 'voice-status', create: () => new widgets.VoiceStatusWidget() },
+    { type: 'remote-control-status', create: () => new widgets.RemoteControlStatusWidget() },
     { type: 'worktree-mode', create: () => new widgets.GitWorktreeModeWidget() },
     { type: 'worktree-name', create: () => new widgets.GitWorktreeNameWidget() },
     { type: 'worktree-branch', create: () => new widgets.GitWorktreeBranchWidget() },

--- a/src/widgets/RemoteControlStatus.ts
+++ b/src/widgets/RemoteControlStatus.ts
@@ -1,0 +1,158 @@
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    CustomKeybind,
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+import { getRemoteControlStatus } from '../utils/claude-settings';
+
+const SATELLITE_EMOJI = '📡';
+const SATELLITE_NERD_FONT = '';
+const SATELLITE_SLASH_NERD_FONT = '';
+const STATE_DOT_OFF = '○';
+const STATE_DOT_ON = '◉';
+
+const FORMATS = ['icon', 'icon-text', 'text', 'word'] as const;
+type RemoteFormat = typeof FORMATS[number];
+
+const DEFAULT_FORMAT: RemoteFormat = 'icon';
+const CYCLE_FORMAT_ACTION = 'cycle-format';
+const TOGGLE_NERD_FONT_ACTION = 'toggle-nerd-font';
+const NERD_FONT_METADATA_KEY = 'nerdFont';
+
+function getFormat(item: WidgetItem): RemoteFormat {
+    const f = item.metadata?.format;
+    return (FORMATS as readonly string[]).includes(f ?? '') ? (f as RemoteFormat) : DEFAULT_FORMAT;
+}
+
+function setFormat(item: WidgetItem, format: RemoteFormat): WidgetItem {
+    if (format === DEFAULT_FORMAT) {
+        const { format: removedFormat, ...restMetadata } = item.metadata ?? {};
+        void removedFormat;
+
+        return {
+            ...item,
+            metadata: Object.keys(restMetadata).length > 0 ? restMetadata : undefined
+        };
+    }
+
+    return {
+        ...item,
+        metadata: {
+            ...(item.metadata ?? {}),
+            format
+        }
+    };
+}
+
+function isNerdFontEnabled(item: WidgetItem): boolean {
+    return item.metadata?.[NERD_FONT_METADATA_KEY] === 'true';
+}
+
+function toggleNerdFont(item: WidgetItem): WidgetItem {
+    if (!isNerdFontEnabled(item)) {
+        return {
+            ...item,
+            metadata: {
+                ...(item.metadata ?? {}),
+                [NERD_FONT_METADATA_KEY]: 'true'
+            }
+        };
+    }
+
+    const { [NERD_FONT_METADATA_KEY]: removedNerdFont, ...restMetadata } = item.metadata ?? {};
+    void removedNerdFont;
+
+    return {
+        ...item,
+        metadata: Object.keys(restMetadata).length > 0 ? restMetadata : undefined
+    };
+}
+
+function formatStatus(enabled: boolean, format: RemoteFormat, nerdFont: boolean): string {
+    const stateText = enabled ? 'on' : 'off';
+    const stateDot = enabled ? STATE_DOT_ON : STATE_DOT_OFF;
+    const icon = nerdFont
+        ? (enabled ? SATELLITE_NERD_FONT : SATELLITE_SLASH_NERD_FONT)
+        : SATELLITE_EMOJI;
+
+    switch (format) {
+        case 'icon':
+            return nerdFont ? icon : `${icon} ${stateDot}`;
+        case 'icon-text':
+            return `${icon} ${stateText}`;
+        case 'text':
+            return stateText;
+        case 'word':
+            return `remote ${stateText}`;
+    }
+}
+
+export class RemoteControlStatusWidget implements Widget {
+    getDefaultColor(): string { return 'blue'; }
+    getDescription(): string { return 'Shows whether Claude Code remote control is attached to the current session'; }
+    getDisplayName(): string { return 'Remote Control Status'; }
+    getCategory(): string { return 'Core'; }
+
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
+        const modifiers: string[] = [getFormat(item)];
+        if (isNerdFontEnabled(item)) {
+            modifiers.push('nerd font');
+        }
+
+        return {
+            displayText: this.getDisplayName(),
+            modifierText: `(${modifiers.join(', ')})`
+        };
+    }
+
+    handleEditorAction(action: string, item: WidgetItem): WidgetItem | null {
+        if (action === CYCLE_FORMAT_ACTION) {
+            const currentFormat = getFormat(item);
+            const nextFormat = FORMATS[(FORMATS.indexOf(currentFormat) + 1) % FORMATS.length] ?? DEFAULT_FORMAT;
+
+            return setFormat(item, nextFormat);
+        }
+
+        if (action === TOGGLE_NERD_FONT_ACTION) {
+            return toggleNerdFont(item);
+        }
+
+        return null;
+    }
+
+    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+        const format = getFormat(item);
+        const nerdFont = isNerdFontEnabled(item);
+
+        if (context.isPreview) {
+            if (item.rawValue) {
+                return 'on';
+            }
+            return formatStatus(true, format, nerdFont);
+        }
+
+        const status = getRemoteControlStatus(context.data?.session_id);
+        if (status === null) {
+            return null;
+        }
+
+        if (item.rawValue) {
+            return status.enabled ? 'on' : 'off';
+        }
+
+        return formatStatus(status.enabled, format, nerdFont);
+    }
+
+    getCustomKeybinds(): CustomKeybind[] {
+        return [
+            { key: 'f', label: '(f)ormat', action: CYCLE_FORMAT_ACTION },
+            { key: 'n', label: '(n)erd font', action: TOGGLE_NERD_FONT_ACTION }
+        ];
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(_item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/RemoteControlStatus.ts
+++ b/src/widgets/RemoteControlStatus.ts
@@ -14,7 +14,9 @@ const SATELLITE_SLASH_NERD_FONT = '';
 const STATE_DOT_OFF = '○';
 const STATE_DOT_ON = '◉';
 
-const FORMATS = ['icon', 'icon-text', 'text', 'word'] as const;
+const FORMATS = ['icon', 'icon-text', 'text', 'word', 'label-check'] as const;
+const CHECK_EMOJI = '✅';
+const CROSS_EMOJI = '❌';
 type RemoteFormat = typeof FORMATS[number];
 
 const DEFAULT_FORMAT: RemoteFormat = 'icon';
@@ -87,6 +89,8 @@ function formatStatus(enabled: boolean, format: RemoteFormat, nerdFont: boolean)
             return stateText;
         case 'word':
             return `remote ${stateText}`;
+        case 'label-check':
+            return `remote ${enabled ? CHECK_EMOJI : CROSS_EMOJI}`;
     }
 }
 

--- a/src/widgets/RemoteControlStatus.ts
+++ b/src/widgets/RemoteControlStatus.ts
@@ -14,9 +14,11 @@ const SATELLITE_SLASH_NERD_FONT = '';
 const STATE_DOT_OFF = '○';
 const STATE_DOT_ON = '◉';
 
-const FORMATS = ['icon', 'icon-text', 'text', 'word', 'label-check'] as const;
+const FORMATS = ['icon', 'icon-text', 'text', 'word', 'label-check', 'label-mark'] as const;
 const CHECK_EMOJI = '✅';
 const CROSS_EMOJI = '❌';
+const CHECK_MARK = '✓';
+const CROSS_MARK = '✗';
 type RemoteFormat = typeof FORMATS[number];
 
 const DEFAULT_FORMAT: RemoteFormat = 'icon';
@@ -91,6 +93,8 @@ function formatStatus(enabled: boolean, format: RemoteFormat, nerdFont: boolean)
             return `remote ${stateText}`;
         case 'label-check':
             return `remote ${enabled ? CHECK_EMOJI : CROSS_EMOJI}`;
+        case 'label-mark':
+            return `remote ${enabled ? CHECK_MARK : CROSS_MARK}`;
     }
 }
 

--- a/src/widgets/__tests__/RemoteControlStatus.test.ts
+++ b/src/widgets/__tests__/RemoteControlStatus.test.ts
@@ -83,16 +83,18 @@ describe('RemoteControlStatusWidget', () => {
             });
         });
 
-        it('cycles icon -> icon-text -> text -> word -> icon', () => {
+        it('cycles icon -> icon-text -> text -> word -> label-check -> icon', () => {
             const widget = new RemoteControlStatusWidget();
             const iconText = widget.handleEditorAction('cycle-format', ITEM);
             const text = widget.handleEditorAction('cycle-format', iconText ?? ITEM);
             const word = widget.handleEditorAction('cycle-format', text ?? ITEM);
-            const back = widget.handleEditorAction('cycle-format', word ?? ITEM);
+            const labelCheck = widget.handleEditorAction('cycle-format', word ?? ITEM);
+            const back = widget.handleEditorAction('cycle-format', labelCheck ?? ITEM);
 
             expect(iconText?.metadata?.format).toBe('icon-text');
             expect(text?.metadata?.format).toBe('text');
             expect(word?.metadata?.format).toBe('word');
+            expect(labelCheck?.metadata?.format).toBe('label-check');
             expect(back?.metadata?.format).toBeUndefined();
         });
 
@@ -175,6 +177,20 @@ describe('RemoteControlStatusWidget', () => {
         it('renders "remote on" when ON', () => {
             vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: true });
             expect(new RemoteControlStatusWidget().render(FORMAT_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('remote on');
+        });
+    });
+
+    describe('render() - format label-check', () => {
+        const FORMAT_ITEM: WidgetItem = { ...ITEM, metadata: { format: 'label-check' } };
+
+        it('renders "remote ❌" when OFF', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: false });
+            expect(new RemoteControlStatusWidget().render(FORMAT_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('remote ❌');
+        });
+
+        it('renders "remote ✅" when ON', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: true });
+            expect(new RemoteControlStatusWidget().render(FORMAT_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('remote ✅');
         });
     });
 

--- a/src/widgets/__tests__/RemoteControlStatus.test.ts
+++ b/src/widgets/__tests__/RemoteControlStatus.test.ts
@@ -1,0 +1,238 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import type {
+    RenderContext,
+    WidgetItem
+} from '../../types';
+import { DEFAULT_SETTINGS } from '../../types/Settings';
+import * as claudeSettings from '../../utils/claude-settings';
+import { RemoteControlStatusWidget } from '../RemoteControlStatus';
+
+const ITEM: WidgetItem = { id: 'remote-control-status', type: 'remote-control-status' };
+const SESSION_ID = 'session-abc-123';
+
+function makeContext(overrides: Partial<RenderContext> = {}): RenderContext {
+    return { data: { session_id: SESSION_ID }, ...overrides };
+}
+
+beforeEach(() => {
+    vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: false });
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('RemoteControlStatusWidget', () => {
+    describe('metadata', () => {
+        it('has correct display name', () => {
+            expect(new RemoteControlStatusWidget().getDisplayName()).toBe('Remote Control Status');
+        });
+
+        it('has correct description', () => {
+            expect(new RemoteControlStatusWidget().getDescription())
+                .toBe('Shows whether Claude Code remote control is attached to the current session');
+        });
+
+        it('has correct category', () => {
+            expect(new RemoteControlStatusWidget().getCategory()).toBe('Core');
+        });
+
+        it('has blue default color', () => {
+            expect(new RemoteControlStatusWidget().getDefaultColor()).toBe('blue');
+        });
+
+        it('supports raw value', () => {
+            expect(new RemoteControlStatusWidget().supportsRawValue()).toBe(true);
+        });
+
+        it('supports colors', () => {
+            expect(new RemoteControlStatusWidget().supportsColors(ITEM)).toBe(true);
+        });
+    });
+
+    describe('editor configuration', () => {
+        it('exposes f and n keybinds', () => {
+            expect(new RemoteControlStatusWidget().getCustomKeybinds()).toEqual([
+                { key: 'f', label: '(f)ormat', action: 'cycle-format' },
+                { key: 'n', label: '(n)erd font', action: 'toggle-nerd-font' }
+            ]);
+        });
+
+        it('defaults to icon in the editor display', () => {
+            expect(new RemoteControlStatusWidget().getEditorDisplay(ITEM)).toEqual({
+                displayText: 'Remote Control Status',
+                modifierText: '(icon)'
+            });
+        });
+
+        it('shows the configured format and nerd font in the editor display', () => {
+            expect(new RemoteControlStatusWidget().getEditorDisplay({
+                ...ITEM,
+                metadata: { format: 'word', nerdFont: 'true' }
+            })).toEqual({
+                displayText: 'Remote Control Status',
+                modifierText: '(word, nerd font)'
+            });
+        });
+
+        it('cycles icon -> icon-text -> text -> word -> icon', () => {
+            const widget = new RemoteControlStatusWidget();
+            const iconText = widget.handleEditorAction('cycle-format', ITEM);
+            const text = widget.handleEditorAction('cycle-format', iconText ?? ITEM);
+            const word = widget.handleEditorAction('cycle-format', text ?? ITEM);
+            const back = widget.handleEditorAction('cycle-format', word ?? ITEM);
+
+            expect(iconText?.metadata?.format).toBe('icon-text');
+            expect(text?.metadata?.format).toBe('text');
+            expect(word?.metadata?.format).toBe('word');
+            expect(back?.metadata?.format).toBeUndefined();
+        });
+
+        it('toggles nerd font metadata on and off', () => {
+            const widget = new RemoteControlStatusWidget();
+            const enabled = widget.handleEditorAction('toggle-nerd-font', ITEM);
+            const disabled = widget.handleEditorAction('toggle-nerd-font', enabled ?? ITEM);
+
+            expect(enabled?.metadata?.nerdFont).toBe('true');
+            expect(disabled?.metadata?.nerdFont).toBeUndefined();
+        });
+
+        it('returns null for unknown editor actions', () => {
+            expect(new RemoteControlStatusWidget().handleEditorAction('unknown', ITEM)).toBeNull();
+        });
+    });
+
+    describe('render() - format icon (default), standard glyphs', () => {
+        it('renders 📡 ○ when OFF', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: false });
+            expect(new RemoteControlStatusWidget().render(ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('📡 ○');
+        });
+
+        it('renders 📡 ◉ when ON', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: true });
+            expect(new RemoteControlStatusWidget().render(ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('📡 ◉');
+        });
+    });
+
+    describe('render() - format icon, Nerd Font', () => {
+        const NERD_ITEM: WidgetItem = { ...ITEM, metadata: { nerdFont: 'true' } };
+
+        it('renders disconnected glyph (U+F6AC) when OFF', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: false });
+            expect(new RemoteControlStatusWidget().render(NERD_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('\uF6AC');
+        });
+
+        it('renders connected glyph (U+F1EB) when ON', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: true });
+            expect(new RemoteControlStatusWidget().render(NERD_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('\uF1EB');
+        });
+    });
+
+    describe('render() - format icon-text', () => {
+        const FORMAT_ITEM: WidgetItem = { ...ITEM, metadata: { format: 'icon-text' } };
+
+        it('renders 📡 off when OFF', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: false });
+            expect(new RemoteControlStatusWidget().render(FORMAT_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('📡 off');
+        });
+
+        it('renders 📡 on when ON', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: true });
+            expect(new RemoteControlStatusWidget().render(FORMAT_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('📡 on');
+        });
+    });
+
+    describe('render() - format text', () => {
+        const FORMAT_ITEM: WidgetItem = { ...ITEM, metadata: { format: 'text' } };
+
+        it('renders "off" when OFF', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: false });
+            expect(new RemoteControlStatusWidget().render(FORMAT_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('off');
+        });
+
+        it('renders "on" when ON', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: true });
+            expect(new RemoteControlStatusWidget().render(FORMAT_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('on');
+        });
+    });
+
+    describe('render() - format word', () => {
+        const FORMAT_ITEM: WidgetItem = { ...ITEM, metadata: { format: 'word' } };
+
+        it('renders "remote off" when OFF', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: false });
+            expect(new RemoteControlStatusWidget().render(FORMAT_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('remote off');
+        });
+
+        it('renders "remote on" when ON', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: true });
+            expect(new RemoteControlStatusWidget().render(FORMAT_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('remote on');
+        });
+    });
+
+    describe('render() - session id passthrough', () => {
+        it('forwards the session id from the status JSON to the lookup helper', () => {
+            new RemoteControlStatusWidget().render(ITEM, makeContext(), DEFAULT_SETTINGS);
+            expect(claudeSettings.getRemoteControlStatus).toHaveBeenCalledWith(SESSION_ID);
+        });
+
+        it('passes undefined when no session id is present', () => {
+            new RemoteControlStatusWidget().render(ITEM, { data: {} }, DEFAULT_SETTINGS);
+            expect(claudeSettings.getRemoteControlStatus).toHaveBeenCalledWith(undefined);
+        });
+    });
+
+    describe('render() - preview mode', () => {
+        it('renders the ON state for the default format', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: false });
+            expect(new RemoteControlStatusWidget().render(ITEM, makeContext({ isPreview: true }), DEFAULT_SETTINGS))
+                .toBe('📡 ◉');
+        });
+
+        it('renders the ON state for word format with nerd font', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: false });
+            const item: WidgetItem = { ...ITEM, metadata: { format: 'word', nerdFont: 'true' } };
+            expect(new RemoteControlStatusWidget().render(item, makeContext({ isPreview: true }), DEFAULT_SETTINGS))
+                .toBe('remote on');
+        });
+    });
+
+    describe('render() - missing manifest', () => {
+        it('returns null when getRemoteControlStatus returns null', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue(null);
+            expect(new RemoteControlStatusWidget().render(ITEM, makeContext(), DEFAULT_SETTINGS)).toBeNull();
+        });
+    });
+
+    describe('render() - raw value', () => {
+        const RAW_ITEM: WidgetItem = { ...ITEM, rawValue: true };
+
+        it('returns "on" when ON', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: true });
+            expect(new RemoteControlStatusWidget().render(RAW_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('on');
+        });
+
+        it('returns "off" when OFF', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: false });
+            expect(new RemoteControlStatusWidget().render(RAW_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('off');
+        });
+
+        it('returns "on" in preview mode', () => {
+            expect(new RemoteControlStatusWidget().render(RAW_ITEM, makeContext({ isPreview: true }), DEFAULT_SETTINGS))
+                .toBe('on');
+        });
+
+        it('returns null when manifest lookup is null', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue(null);
+            expect(new RemoteControlStatusWidget().render(RAW_ITEM, makeContext(), DEFAULT_SETTINGS)).toBeNull();
+        });
+    });
+});

--- a/src/widgets/__tests__/RemoteControlStatus.test.ts
+++ b/src/widgets/__tests__/RemoteControlStatus.test.ts
@@ -83,18 +83,20 @@ describe('RemoteControlStatusWidget', () => {
             });
         });
 
-        it('cycles icon -> icon-text -> text -> word -> label-check -> icon', () => {
+        it('cycles icon -> icon-text -> text -> word -> label-check -> label-mark -> icon', () => {
             const widget = new RemoteControlStatusWidget();
             const iconText = widget.handleEditorAction('cycle-format', ITEM);
             const text = widget.handleEditorAction('cycle-format', iconText ?? ITEM);
             const word = widget.handleEditorAction('cycle-format', text ?? ITEM);
             const labelCheck = widget.handleEditorAction('cycle-format', word ?? ITEM);
-            const back = widget.handleEditorAction('cycle-format', labelCheck ?? ITEM);
+            const labelMark = widget.handleEditorAction('cycle-format', labelCheck ?? ITEM);
+            const back = widget.handleEditorAction('cycle-format', labelMark ?? ITEM);
 
             expect(iconText?.metadata?.format).toBe('icon-text');
             expect(text?.metadata?.format).toBe('text');
             expect(word?.metadata?.format).toBe('word');
             expect(labelCheck?.metadata?.format).toBe('label-check');
+            expect(labelMark?.metadata?.format).toBe('label-mark');
             expect(back?.metadata?.format).toBeUndefined();
         });
 
@@ -191,6 +193,20 @@ describe('RemoteControlStatusWidget', () => {
         it('renders "remote ✅" when ON', () => {
             vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: true });
             expect(new RemoteControlStatusWidget().render(FORMAT_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('remote ✅');
+        });
+    });
+
+    describe('render() - format label-mark', () => {
+        const FORMAT_ITEM: WidgetItem = { ...ITEM, metadata: { format: 'label-mark' } };
+
+        it('renders "remote ✗" when OFF', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: false });
+            expect(new RemoteControlStatusWidget().render(FORMAT_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('remote ✗');
+        });
+
+        it('renders "remote ✓" when ON', () => {
+            vi.spyOn(claudeSettings, 'getRemoteControlStatus').mockReturnValue({ enabled: true });
+            expect(new RemoteControlStatusWidget().render(FORMAT_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('remote ✓');
         });
     });
 

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -74,3 +74,4 @@ export { GitWorktreeBranchWidget } from './GitWorktreeBranch';
 export { GitWorktreeOriginalBranchWidget } from './GitWorktreeOriginalBranch';
 export { CompactionCounterWidget } from './CompactionCounter';
 export { VoiceStatusWidget } from './VoiceStatus';
+export { RemoteControlStatusWidget } from './RemoteControlStatus';


### PR DESCRIPTION
## Summary

Adds a `remote-control-status` widget that surfaces whether the *current* Claude Code session has a remote-control bridge attached, so users running with `remoteControlAtStartup: true` can see at a glance whether their session is actually reachable from the mobile/web bridge.

## How detection works

Claude Code writes per-PID session manifests to `<config>/sessions/<pid>.json`. Each manifest carries a `sessionId` and (when remote control is connected) a `bridgeSessionId`. The widget:

1. Reads the `session_id` from the status JSON Claude Code pipes in.
2. Scans the sessions directory for the manifest whose `sessionId` matches.
3. Reports ON when `bridgeSessionId` is a non-empty string, OFF when it is `null`/empty/missing, and hides itself when no matching manifest exists (e.g., sessions dir absent).

Verified empirically that running `/remote-control` to disconnect sets `bridgeSessionId` to `null` (not removed) and Claude Code rewrites the manifest within ~1s — so the widget reflects connect/disconnect transitions at the next status-line refresh. The Zod schema accepts `nullable().optional()` to match this.

Detection is per-session: disconnecting in one Claude Code window leaves the other window's manifest untouched.

## Widget surface

Same shape as `VoiceStatus`:

- **Default color:** blue (overridable)
- **Category:** Core
- **Raw value:** `on` / `off`
- **Format options** (cycled via `f`):
  - `icon` — 📡 ○ / 📡 ◉ (or U+F1EB / U+F6AC with `n` for Nerd Font)
  - `icon-text` — 📡 on / 📡 off
  - `text` — on / off
  - `word` — remote on / remote off
  - `label-check` — remote ✅ / remote ❌
  - `label-mark` — remote ✓ / remote ✗ (text-mode, picks up widget color)

## Files

- `src/utils/claude-settings.ts` — new `getRemoteControlStatus(sessionId)` helper
- `src/widgets/RemoteControlStatus.ts` — widget implementation
- `src/widgets/__tests__/RemoteControlStatus.test.ts` — 35 tests
- `src/widgets/index.ts`, `src/utils/widget-manifest.ts` — registry wiring

## Test plan

- [x] `bun test` — full suite green (1287 tests)
- [x] `bun run lint` — tsc + eslint clean
- [x] Manually verified against a live session: widget renders correctly with `bun run src/ccstatusline.ts` piped a real `session_id`, transitions ON → OFF within one refresh cycle after `/remote-control` disconnect, returns to ON after reconnect.