### PR TITLE
feat: add gradient as a first-class widget color

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "remotion": "^4.0.459",
         "strip-ansi": "^7.1.0",
         "tinyglobby": "^0.2.14",
+        "tinygradient": "^1.1.5",
         "typedoc": "^0.28.12",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.39.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-dom": "19.2.6",
     "remotion": "^4.0.459",
     "strip-ansi": "^7.1.0",
+    "tinygradient": "^1.1.5",
     "tinyglobby": "^0.2.14",
     "typedoc": "^0.28.12",
     "typescript": "^6.0.2",

--- a/src/tui/components/ColorMenu.tsx
+++ b/src/tui/components/ColorMenu.tsx
@@ -15,6 +15,10 @@ import {
     getAvailableBackgroundColorsForUI,
     getAvailableColorsForUI
 } from '../../utils/colors';
+import {
+    GRADIENT_PRESET_NAMES,
+    parseGradientSpec
+} from '../../utils/gradient';
 import { shouldInsertInput } from '../../utils/input-guards';
 import { getWidget } from '../../utils/widgets';
 
@@ -42,6 +46,11 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
     const [ansi256InputMode, setAnsi256InputMode] = useState(false);
     const [ansi256Input, setAnsi256Input] = useState('');
     const [showClearConfirm, setShowClearConfirm] = useState(false);
+    const [gradientMode, setGradientMode] = useState(false);
+    const [gradientIndex, setGradientIndex] = useState(0);
+    const [gradientCustomStep, setGradientCustomStep] = useState<'start' | 'end' | null>(null);
+    const [gradientStartHex, setGradientStartHex] = useState('');
+    const [gradientHexInput, setGradientHexInput] = useState('');
 
     const powerlineEnabled = settings.powerline.enabled;
 
@@ -146,6 +155,69 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
             return;
         }
 
+        // Handle gradient selection mode
+        if (gradientMode) {
+            const exitGradient = () => {
+                setGradientMode(false);
+                setGradientCustomStep(null);
+                setGradientStartHex('');
+                setGradientHexInput('');
+            };
+
+            const applyGradientValue = (value: string) => {
+                const selectedWidget = colorableWidgets.find(widget => widget.id === highlightedItemId);
+                if (selectedWidget) {
+                    onUpdate(setWidgetColor(widgets, selectedWidget.id, value, false));
+                }
+                exitGradient();
+            };
+
+            // Custom start/end hex entry
+            if (gradientCustomStep) {
+                if (key.escape) {
+                    setGradientCustomStep(null);
+                    setGradientHexInput('');
+                } else if (key.return) {
+                    if (gradientHexInput.length === 6) {
+                        if (gradientCustomStep === 'start') {
+                            setGradientStartHex(gradientHexInput);
+                            setGradientHexInput('');
+                            setGradientCustomStep('end');
+                        } else {
+                            applyGradientValue(`gradient:${gradientStartHex}-${gradientHexInput}`);
+                        }
+                    }
+                } else if (key.backspace || key.delete) {
+                    setGradientHexInput(gradientHexInput.slice(0, -1));
+                } else if (shouldInsertInput(input, key) && gradientHexInput.length < 6) {
+                    const upperInput = input.toUpperCase();
+                    if (/^[0-9A-F]$/.test(upperInput)) {
+                        setGradientHexInput(gradientHexInput + upperInput);
+                    }
+                }
+                return;
+            }
+
+            // Preset list navigation (last item is the "Custom" entry)
+            const total = GRADIENT_PRESET_NAMES.length + 1;
+            if (key.escape) {
+                exitGradient();
+            } else if (key.upArrow) {
+                setGradientIndex((gradientIndex - 1 + total) % total);
+            } else if (key.downArrow) {
+                setGradientIndex((gradientIndex + 1) % total);
+            } else if (key.return) {
+                if (gradientIndex < GRADIENT_PRESET_NAMES.length) {
+                    applyGradientValue(`gradient:${GRADIENT_PRESET_NAMES[gradientIndex]}`);
+                } else {
+                    setGradientStartHex('');
+                    setGradientHexInput('');
+                    setGradientCustomStep('start');
+                }
+            }
+            return;
+        }
+
         // Ignore number keys to prevent SelectInput numerical navigation
         if (input && /^[0-9]$/.test(input)) {
             return;
@@ -169,6 +241,15 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
             if (highlightedItemId && highlightedItemId !== 'back' && settings.colorLevel === 2) {
                 setAnsi256InputMode(true);
                 setAnsi256Input('');
+            }
+        } else if (input === 'g' || input === 'G') {
+            // Enter gradient selection mode (foreground only, needs a real color palette)
+            if (highlightedItemId && highlightedItemId !== 'back' && !editingBackground && settings.colorLevel >= 2) {
+                setGradientMode(true);
+                setGradientIndex(0);
+                setGradientCustomStep(null);
+                setGradientStartHex('');
+                setGradientHexInput('');
             }
         } else if ((input === 's' || input === 'S') && !key.ctrl) {
             // Toggle show separators (only if not in powerline mode and no default separator)
@@ -336,6 +417,16 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
                 displayName = `ANSI ${currentColor.substring(8)}`;
             } else if (currentColor.startsWith('hex:')) {
                 displayName = `#${currentColor.substring(4)}`;
+            } else if (currentColor.startsWith('gradient:')) {
+                const body = currentColor.substring(9);
+                const spec = parseGradientSpec(currentColor);
+                if (spec && GRADIENT_PRESET_NAMES.includes(body.toLowerCase())) {
+                    displayName = `Gradient: ${body.toLowerCase()}`;
+                } else if (spec) {
+                    displayName = `Gradient: ${spec.stops.join(' → ')}`;
+                } else {
+                    displayName = currentColor;
+                }
             } else {
                 const colorOption = colorOptions.find(c => c.value === currentColor);
                 displayName = colorOption ? colorOption.name : currentColor;
@@ -345,6 +436,63 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
             const level = getColorLevelString(settings.colorLevel);
             colorDisplay = applyColors(displayName, currentColor, undefined, false, level);
         }
+    }
+
+    // Gradient selection mode takes over the whole view
+    if (gradientMode) {
+        const level = getColorLevelString(settings.colorLevel);
+        const widgetName = selectedWidget ? getItemLabel(selectedWidget) : '';
+
+        if (gradientCustomStep) {
+            return (
+                <Box flexDirection='column'>
+                    <Text bold>
+                        Custom Gradient
+                        {widgetName ? ` - ${widgetName}` : ''}
+                    </Text>
+                    <Box marginTop={1} flexDirection='column'>
+                        <Text>{gradientCustomStep === 'start' ? 'Enter START hex color (without #):' : 'Enter END hex color (without #):'}</Text>
+                        {gradientCustomStep === 'end' && (
+                            <Text dimColor>
+                                Start: #
+                                {gradientStartHex}
+                            </Text>
+                        )}
+                        <Text>
+                            #
+                            {gradientHexInput}
+                            <Text dimColor>{gradientHexInput.length < 6 ? '_'.repeat(6 - gradientHexInput.length) : ''}</Text>
+                        </Text>
+                        <Text> </Text>
+                        <Text dimColor>Press Enter when done, ESC to go back</Text>
+                    </Box>
+                </Box>
+            );
+        }
+
+        return (
+            <Box flexDirection='column'>
+                <Text bold>
+                    Select Gradient
+                    {widgetName ? ` - ${widgetName}` : ''}
+                </Text>
+                <Box marginTop={1}>
+                    <Text dimColor>↑↓ to select, Enter to apply, ESC to cancel</Text>
+                </Box>
+                <Box marginTop={1} flexDirection='column'>
+                    {GRADIENT_PRESET_NAMES.map((name, idx) => (
+                        <Text key={name}>
+                            {idx === gradientIndex ? '▶ ' : '  '}
+                            {applyColors(name, `gradient:${name}`, undefined, idx === gradientIndex, level)}
+                        </Text>
+                    ))}
+                    <Text key='__custom' bold={gradientIndex === GRADIENT_PRESET_NAMES.length}>
+                        {gradientIndex === GRADIENT_PRESET_NAMES.length ? '▶ ' : '  '}
+                        Custom (start → end)
+                    </Text>
+                </Box>
+            </Box>
+        );
     }
 
     // Show confirmation dialog if clearing all colors
@@ -433,6 +581,7 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
                         {editingBackground ? 'background' : 'foreground'}
                         , (f) to toggle bg/fg, (b)old,
                         {settings.colorLevel === 3 ? ' (h)ex,' : settings.colorLevel === 2 ? ' (a)nsi256,' : ''}
+                        {!editingBackground && settings.colorLevel >= 2 ? ' (g)radient,' : ''}
                         {' '}
                         (r)eset, (c)lear all, ESC to go back
                     </Text>

--- a/src/utils/__tests__/color-sanitize.test.ts
+++ b/src/utils/__tests__/color-sanitize.test.ts
@@ -53,6 +53,21 @@ describe('color sanitize helpers', () => {
         expect(sanitized[0]?.[1]?.backgroundColor).toBe('hex:112233');
     });
 
+    it('leaves gradient colors untouched at every color level (they self-degrade at render time)', () => {
+        const lines: WidgetItem[][] = [[
+            { id: '1', type: 'model', color: 'gradient:retro' },
+            { id: '2', type: 'context-length', color: 'gradient:ff0000-0000ff' }
+        ]];
+
+        for (const level of [1, 2, 3] as const) {
+            const sanitized = sanitizeLinesForColorLevel(lines, level);
+            expect(sanitized[0]?.[0]?.color).toBe('gradient:retro');
+            expect(sanitized[0]?.[1]?.color).toBe('gradient:ff0000-0000ff');
+        }
+
+        expect(hasCustomWidgetColors(lines)).toBe(false);
+    });
+
     it('sanitizes all custom colors when moving to basic/no-color modes', () => {
         const lines: WidgetItem[][] = [[
             { id: '1', type: 'model', color: 'ansi256:99', backgroundColor: 'hex:123456' },

--- a/src/utils/__tests__/colors-gradient.test.ts
+++ b/src/utils/__tests__/colors-gradient.test.ts
@@ -1,0 +1,56 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import {
+    applyColors,
+    getColorAnsiCode
+} from '../colors';
+
+describe('applyColors with gradient foreground', () => {
+    it('renders a per-character gradient at truecolor with a single trailing reset', () => {
+        const out = applyColors('ABCD', 'gradient:retro', undefined, false, 'truecolor');
+        const codes = out.match(/\x1b\[38;2;\d+;\d+;\d+m/g) ?? [];
+        expect(codes.length).toBe(4);
+        // at least two distinct colors across the gradient
+        expect(new Set(codes).size).toBeGreaterThan(1);
+        // exactly one foreground reset, at the very end
+        expect(out.match(/\x1b\[39m/g) ?? []).toHaveLength(1);
+        expect(out.endsWith('\x1b[39m')).toBe(true);
+    });
+
+    it('keeps bold and background wrapping around the gradient body', () => {
+        // Use a hex background so the code is produced deterministically regardless of
+        // chalk.level (named colors emit nothing when chalk.level is 0, as in tests).
+        const out = applyColors('AB', 'gradient:ff0000-0000ff', 'hex:0000ff', true, 'truecolor');
+        expect(out.startsWith('\x1b[1m')).toBe(true); // bold opens first
+        expect(out).toContain('\x1b[48;2;0;0;255m'); // background code present
+        expect(out).toContain('\x1b[49m'); // background reset present
+        expect(out).toContain('\x1b[22m'); // bold reset present
+        expect(out).toContain('\x1b[39m'); // foreground reset present
+    });
+
+    it('falls back to a solid first stop at ansi16', () => {
+        const out = applyColors('ABCD', 'gradient:ff0000-0000ff', undefined, false, 'ansi16');
+        const codes = out.match(/\x1b\[38;2;\d+;\d+;\d+m/g) ?? [];
+        // single solid color for the whole text (first stop #ff0000)
+        expect(codes).toHaveLength(1);
+        expect(codes[0]).toBe('\x1b[38;2;255;0;0m');
+    });
+});
+
+describe('getColorAnsiCode with gradient (powerline path)', () => {
+    it('returns the first stop as a single truecolor code', () => {
+        expect(getColorAnsiCode('gradient:ff0000-0000ff', 'truecolor', false)).toBe('\x1b[38;2;255;0;0m');
+    });
+
+    it('returns a 256-color code at ansi256 level', () => {
+        expect(getColorAnsiCode('gradient:ff0000-0000ff', 'ansi256', false)).toBe('\x1b[38;5;196m');
+    });
+
+    it('returns empty string for an invalid gradient spec', () => {
+        expect(getColorAnsiCode('gradient:nope', 'truecolor', false)).toBe('');
+    });
+});

--- a/src/utils/__tests__/gradient.test.ts
+++ b/src/utils/__tests__/gradient.test.ts
@@ -1,0 +1,104 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import {
+    GRADIENT_PRESET_NAMES,
+    applyGradientToText,
+    parseGradientSpec,
+    rgbToAnsi256
+} from '../gradient';
+
+describe('parseGradientSpec', () => {
+    it('parses named presets case-insensitively', () => {
+        const retro = parseGradientSpec('gradient:retro');
+        expect(retro).not.toBeNull();
+        expect(retro?.stops).toHaveLength(9);
+        expect(retro?.hsv).toBe(false);
+
+        const upper = parseGradientSpec('gradient:RETRO');
+        expect(upper?.stops).toHaveLength(9);
+    });
+
+    it('flags hsv presets with their spin', () => {
+        const rainbow = parseGradientSpec('gradient:rainbow');
+        expect(rainbow?.hsv).toBe(true);
+        expect(rainbow?.hsvSpin).toBe('long');
+
+        const vice = parseGradientSpec('gradient:vice');
+        expect(vice?.hsv).toBe(true);
+        expect(vice?.hsvSpin).toBe('short');
+    });
+
+    it('parses custom start/end and multi-stop hex specs', () => {
+        const two = parseGradientSpec('gradient:ff5f6d-ffc371');
+        expect(two?.stops).toEqual(['#ff5f6d', '#ffc371']);
+        expect(two?.hsv).toBe(false);
+
+        const three = parseGradientSpec('gradient:ff0000-00ff00-0000ff');
+        expect(three?.stops).toEqual(['#ff0000', '#00ff00', '#0000ff']);
+    });
+
+    it('rejects invalid specs without throwing', () => {
+        expect(parseGradientSpec('gradient:')).toBeNull();
+        expect(parseGradientSpec('gradient:notapreset')).toBeNull();
+        expect(parseGradientSpec('gradient:ffffff')).toBeNull(); // single stop
+        expect(parseGradientSpec('gradient:gggggg-000000')).toBeNull(); // bad hex
+        expect(parseGradientSpec('hex:FF0000')).toBeNull();
+        expect(parseGradientSpec(undefined)).toBeNull();
+    });
+
+    it('exposes the list of preset names', () => {
+        expect(GRADIENT_PRESET_NAMES).toContain('retro');
+        expect(GRADIENT_PRESET_NAMES).toContain('rainbow');
+        expect(GRADIENT_PRESET_NAMES.length).toBeGreaterThanOrEqual(13);
+    });
+});
+
+describe('rgbToAnsi256', () => {
+    it('maps grayscale and cube anchors', () => {
+        expect(rgbToAnsi256(0, 0, 0)).toBe(16);
+        expect(rgbToAnsi256(255, 255, 255)).toBe(231);
+        expect(rgbToAnsi256(255, 0, 0)).toBe(196);
+        expect(rgbToAnsi256(128, 128, 128)).toBeGreaterThanOrEqual(232); // grayscale ramp
+    });
+});
+
+describe('applyGradientToText', () => {
+    const spec = parseGradientSpec('gradient:ff0000-0000ff');
+    if (!spec) {
+        throw new Error('expected a valid gradient spec');
+    }
+
+    it('emits one truecolor code per visible character and leaves spaces uncolored', () => {
+        const out = applyGradientToText('AB CD', spec, 'truecolor');
+        const codes = out.match(/\x1b\[38;2;\d+;\d+;\d+m/g) ?? [];
+        // 4 visible characters (A, B, C, D) -> exactly 4 codes; the space gets none
+        expect(codes).toHaveLength(4);
+        // no per-character reset inside the body
+        expect(out).not.toContain('\x1b[39m');
+        // the raw space survives in the output, and is immediately followed by the
+        // next character's color code (i.e. it consumed no gradient step)
+        expect(out).toContain(' \x1b[38;2;');
+        // gradient actually changes color: first and last codes differ
+        expect(codes[0]).not.toBe(codes[codes.length - 1]);
+    });
+
+    it('uses 256-color codes at ansi256 level', () => {
+        const out = applyGradientToText('ABCD', spec, 'ansi256');
+        const codes = out.match(/\x1b\[38;5;\d+m/g) ?? [];
+        expect(codes).toHaveLength(4);
+        expect(out).not.toContain('38;2;');
+    });
+
+    it('returns text unchanged at ansi16', () => {
+        expect(applyGradientToText('ABCD', spec, 'ansi16')).toBe('ABCD');
+    });
+
+    it('handles all-whitespace and empty input', () => {
+        expect(applyGradientToText('   ', spec, 'truecolor')).toBe('   ');
+        expect(applyGradientToText('', spec, 'truecolor')).toBe('');
+    });
+});

--- a/src/utils/__tests__/renderer-gradient.test.ts
+++ b/src/utils/__tests__/renderer-gradient.test.ts
@@ -1,0 +1,73 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import {
+    DEFAULT_SETTINGS,
+    type Settings
+} from '../../types/Settings';
+import type { WidgetItem } from '../../types/Widget';
+import {
+    calculateMaxWidthsFromPreRendered,
+    preRenderAllWidgets,
+    renderStatusLine
+} from '../renderer';
+
+function createSettings(overrides: Partial<Settings> = {}): Settings {
+    return {
+        ...DEFAULT_SETTINGS,
+        flexMode: 'full',
+        ...overrides,
+        powerline: {
+            ...DEFAULT_SETTINGS.powerline,
+            ...(overrides.powerline ?? {})
+        }
+    };
+}
+
+function renderLine(widgets: WidgetItem[], settingsOverrides: Partial<Settings> = {}): string {
+    const settings = createSettings(settingsOverrides);
+    const context: RenderContext = { isPreview: false, terminalWidth: 200 };
+    const preRenderedLines = preRenderAllWidgets([widgets], settings, context);
+    const preCalculatedMaxWidths = calculateMaxWidthsFromPreRendered(preRenderedLines, settings);
+    return renderStatusLine(widgets, settings, context, preRenderedLines[0] ?? [], preCalculatedMaxWidths);
+}
+
+describe('renderer gradient widget colors', () => {
+    it('renders a per-character gradient in the regular path', () => {
+        const widgets: WidgetItem[] = [
+            { id: 'w1', type: 'custom-text', customText: 'ABCDEF', color: 'gradient:retro' }
+        ];
+
+        const line = renderLine(widgets, { colorLevel: 3 });
+        const codes = line.match(/\x1b\[38;2;\d+;\d+;\d+m/g) ?? [];
+        // 6 visible characters -> 6 color codes, with several distinct colors
+        expect(codes.length).toBeGreaterThanOrEqual(6);
+        expect(new Set(codes).size).toBeGreaterThan(1);
+    });
+
+    it('degrades to a solid first-stop color in the powerline path', () => {
+        const widgets: WidgetItem[] = [
+            { id: 'w1', type: 'custom-text', customText: 'ABCDEF', color: 'gradient:retro', backgroundColor: 'bgBlue' }
+        ];
+
+        const line = renderLine(widgets, {
+            colorLevel: 3,
+            powerline: {
+                ...DEFAULT_SETTINGS.powerline,
+                enabled: true,
+                separators: [''],
+                separatorInvertBackground: [false]
+            }
+        });
+
+        // first stop of the retro preset is #3f51b1 -> rgb(63,81,177)
+        expect(line).toContain('\x1b[38;2;63;81;177m');
+        // not a per-character gradient: only one distinct foreground color for the text
+        const fgCodes = line.match(/\x1b\[38;2;\d+;\d+;\d+m/g) ?? [];
+        expect(new Set(fgCodes).size).toBe(1);
+    });
+});

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -2,6 +2,12 @@ import chalk, { type ChalkInstance } from 'chalk';
 
 import type { ColorEntry } from '../types/ColorEntry';
 
+import {
+    applyGradientToText,
+    parseGradientSpec,
+    rgbToAnsi256
+} from './gradient';
+
 // Re-export for backward compatibility
 export type { ColorEntry };
 
@@ -154,6 +160,14 @@ export function applyColors(
 
     // Apply foreground color
     if (foregroundColor) {
+        // Per-character gradient foreground. Only possible with a real color palette;
+        // at ansi16 (or for an unparseable spec) we fall through to a solid first stop
+        // via getColorAnsiCode below.
+        const gradientSpec = foregroundColor.startsWith('gradient:') ? parseGradientSpec(foregroundColor) : null;
+        if (gradientSpec && colorLevel !== 'ansi16') {
+            return prefix + applyGradientToText(text, gradientSpec, colorLevel) + '\x1b[39m' + suffix;
+        }
+
         const fgCode = getColorAnsiCode(foregroundColor, colorLevel, false);
         if (fgCode) {
             prefix += fgCode;
@@ -168,6 +182,27 @@ export function applyColors(
 export function getColorAnsiCode(colorName: string | undefined, colorLevel: 'ansi16' | 'ansi256' | 'truecolor' = 'ansi16', isBackground = false): string {
     if (!colorName)
         return '';
+
+    // Handle gradient:<name> / gradient:RRGGBB-RRGGBB format.
+    // A single ANSI code cannot represent a gradient, so collapse to the first stop
+    // as a solid color. The per-character gradient is produced in applyColors(); this
+    // path is what the powerline renderer (which calls getColorAnsiCode directly) sees.
+    if (colorName.startsWith('gradient:')) {
+        const spec = parseGradientSpec(colorName);
+        if (!spec)
+            return '';
+        const hex = spec.stops[0]?.replace(/^#/, '') ?? '';
+        if (!/^[0-9A-Fa-f]{6}$/.test(hex))
+            return '';
+        const r = parseInt(hex.substring(0, 2), 16);
+        const g = parseInt(hex.substring(2, 4), 16);
+        const b = parseInt(hex.substring(4, 6), 16);
+        if (colorLevel === 'ansi256') {
+            const code = rgbToAnsi256(r, g, b);
+            return isBackground ? `\x1b[48;5;${code}m` : `\x1b[38;5;${code}m`;
+        }
+        return isBackground ? `\x1b[48;2;${r};${g};${b}m` : `\x1b[38;2;${r};${g};${b}m`;
+    }
 
     // Handle ansi256:X format
     if (colorName.startsWith('ansi256:')) {

--- a/src/utils/gradient.ts
+++ b/src/utils/gradient.ts
@@ -1,0 +1,142 @@
+import tinygradient from 'tinygradient';
+
+// A parsed gradient definition ready to be interpolated.
+export interface GradientSpec {
+    stops: string[]; // hex colors including the leading '#'
+    hsv: boolean;
+    hsvSpin: 'short' | 'long';
+}
+
+interface PresetDef {
+    stops: string[];
+    hsv?: boolean;
+    hsvSpin?: 'short' | 'long';
+}
+
+// Named gradient presets. The color stops mirror the named gradients shipped by
+// `gradient-string` (pulled in transitively through `ink-gradient`), reproduced
+// here so the status line renderer can interpolate them without going through
+// the React/Ink rendering layer.
+// Source: gradient-string (MIT) - https://github.com/bokub/gradient-string
+export const GRADIENT_PRESETS: Record<string, PresetDef> = {
+    atlas: { stops: ['#feac5e', '#c779d0', '#4bc0c8'] },
+    cristal: { stops: ['#bdfff3', '#4ac29a'] },
+    teen: { stops: ['#77a1d3', '#79cbca', '#e684ae'] },
+    mind: { stops: ['#473b7b', '#3584a7', '#30d2be'] },
+    morning: { stops: ['#ff5f6d', '#ffc371'], hsv: true, hsvSpin: 'short' },
+    vice: { stops: ['#5ee7df', '#b490ca'], hsv: true, hsvSpin: 'short' },
+    passion: { stops: ['#f43b47', '#453a94'] },
+    fruit: { stops: ['#ff4e50', '#f9d423'] },
+    instagram: { stops: ['#833ab4', '#fd1d1d', '#fcb045'] },
+    retro: { stops: ['#3f51b1', '#5a55ae', '#7b5fac', '#8f6aae', '#a86aa4', '#cc6b8e', '#f18271', '#f3a469', '#f7c978'] },
+    summer: { stops: ['#fdbb2d', '#22c1c3'] },
+    rainbow: { stops: ['#ff0000', '#ff0100'], hsv: true, hsvSpin: 'long' },
+    pastel: { stops: ['#74ebd5', '#74ecd5'], hsv: true, hsvSpin: 'long' }
+};
+
+export const GRADIENT_PRESET_NAMES: string[] = Object.keys(GRADIENT_PRESETS);
+
+const HEX6 = /^[0-9A-Fa-f]{6}$/;
+
+// Parse a `gradient:<name>` or `gradient:RRGGBB-RRGGBB[-RRGGBB...]` color value.
+// Returns null for anything that is not a valid gradient spec (never throws).
+export function parseGradientSpec(color: string | undefined): GradientSpec | null {
+    if (!color?.startsWith('gradient:')) {
+        return null;
+    }
+
+    const body = color.slice('gradient:'.length);
+    if (!body) {
+        return null;
+    }
+
+    // Named preset (case-insensitive)
+    const preset = GRADIENT_PRESETS[body.toLowerCase()];
+    if (preset) {
+        return {
+            stops: preset.stops,
+            hsv: preset.hsv ?? false,
+            hsvSpin: preset.hsvSpin ?? 'short'
+        };
+    }
+
+    // Custom stops: RRGGBB-RRGGBB[-RRGGBB...] (at least 2 stops; tinygradient
+    // throws with fewer than 2).
+    const parts = body.split('-');
+    if (parts.length >= 2 && parts.every(p => HEX6.test(p))) {
+        return {
+            stops: parts.map(p => '#' + p),
+            hsv: false,
+            hsvSpin: 'short'
+        };
+    }
+
+    return null;
+}
+
+// Convert an RGB triple to the nearest xterm 256-color palette index.
+// Standard algorithm used by ansi-styles / chalk.
+export function rgbToAnsi256(r: number, g: number, b: number): number {
+    if (r === g && g === b) {
+        if (r < 8) {
+            return 16;
+        }
+        if (r > 248) {
+            return 231;
+        }
+        return Math.round(((r - 8) / 247) * 24) + 232;
+    }
+
+    return 16
+        + (36 * Math.round((r / 255) * 5))
+        + (6 * Math.round((g / 255) * 5))
+        + Math.round((b / 255) * 5);
+}
+
+// Apply a gradient across the visible characters of `text`, emitting one opening
+// color code per visible character. Whitespace is left uncolored (and does not
+// consume a gradient step), matching gradient-string's behavior. No reset code is
+// emitted here - the caller is responsible for the trailing `\x1b[39m`.
+//
+// At ansi16 the gradient cannot be represented; the text is returned unchanged and
+// the caller falls back to a solid first-stop color.
+export function applyGradientToText(
+    text: string,
+    spec: GradientSpec,
+    colorLevel: 'ansi16' | 'ansi256' | 'truecolor'
+): string {
+    if (colorLevel === 'ansi16' || text.length === 0) {
+        return text;
+    }
+
+    let visibleCount = 0;
+    for (const ch of text) {
+        if (!/\s/.test(ch)) {
+            visibleCount++;
+        }
+    }
+    const count = Math.max(visibleCount, spec.stops.length);
+    if (count === 0) {
+        return text;
+    }
+
+    const grad = tinygradient(spec.stops);
+    const colors = spec.hsv ? grad.hsv(count, spec.hsvSpin) : grad.rgb(count);
+
+    let result = '';
+    let i = 0;
+    for (const ch of text) {
+        if (/\s/.test(ch)) {
+            result += ch;
+            continue;
+        }
+
+        const color = colors[i++];
+        const { r, g, b } = color ? color.toRgb() : { r: 255, g: 255, b: 255 };
+        result += colorLevel === 'truecolor'
+            ? `\x1b[38;2;${r};${g};${b}m${ch}`
+            : `\x1b[38;5;${rgbToAnsi256(r, g, b)}m${ch}`;
+    }
+
+    return result;
+}


### PR DESCRIPTION
## What

Adds `gradient` as a selectable widget text color, alongside the existing solid colors. A widget's text can now be painted with a multi-stop color gradient spread across its characters.

Two forms are supported:
- **Named presets** — `gradient:atlas`, `gradient:rainbow`, `gradient:vice`, … (the named gradients shipped by `gradient-string`, reproduced as raw stops).
- **Custom stops** — `gradient:RRGGBB-RRGGBB[-RRGGBB...]` (2+ hex stops).

The `ColorMenu` TUI gains a gradient picker so it can be configured interactively.

## How

- New `src/utils/gradient.ts`: parses a `gradient:` color spec and interpolates it across the visible characters of the text, emitting one ANSI color code per character. Whitespace is skipped (matching `gradient-string` behavior).
- Color-level aware: truecolor → `38;2;r;g;b`, ansi256 → nearest xterm-256 index, ansi16 → falls back to a solid first-stop color (gradients can't be represented at 16 colors).
- `colors.ts` / `renderer.ts` hook the gradient path into the existing color application flow; non-gradient colors are unaffected.

## Why tinygradient (not gradient-string directly)

`gradient-string` (already present transitively via `ink-gradient`) is built to emit chalk/ink-styled strings at the render layer. The status line renderer needs raw, per-character ANSI codes at a specific color level (with 256-color downsampling and whitespace handling) outside the React/Ink layer, so this uses `tinygradient` — the underlying interpolation primitive — directly. Preset stops are reproduced from `gradient-string` (MIT) with attribution in the source.

## Tests

Adds focused tests for gradient parsing, color interpolation, 256-color downsampling, sanitization, and renderer integration. Full suite green.