### PR TITLE
fix(extra-usage): correct unit assumptions for usage API response

### DIFF
--- a/src/utils/__tests__/usage-fetch.test.ts
+++ b/src/utils/__tests__/usage-fetch.test.ts
@@ -308,8 +308,8 @@ describe('fetchUsageData error handling', () => {
         extra_usage: {
             is_enabled: true,
             monthly_limit: 400000,
-            used_credits: 106,
-            utilization: 0.026
+            used_credits: 10600,
+            utilization: 2.6
         }
     });
     const rateLimitedResponseBody = JSON.stringify({
@@ -571,8 +571,8 @@ describe('fetchUsageData error handling', () => {
                 weeklyResetAt: '2030-01-07T00:00:00.000Z',
                 extraUsageEnabled: true,
                 extraUsageLimit: 400000,
-                extraUsageUsed: 106,
-                extraUsageUtilization: 0.026
+                extraUsageUsed: 10600,
+                extraUsageUtilization: 2.6
             });
             expect(result.second).toEqual(result.first);
             expect(result.requestCount).toBe(1);

--- a/src/utils/__tests__/usage-prefetch.test.ts
+++ b/src/utils/__tests__/usage-prefetch.test.ts
@@ -344,8 +344,8 @@ describe('usage prefetch', () => {
         mockFetchUsageData.mockResolvedValue({
             extraUsageEnabled: true,
             extraUsageLimit: 400000,
-            extraUsageUsed: 106,
-            extraUsageUtilization: 0.026
+            extraUsageUsed: 10600,
+            extraUsageUtilization: 2.6
         });
 
         const lines = makeLines(
@@ -358,8 +358,8 @@ describe('usage prefetch', () => {
             sessionUsage: 42,
             extraUsageEnabled: true,
             extraUsageLimit: 400000,
-            extraUsageUsed: 106,
-            extraUsageUtilization: 0.026
+            extraUsageUsed: 10600,
+            extraUsageUtilization: 2.6
         });
         expect(mockFetchUsageData.mock.calls).toEqual([
             [{

--- a/src/utils/usage-types.ts
+++ b/src/utils/usage-types.ts
@@ -17,8 +17,8 @@ export interface UsageData {
     weeklyOpusResetAt?: string;   // seven_day_opus.resets_at
     extraUsageEnabled?: boolean;
     extraUsageLimit?: number;      // in cents (divide by 100 for dollars)
-    extraUsageUsed?: number;       // in dollars
-    extraUsageUtilization?: number;
+    extraUsageUsed?: number;       // in cents (divide by 100 for dollars)
+    extraUsageUtilization?: number; // percentage 0-100
     error?: UsageError;
 }
 

--- a/src/widgets/ExtraUsageRemaining.ts
+++ b/src/widgets/ExtraUsageRemaining.ts
@@ -50,9 +50,10 @@ export class ExtraUsageRemainingWidget implements Widget {
             return null;
         }
 
-        // extraUsageLimit is in cents; extraUsageUsed is in dollars
+        // Both extraUsageLimit and extraUsageUsed are in cents
         const limitDollars = data.extraUsageLimit / 100;
-        const remaining = Math.max(0, limitDollars - data.extraUsageUsed);
+        const usedDollars = data.extraUsageUsed / 100;
+        const remaining = Math.max(0, limitDollars - usedDollars);
         const formatted = `$${remaining.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
         return formatRawOrLabeledValue(item, 'Overage Left: ', formatted);

--- a/src/widgets/ExtraUsageUtilization.ts
+++ b/src/widgets/ExtraUsageUtilization.ts
@@ -94,7 +94,8 @@ export class ExtraUsageUtilizationWidget implements Widget {
             return null;
         }
 
-        const percent = Math.max(0, Math.min(100, data.extraUsageUtilization * 100));
+        // extraUsageUtilization is already a percentage (0-100), not a fraction
+        const percent = Math.max(0, Math.min(100, data.extraUsageUtilization));
         const renderedPercent = inverted ? 100 - percent : percent;
 
         if (isUsageProgressMode(displayMode)) {

--- a/src/widgets/__tests__/ExtraUsageRemaining.test.ts
+++ b/src/widgets/__tests__/ExtraUsageRemaining.test.ts
@@ -111,7 +111,7 @@ describe('ExtraUsageRemainingWidget', () => {
                 error: 'timeout',
                 extraUsageEnabled: false,
                 extraUsageLimit: 400000,
-                extraUsageUsed: 106
+                extraUsageUsed: 10600
             }
         })).toBe('Overage Left: n/a');
         expect(render(widget, { id: 'extra', rawValue: true, type: 'extra-usage-remaining' }, { usageData: { extraUsageEnabled: false } })).toBe('n/a');

--- a/src/widgets/__tests__/ExtraUsageRemaining.test.ts
+++ b/src/widgets/__tests__/ExtraUsageRemaining.test.ts
@@ -35,7 +35,7 @@ describe('ExtraUsageRemainingWidget', () => {
             usageData: {
                 extraUsageEnabled: true,
                 extraUsageLimit: 400000,
-                extraUsageUsed: 106
+                extraUsageUsed: 10600
             }
         };
 
@@ -54,7 +54,7 @@ describe('ExtraUsageRemainingWidget', () => {
             usageData: {
                 extraUsageEnabled: true,
                 extraUsageLimit: 1000,
-                extraUsageUsed: 15
+                extraUsageUsed: 1500
             }
         })).toBe('Overage Left: $0.00');
     });
@@ -84,7 +84,7 @@ describe('ExtraUsageRemainingWidget', () => {
                 error: 'timeout',
                 extraUsageEnabled: true,
                 extraUsageLimit: 400000,
-                extraUsageUsed: 106
+                extraUsageUsed: 10600
             }
         })).toBe('Overage Left: $3,894.00');
     });

--- a/src/widgets/__tests__/ExtraUsageUtilization.test.ts
+++ b/src/widgets/__tests__/ExtraUsageUtilization.test.ts
@@ -115,7 +115,7 @@ describe('ExtraUsageUtilizationWidget', () => {
             usageData: {
                 error: 'timeout',
                 extraUsageEnabled: false,
-                extraUsageUtilization: 0.25
+                extraUsageUtilization: 25
             }
         })).toBe('Overage: n/a');
         const rawProgressItem: WidgetItem = {

--- a/src/widgets/__tests__/ExtraUsageUtilization.test.ts
+++ b/src/widgets/__tests__/ExtraUsageUtilization.test.ts
@@ -34,7 +34,7 @@ describe('ExtraUsageUtilizationWidget', () => {
         const context: RenderContext = {
             usageData: {
                 extraUsageEnabled: true,
-                extraUsageUtilization: 0.25
+                extraUsageUtilization: 25
             }
         };
 
@@ -63,7 +63,7 @@ describe('ExtraUsageUtilizationWidget', () => {
             usageData: {
                 error: 'timeout',
                 extraUsageEnabled: true,
-                extraUsageUtilization: 0.026
+                extraUsageUtilization: 2.6
             }
         })).toBe('Overage: 2.6%');
     });
@@ -150,7 +150,7 @@ describe('ExtraUsageUtilizationWidget', () => {
         }, {
             usageData: {
                 extraUsageEnabled: true,
-                extraUsageUtilization: 0.25
+                extraUsageUtilization: 25
             }
         })).toBe('Overage: [████████████░░░░] 75.0%');
     });


### PR DESCRIPTION
## Summary

Fixes #387.

- `ExtraUsageRemaining`: `extraUsageUsed` is in cents (not dollars), so divide by 100 before subtracting from the limit. Previously the widget subtracted a cents value from a dollars value, producing an inflated "Overage Left" amount.
- `ExtraUsageUtilization`: `extraUsageUtilization` is already a percentage (0–100), not a fraction. Removed the erroneous `* 100` that caused the value to clamp to 100% almost immediately.

## Test plan

- [x] Verify "Overage Left" shows a sane dollar value against a real pay-as-you-go account
- [x] Verify "Overage Utilization" matches the percentage reported by the Claude usage API
- [x] `bun run lint` passes
- [ ] `bun test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)