### PR TITLE
feat(custom-command): include terminal_width in stdin JSON

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -203,6 +203,7 @@ Add a single symbol or emoji to your status line when you want a compact visual 
 Execute shell commands and display their output dynamically:
 - Refreshes whenever the statusline is updated by Claude Code
 - Receives the full Claude Code JSON data via stdin (model info, session ID, transcript path, etc.)
+- Also includes `terminal_width` — the detected terminal width in columns, added by ccstatusline (omitted when it can't be determined) — so scripts can adapt their output to the available space
 - Displays command output inline in your status line
 - Configurable timeout (default: 1000ms)
 - Optional max-width truncation
@@ -217,7 +218,7 @@ Execute shell commands and display their output dynamically:
 
 > ⚠️ **Important:** Commands should complete quickly to avoid delays. Long-running commands will be killed after the configured timeout. If you're not seeing output from your custom command, try increasing the timeout value (press 't' in the editor).
 
-> 💡 **Tip:** Custom commands can be other Claude Code compatible status line formatters. They receive the same JSON via stdin that `ccstatusline` receives from Claude Code, allowing you to chain or combine multiple status line tools.
+> 💡 **Tip:** Custom commands can be other Claude Code compatible status line formatters. They receive the same JSON via stdin that `ccstatusline` receives from Claude Code (augmented with a `terminal_width` field), allowing you to chain or combine multiple status line tools.
 
 ### Link Widget
 

--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -41,6 +41,7 @@ import {
     getWidgetSpeedWindowSeconds,
     isWidgetSpeedWindowEnabled
 } from './utils/speed-window';
+import { getTerminalWidth } from './utils/terminal';
 import { prefetchUsageDataIfNeeded } from './utils/usage-prefetch';
 
 function hasSessionDurationInStatusJson(data: StatusJSON): boolean {
@@ -175,6 +176,7 @@ async function renderMultipleLines(data: StatusJSON) {
         sessionDuration,
         skillsMetrics,
         compactionData: hasCompactionWidget ? { count: compactionCount } : null,
+        terminalWidth: getTerminalWidth(),
         isPreview: false,
         minimalist: settings.minimalistMode,
         gitCacheTtlSeconds: settings.gitCacheTtlSeconds

--- a/src/widgets/CustomCommand.tsx
+++ b/src/widgets/CustomCommand.tsx
@@ -60,7 +60,11 @@ export class CustomCommandWidget implements Widget {
         } else if (item.commandPath && context.data) {
             try {
                 const timeout = item.timeout ?? 1000;
-                const jsonInput = JSON.stringify(context.data);
+                const jsonInput = JSON.stringify(
+                    typeof context.terminalWidth === 'number'
+                        ? { ...context.data, terminal_width: context.terminalWidth }
+                        : context.data
+                );
                 let output = execSync(item.commandPath, {
                     encoding: 'utf8',
                     input: jsonInput,

--- a/src/widgets/__tests__/CustomCommand.test.ts
+++ b/src/widgets/__tests__/CustomCommand.test.ts
@@ -1,0 +1,74 @@
+import {
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import type { Settings } from '../../types/Settings';
+import type { WidgetItem } from '../../types/Widget';
+import { CustomCommandWidget } from '../CustomCommand';
+
+// Mock the process boundary: echo back whatever is piped to stdin, the way
+// `cat` would. The widget output then IS the JSON it sent, so we can assert
+// exactly what the custom command received — without spawning a subprocess.
+vi.mock('child_process', () => ({ execSync: vi.fn((_command: string, options?: { input?: string }) => options?.input ?? '') }));
+
+describe('CustomCommandWidget', () => {
+    const widget = new CustomCommandWidget();
+
+    const defaultSettings: Settings = {
+        version: 3,
+        lines: [],
+        flexMode: 'full',
+        compactThreshold: 60,
+        colorLevel: 2,
+        defaultPadding: ' ',
+        inheritSeparatorColors: false,
+        globalBold: false,
+        gitCacheTtlSeconds: 5,
+        minimalistMode: false,
+        powerline: {
+            enabled: false,
+            separators: [],
+            separatorInvertBackground: [],
+            startCaps: [],
+            endCaps: [],
+            autoAlign: false,
+            continueThemeAcrossLines: false
+        }
+    };
+
+    const createItem = (): WidgetItem => ({
+        id: 'test',
+        type: 'custom-command',
+        commandPath: 'echo'
+    });
+
+    const createContext = (terminalWidth: number | null | undefined): RenderContext => ({
+        data: { model: { display_name: 'Sonnet' } },
+        terminalWidth,
+        isPreview: false
+    });
+
+    const renderParsed = (terminalWidth: number | null | undefined): Record<string, unknown> => {
+        const output = widget.render(createItem(), createContext(terminalWidth), defaultSettings);
+        if (output === null)
+            throw new Error('expected command output');
+        return JSON.parse(output) as Record<string, unknown>;
+    };
+
+    it('includes terminal_width in the JSON piped to the command', () => {
+        expect(renderParsed(142).terminal_width).toBe(142);
+    });
+
+    it('still passes through the existing data fields', () => {
+        const model = renderParsed(142).model as { display_name?: string } | undefined;
+        expect(model?.display_name).toBe('Sonnet');
+    });
+
+    it('omits terminal_width when the width is unknown', () => {
+        expect(renderParsed(null)).not.toHaveProperty('terminal_width');
+    });
+});


### PR DESCRIPTION
## Summary

Custom Command widgets receive `context.data` as JSON over stdin, but the terminal width was not part of it, so scripts had no way to adapt their output to the terminal. `tput cols` / `stty size` / `$COLUMNS` all report `80` in ccstatusline's piped stdio context, so the width is otherwise unrecoverable from a custom command. Requested in #308.

## What changed

- **`src/ccstatusline.ts`** — populate `terminalWidth` once on the render context via `getTerminalWidth()`. Custom commands execute during `preRenderAllWidgets`, *before* `renderStatusLine` computes the width, so the value has to be on the context up front. As a side benefit, the renderer now reuses this value instead of re-probing per line.
- **`src/widgets/CustomCommand.tsx`** — add `terminal_width` to the JSON piped to the command when a numeric width is known (omitted otherwise).

```json
{ "model": { "display_name": "..." }, "workspace": { "current_dir": "..." }, "terminal_width": 142 }
```

## Notes

- **Field name** `terminal_width` (snake_case) matches the existing Claude Code payload (`session_id`, `current_dir`, `used_percentage`, …).
- **Raw terminal width**, not flex-adjusted — scripts get the actual column count (and it honors `CCSTATUSLINE_WIDTH`), independent of `flexMode`. This is complementary to #380: `CCSTATUSLINE_WIDTH` overrides the probe, whereas this exposes the resulting width to custom-command stdin.
- **Omitted when undetectable**, so script authors can guard for its absence.

## Use case

Adaptive labels — full text ("ReadCache", "CacheCreate") on wide terminals, abbreviated ("RC", "CC") on narrow ones — as described in the issue.

## Testing

- New unit test (`src/widgets/__tests__/CustomCommand.test.ts`) mocking the `execSync` boundary: field present when width is known, existing data still passes through, field omitted when width is unknown.
- Full suite green (1396 tests), lint clean.
- Manually verified end-to-end with an adaptive custom-command script through both `bun` and the bundled `dist` (via `node`): full labels on wide terminals, abbreviated on narrow, the real tty width picked up with no override, and the raw width preserved under `full-minus-40`.
- `docs/USAGE.md` updated.

Closes #308
