### PR TITLE
fix(git): use compatible git commands for older git versions

### DIFF
--- a/src/utils/__tests__/git-remote.test.ts
+++ b/src/utils/__tests__/git-remote.test.ts
@@ -18,6 +18,8 @@ import {
     parseRemoteUrl
 } from '../git-remote';
 
+import { expectGitExecOptions } from './git-test-helpers';
+
 vi.mock('child_process', () => ({
     execSync: vi.fn(),
     execFileSync: vi.fn(),
@@ -229,7 +231,8 @@ describe('git-remote utils', () => {
             getRemoteInfo(remoteName, {});
 
             expect(mockExecFileSync.mock.calls[0]?.[0]).toBe('git');
-            expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['--no-optional-locks', 'remote', 'get-url', '--', remoteName]);
+            expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['remote', 'get-url', '--', remoteName]);
+            expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2]);
         });
 
         it('returns null when remote does not exist', () => {

--- a/src/utils/__tests__/git-review-cache.test.ts
+++ b/src/utils/__tests__/git-review-cache.test.ts
@@ -59,7 +59,7 @@ function createHarness(): PrCacheHarness {
                 }
                 return `${originRemoteUrl}\n`;
             }
-            if (cmd === 'git' && commandArgs[0] === 'branch')
+            if (cmd === 'git' && commandArgs[0] === 'symbolic-ref')
                 return `${currentRef}\n`;
             if (cmd === 'git' && commandArgs[0] === 'rev-parse')
                 return 'abc123\n';

--- a/src/utils/__tests__/git-test-helpers.ts
+++ b/src/utils/__tests__/git-test-helpers.ts
@@ -1,0 +1,14 @@
+import { expect } from 'vitest';
+
+export function expectGitExecOptions(options: unknown, cwd?: string): void {
+    expect(options).toEqual(expect.objectContaining({
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'ignore'],
+        ...(cwd ? { cwd } : {})
+    }));
+
+    expect((options as { env?: Record<string, string | undefined> }).env?.GIT_OPTIONAL_LOCKS).toBe('0');
+
+    if (!cwd)
+        expect(options).not.toHaveProperty('cwd');
+}

--- a/src/utils/__tests__/git.test.ts
+++ b/src/utils/__tests__/git.test.ts
@@ -18,6 +18,8 @@ import {
     runGit
 } from '../git';
 
+import { expectGitExecOptions } from './git-test-helpers';
+
 vi.mock('child_process', () => ({
     execSync: vi.fn(),
     execFileSync: vi.fn(),
@@ -95,16 +97,12 @@ describe('git utils', () => {
             mockExecFileSync.mockReturnValueOnce('feature/worktree\n');
             const context: RenderContext = { data: { cwd: '/tmp/repo' } };
 
-            const result = runGit('branch --show-current', context);
+            const result = runGit('symbolic-ref --short HEAD', context);
 
             expect(result).toBe('feature/worktree');
             expect(mockExecFileSync.mock.calls[0]?.[0]).toBe('git');
-            expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['--no-optional-locks', 'branch', '--show-current']);
-            expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
-                encoding: 'utf8',
-                stdio: ['pipe', 'pipe', 'ignore'],
-                cwd: '/tmp/repo'
-            });
+            expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['symbolic-ref', '--short', 'HEAD']);
+            expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2], '/tmp/repo');
         });
 
         it('runs git command without cwd when no context directory exists', () => {
@@ -113,10 +111,7 @@ describe('git utils', () => {
             const result = runGit('rev-parse --is-inside-work-tree', {});
 
             expect(result).toBe('true');
-            expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
-                encoding: 'utf8',
-                stdio: ['pipe', 'pipe', 'ignore']
-            });
+            expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2]);
         });
 
         it('returns null when the command fails', () => {

--- a/src/utils/git-review-cache.ts
+++ b/src/utils/git-review-cache.ts
@@ -71,8 +71,8 @@ function runGitForCache(args: string[], cwd: string, deps: GitReviewCacheDeps): 
 }
 
 function getCurrentBranch(cwd: string, deps: GitReviewCacheDeps): string | null {
-    const branch = runGitForCache(['rev-parse', '--abbrev-ref', 'HEAD'], cwd, deps);
-    return branch.length > 0 && branch !== 'HEAD' ? branch : null;
+    const branch = runGitForCache(['symbolic-ref', '--short', 'HEAD'], cwd, deps);
+    return branch.length > 0 ? branch : null;
 }
 
 function getCacheRef(cwd: string, deps: GitReviewCacheDeps): string {

--- a/src/utils/git-review-cache.ts
+++ b/src/utils/git-review-cache.ts
@@ -71,8 +71,8 @@ function runGitForCache(args: string[], cwd: string, deps: GitReviewCacheDeps): 
 }
 
 function getCurrentBranch(cwd: string, deps: GitReviewCacheDeps): string | null {
-    const branch = runGitForCache(['branch', '--show-current'], cwd, deps);
-    return branch.length > 0 ? branch : null;
+    const branch = runGitForCache(['rev-parse', '--abbrev-ref', 'HEAD'], cwd, deps);
+    return branch.length > 0 && branch !== 'HEAD' ? branch : null;
 }
 
 function getCacheRef(cwd: string, deps: GitReviewCacheDeps): string {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -47,15 +47,18 @@ export function runGitArgs(args: string[], context: RenderContext, cacheCommand?
         return gitCommandCache.get(cacheKey) ?? null;
     }
 
-    // --no-optional-locks prevents read-only commands (diff, status, rev-list, ...)
-    // from racing on .git/index.lock when another git process is writing it.
+    // --no-optional-locks (or GIT_OPTIONAL_LOCKS=0) prevents read-only commands
+    // (diff, status, rev-list, ...) from racing on .git/index.lock when another
+    // git process is writing it.
+    // We use the environment variable instead of the CLI flag because older Git
+    // versions (like 2.10.1) fail with "Unknown option: --no-optional-locks".
     // See https://git-scm.com/docs/git#Documentation/git.txt---no-optional-locks
-    const gitArgs = ['--no-optional-locks', ...args];
 
     try {
-        const output = execFileSync('git', gitArgs, {
+        const output = execFileSync('git', args, {
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],
+            env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
             ...(cwd ? { cwd } : {})
         }).trimEnd();
 

--- a/src/widgets/GitBranch.ts
+++ b/src/widgets/GitBranch.ts
@@ -119,8 +119,7 @@ export class GitBranchWidget implements Widget {
     }
 
     private getGitBranch(context: RenderContext): string | null {
-        const branch = runGit('rev-parse --abbrev-ref HEAD', context);
-        return branch === 'HEAD' ? null : branch;
+        return runGit('symbolic-ref --short HEAD', context);
     }
 
     getCustomKeybinds(): CustomKeybind[] {

--- a/src/widgets/GitBranch.ts
+++ b/src/widgets/GitBranch.ts
@@ -119,7 +119,8 @@ export class GitBranchWidget implements Widget {
     }
 
     private getGitBranch(context: RenderContext): string | null {
-        return runGit('branch --show-current', context);
+        const branch = runGit('rev-parse --abbrev-ref HEAD', context);
+        return branch === 'HEAD' ? null : branch;
     }
 
     getCustomKeybinds(): CustomKeybind[] {

--- a/src/widgets/__tests__/GitBranch.test.ts
+++ b/src/widgets/__tests__/GitBranch.test.ts
@@ -10,6 +10,7 @@ import {
 import type { RenderContext } from '../../types/RenderContext';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { expectGitExecOptions } from '../../utils/__tests__/git-test-helpers';
 import { clearGitCache } from '../../utils/git';
 import { renderOsc8Link } from '../../utils/hyperlink';
 import { GitBranchWidget } from '../GitBranch';
@@ -75,19 +76,11 @@ describe('GitBranchWidget', () => {
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('⎇ feature/worktree');
         expect(mockExecFileSync.mock.calls[0]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--is-inside-work-tree']);
-        expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
+        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['rev-parse', '--is-inside-work-tree']);
+        expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2], '/tmp/worktree');
         expect(mockExecFileSync.mock.calls[1]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--abbrev-ref', 'HEAD']);
-        expect(mockExecFileSync.mock.calls[1]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
+        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['symbolic-ref', '--short', 'HEAD']);
+        expectGitExecOptions(mockExecFileSync.mock.calls[1]?.[2], '/tmp/worktree');
     });
 
     it('should render raw branch value', () => {

--- a/src/widgets/__tests__/GitBranch.test.ts
+++ b/src/widgets/__tests__/GitBranch.test.ts
@@ -82,7 +82,7 @@ describe('GitBranchWidget', () => {
             cwd: '/tmp/worktree'
         });
         expect(mockExecFileSync.mock.calls[1]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['--no-optional-locks', 'branch', '--show-current']);
+        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--abbrev-ref', 'HEAD']);
         expect(mockExecFileSync.mock.calls[1]?.[2]).toEqual({
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],

--- a/src/widgets/__tests__/GitChanges.test.ts
+++ b/src/widgets/__tests__/GitChanges.test.ts
@@ -10,6 +10,7 @@ import {
 import type { RenderContext } from '../../types/RenderContext';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { expectGitExecOptions } from '../../utils/__tests__/git-test-helpers';
 import { clearGitCache } from '../../utils/git';
 import { GitChangesWidget } from '../GitChanges';
 
@@ -61,21 +62,9 @@ describe('GitChangesWidget', () => {
         mockExecFileSync.mockReturnValueOnce('1 file changed, 3 insertions(+), 4 deletions(-)');
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('(+5,-5)');
-        expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
-        expect(mockExecFileSync.mock.calls[1]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
-        expect(mockExecFileSync.mock.calls[2]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
+        expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2], '/tmp/worktree');
+        expectGitExecOptions(mockExecFileSync.mock.calls[1]?.[2], '/tmp/worktree');
+        expectGitExecOptions(mockExecFileSync.mock.calls[2]?.[2], '/tmp/worktree');
     });
 
     it('should render zero counts when repo is clean', () => {

--- a/src/widgets/__tests__/GitCleanStatus.test.ts
+++ b/src/widgets/__tests__/GitCleanStatus.test.ts
@@ -10,6 +10,7 @@ import {
 import type { RenderContext } from '../../types/RenderContext';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { expectGitExecOptions } from '../../utils/__tests__/git-test-helpers';
 import { clearGitCache } from '../../utils/git';
 import { GitCleanStatusWidget } from '../GitCleanStatus';
 
@@ -66,12 +67,8 @@ describe('GitCleanStatusWidget', () => {
         mockExecFileSync.mockReturnValueOnce('');
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('✓');
-        expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
-        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['--no-optional-locks', 'status', '--porcelain', '-z']);
+        expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2], '/tmp/worktree');
+        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['status', '--porcelain', '-z']);
     });
 
     it('renders dirty status', () => {

--- a/src/widgets/__tests__/GitDeletions.test.ts
+++ b/src/widgets/__tests__/GitDeletions.test.ts
@@ -10,6 +10,7 @@ import {
 import type { RenderContext } from '../../types/RenderContext';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { expectGitExecOptions } from '../../utils/__tests__/git-test-helpers';
 import { clearGitCache } from '../../utils/git';
 import { GitDeletionsWidget } from '../GitDeletions';
 
@@ -61,21 +62,9 @@ describe('GitDeletionsWidget', () => {
         mockExecFileSync.mockReturnValueOnce('1 file changed, 3 insertions(+), 4 deletions(-)');
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('-5');
-        expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
-        expect(mockExecFileSync.mock.calls[1]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
-        expect(mockExecFileSync.mock.calls[2]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
+        expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2], '/tmp/worktree');
+        expectGitExecOptions(mockExecFileSync.mock.calls[1]?.[2], '/tmp/worktree');
+        expectGitExecOptions(mockExecFileSync.mock.calls[2]?.[2], '/tmp/worktree');
     });
 
     it('should render zero count when repo is clean', () => {

--- a/src/widgets/__tests__/GitInsertions.test.ts
+++ b/src/widgets/__tests__/GitInsertions.test.ts
@@ -10,6 +10,7 @@ import {
 import type { RenderContext } from '../../types/RenderContext';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { expectGitExecOptions } from '../../utils/__tests__/git-test-helpers';
 import { clearGitCache } from '../../utils/git';
 import { GitInsertionsWidget } from '../GitInsertions';
 
@@ -61,21 +62,9 @@ describe('GitInsertionsWidget', () => {
         mockExecFileSync.mockReturnValueOnce('1 file changed, 3 insertions(+), 4 deletions(-)');
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('+5');
-        expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
-        expect(mockExecFileSync.mock.calls[1]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
-        expect(mockExecFileSync.mock.calls[2]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
+        expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2], '/tmp/worktree');
+        expectGitExecOptions(mockExecFileSync.mock.calls[1]?.[2], '/tmp/worktree');
+        expectGitExecOptions(mockExecFileSync.mock.calls[2]?.[2], '/tmp/worktree');
     });
 
     it('should render zero count when repo is clean', () => {

--- a/src/widgets/__tests__/GitRootDir.test.ts
+++ b/src/widgets/__tests__/GitRootDir.test.ts
@@ -10,6 +10,7 @@ import {
 import type { RenderContext } from '../../types/RenderContext';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { expectGitExecOptions } from '../../utils/__tests__/git-test-helpers';
 import { clearGitCache } from '../../utils/git';
 import {
     buildIdeFileUrl,
@@ -74,19 +75,11 @@ describe('GitRootDirWidget', () => {
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('my-repo');
         expect(mockExecFileSync.mock.calls[0]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--is-inside-work-tree']);
-        expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
+        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['rev-parse', '--is-inside-work-tree']);
+        expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2], '/tmp/worktree');
         expect(mockExecFileSync.mock.calls[1]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--show-toplevel']);
-        expect(mockExecFileSync.mock.calls[1]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
+        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['rev-parse', '--show-toplevel']);
+        expectGitExecOptions(mockExecFileSync.mock.calls[1]?.[2], '/tmp/worktree');
     });
 
     it('should handle trailing separators', () => {

--- a/src/widgets/__tests__/GitStagedFiles.test.ts
+++ b/src/widgets/__tests__/GitStagedFiles.test.ts
@@ -10,6 +10,7 @@ import {
 import type { RenderContext } from '../../types/RenderContext';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { expectGitExecOptions } from '../../utils/__tests__/git-test-helpers';
 import { clearGitCache } from '../../utils/git';
 import { GitStagedFilesWidget } from '../GitStagedFiles';
 
@@ -66,13 +67,9 @@ describe('GitStagedFilesWidget', () => {
         mockExecFileSync.mockReturnValueOnce('M  a.ts\0A  b.ts\0 M c.ts\0?? d.ts\0');
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('S:2');
-        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--is-inside-work-tree']);
-        expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
-        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['--no-optional-locks', 'status', '--porcelain', '-z']);
+        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['rev-parse', '--is-inside-work-tree']);
+        expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2], '/tmp/worktree');
+        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['status', '--porcelain', '-z']);
     });
 
     it('renders raw staged file count', () => {

--- a/src/widgets/__tests__/GitUnstagedFiles.test.ts
+++ b/src/widgets/__tests__/GitUnstagedFiles.test.ts
@@ -10,6 +10,7 @@ import {
 import type { RenderContext } from '../../types/RenderContext';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { expectGitExecOptions } from '../../utils/__tests__/git-test-helpers';
 import { clearGitCache } from '../../utils/git';
 import { GitUnstagedFilesWidget } from '../GitUnstagedFiles';
 
@@ -66,12 +67,8 @@ describe('GitUnstagedFilesWidget', () => {
         mockExecFileSync.mockReturnValueOnce('M  a.ts\0 M b.ts\0 D c.ts\0?? d.ts\0');
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('M:2');
-        expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
-        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['--no-optional-locks', 'status', '--porcelain', '-z']);
+        expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2], '/tmp/worktree');
+        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['status', '--porcelain', '-z']);
     });
 
     it('renders raw unstaged file count', () => {

--- a/src/widgets/__tests__/GitUntrackedFiles.test.ts
+++ b/src/widgets/__tests__/GitUntrackedFiles.test.ts
@@ -10,6 +10,7 @@ import {
 import type { RenderContext } from '../../types/RenderContext';
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { expectGitExecOptions } from '../../utils/__tests__/git-test-helpers';
 import { clearGitCache } from '../../utils/git';
 import { GitUntrackedFilesWidget } from '../GitUntrackedFiles';
 
@@ -66,12 +67,8 @@ describe('GitUntrackedFilesWidget', () => {
         mockExecFileSync.mockReturnValueOnce('M  a.ts\0 M b.ts\0?? c.ts\0?? d.ts\0');
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('?:2');
-        expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
-        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['--no-optional-locks', 'status', '--porcelain', '-z']);
+        expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2], '/tmp/worktree');
+        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['status', '--porcelain', '-z']);
     });
 
     it('renders raw untracked file count', () => {

--- a/src/widgets/__tests__/GitWorktree.test.ts
+++ b/src/widgets/__tests__/GitWorktree.test.ts
@@ -11,6 +11,7 @@ import type {
     RenderContext,
     WidgetItem
 } from '../../types';
+import { expectGitExecOptions } from '../../utils/__tests__/git-test-helpers';
 import { clearGitCache } from '../../utils/git';
 import { GitWorktreeWidget } from '../GitWorktree';
 
@@ -68,19 +69,11 @@ describe('GitWorktreeWidget', () => {
 
         expect(render({ cwd: '/tmp/worktree' })).toBe('𖠰 some-worktree');
         expect(mockExecFileSync.mock.calls[0]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--is-inside-work-tree']);
-        expect(mockExecFileSync.mock.calls[0]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
+        expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual(['rev-parse', '--is-inside-work-tree']);
+        expectGitExecOptions(mockExecFileSync.mock.calls[0]?.[2], '/tmp/worktree');
         expect(mockExecFileSync.mock.calls[1]?.[0]).toBe('git');
-        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['--no-optional-locks', 'rev-parse', '--git-dir']);
-        expect(mockExecFileSync.mock.calls[1]?.[2]).toEqual({
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-            cwd: '/tmp/worktree'
-        });
+        expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(['rev-parse', '--git-dir']);
+        expectGitExecOptions(mockExecFileSync.mock.calls[1]?.[2], '/tmp/worktree');
     });
 
     it('should render with nested worktree', () => {


### PR DESCRIPTION
## Description
This PR improves Git version compatibility by replacing newer Git flags and commands with backwards-compatible equivalents. This prevents `ccstatusline` from erroneously falling back to the "no git" state when run on systems with older Git installations (such as Git 2.10.1 built into some macOS environments).

## Changes Made
- **Replaced `--no-optional-locks` CLI argument with `GIT_OPTIONAL_LOCKS=0` environment variable.** 
  - *Why:* The `--no-optional-locks` flag was introduced in Git 2.15.0 and causes older Git versions to fail immediately with `Unknown option`. Passing this configuration via the environment variable achieves the exact same lock-avoidance behavior in newer Git versions while being safely ignored by older versions.
- **Replaced `git branch --show-current` with `git rev-parse --abbrev-ref HEAD`.**
  - *Why:* The `--show-current` flag was introduced in Git 2.22.0. `rev-parse --abbrev-ref HEAD` is broadly compatible. Added a fallback to ensure it returns `null` when in a detached `HEAD` state (matching the behavior of `--show-current`).
- **Updated test suites** to expect the newly updated Git commands.

## Testing
- Successfully passed `bun run verify` and `bun test`.
- Verified that Git widgets and branch links continue working as intended.