### PR TITLE
feat: line-spanning foreground gradients via overrideForegroundColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@
 ### v2.0.0 - Powerline Support & Enhanced Themes
 - **⚡ Powerline Mode** - Beautiful Powerline-style status lines with arrow separators and customizable caps
 - **🎨 Built-in Themes** - Multiple pre-configured themes that you can copy and customize
-- **🌈 Advanced Color Support** - Basic (16), 256-color (with custom ANSI codes), and truecolor (with hex codes) modes
+- **🌈 Advanced Color Support** - Basic (16), 256-color (with custom ANSI codes), and truecolor (with hex codes) modes, plus multi-stop **gradients** (per-widget or spanning the whole line)
 - **🔗 Widget Merging** - Merge multiple widgets together with or without padding for seamless designs
 - **📦 Easy Installation** - Install directly with `npx` or `bunx` - no global package needed
 - **🔤 Custom Separators** - Add multiple Powerline separators with custom hex codes for font support

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -91,7 +91,7 @@ Configure global formatting preferences that apply to all widgets:
   - Press **(o)** to toggle
 - **Minimalist Mode** - Force widgets into raw-value rendering globally for a cleaner, label-free status line
   - Press **(m)** to toggle
-- **Override Foreground Color** - Force all widgets to use the same text color
+- **Override Foreground Color** - Force all widgets to use the same text color, or a whole-line **gradient** (see below)
   - Press **(f)** to cycle through colors
   - Press **(g)** to clear override
 - **Override Background Color** - Force all widgets to use the same background color
@@ -103,6 +103,21 @@ Configure global formatting preferences that apply to all widgets:
 > 💡 **Note:** These settings are applied during rendering and don't add widgets to your widget list. They provide a consistent look across your entire status line without modifying individual widget configurations.
 
 > ⚠️ **VSCode Users:** If colors appear incorrect in the VSCode integrated terminal, the "Terminal › Integrated: Minimum Contrast Ratio" (`terminal.integrated.minimumContrastRatio`) setting is forcing a minimum contrast between foreground and background colors. You can adjust this setting to 1 to disable the contrast enforcement, or use a standalone terminal for accurate colors.
+
+## Gradient Colors
+
+A foreground color can be a multi-stop **gradient** instead of a solid. Colors interpolate in OKLab for perceptually even blends. A gradient value takes one of three forms, all prefixed `gradient:`:
+
+- **Named preset** — `gradient:atlas` (case-insensitive). Built-in presets: `atlas`, `cristal`, `teen`, `mind`, `morning`, `vice`, `passion`, `fruit`, `instagram`, `retro`, `summer`, `rainbow`, `pastel`.
+- **Dash stops** — `gradient:RRGGBB-RRGGBB[-RRGGBB...]` (two or more bare or `#`-prefixed hex stops).
+- **Comma stops** — `gradient:hex:RRGGBB,#RRGGBB,RRGGBB` (two or more `hex:`/`#`/bare stops).
+
+Gradients apply at **two scopes**:
+
+- **Per-widget** — set a widget's color to a gradient so its text carries its own self-contained sweep. In the color menu (foreground, 256-color or truecolor mode), press **(g)** to open the gradient picker, then choose a preset or enter custom start/end hex stops.
+- **Whole line** — set `overrideForegroundColor` to a gradient spec to paint the entire status line with one continuous sweep, each character colored by its column position. (Authored in `settings.json`; the TUI's override cycler covers solid colors only.)
+
+Gradients self-degrade where they can't render: at the basic 16-color level a per-widget gradient collapses to its first stop and a whole-line gradient is skipped; in Powerline mode the whole-line gradient is ignored (separators derive their foreground from adjacent backgrounds) and per-widget gradients collapse to their first stop.
 
 ## Claude Code Status Line Settings
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -93,7 +93,8 @@ Configure global formatting preferences that apply to all widgets:
   - Press **(m)** to toggle
 - **Override Foreground Color** - Force all widgets to use the same text color, or a whole-line **gradient** (see below)
   - Press **(f)** to cycle through colors
-  - Press **(g)** to clear override
+  - Press **(g)** to choose a gradient
+  - Press **(x)** to clear override
 - **Override Background Color** - Force all widgets to use the same background color
   - Press **(b)** to cycle through colors
   - Press **(c)** to clear override
@@ -115,9 +116,9 @@ A foreground color can be a multi-stop **gradient** instead of a solid. Colors i
 Gradients apply at **two scopes**:
 
 - **Per-widget** — set a widget's color to a gradient so its text carries its own self-contained sweep. In the color menu (foreground, 256-color or truecolor mode), press **(g)** to open the gradient picker, then choose a preset or enter custom start/end hex stops.
-- **Whole line** — set `overrideForegroundColor` to a gradient spec to paint the entire status line with one continuous sweep, each character colored by its column position. (Authored in `settings.json`; the TUI's override cycler covers solid colors only.)
+- **Whole line** — set `overrideForegroundColor` to a gradient spec to paint the entire status line with one continuous sweep, each character colored by its column position. In the Global Overrides menu, press **(g)** on Override FG Color to open the same gradient picker, or author the value directly in `settings.json`.
 
-Gradients self-degrade where they can't render: at the basic 16-color level a per-widget gradient collapses to its first stop and a whole-line gradient is skipped; in Powerline mode the whole-line gradient is ignored (separators derive their foreground from adjacent backgrounds) and per-widget gradients collapse to their first stop.
+Gradients self-degrade where they can't render: at Basic or No Color levels, gradient settings are preserved but render as plain text. In Powerline mode, global foreground gradients color widget text while separators and caps keep Powerline's normal foreground/background contrast rules; per-widget gradients collapse to their first stop when using 256-color or truecolor output.
 
 ## Claude Code Status Line Settings
 

--- a/src/tui/components/ColorMenu.tsx
+++ b/src/tui/components/ColorMenu.tsx
@@ -15,6 +15,7 @@ import {
     getAvailableBackgroundColorsForUI,
     getAvailableColorsForUI
 } from '../../utils/colors';
+import { GRADIENT_PRESET_NAMES } from '../../utils/gradient';
 import { shouldInsertInput } from '../../utils/input-guards';
 import { getWidget } from '../../utils/widgets';
 
@@ -42,6 +43,11 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
     const [ansi256InputMode, setAnsi256InputMode] = useState(false);
     const [ansi256Input, setAnsi256Input] = useState('');
     const [showClearConfirm, setShowClearConfirm] = useState(false);
+    const [gradientMode, setGradientMode] = useState(false);
+    const [gradientIndex, setGradientIndex] = useState(0);
+    const [gradientCustomStep, setGradientCustomStep] = useState<'start' | 'end' | null>(null);
+    const [gradientStartHex, setGradientStartHex] = useState('');
+    const [gradientHexInput, setGradientHexInput] = useState('');
 
     const powerlineEnabled = settings.powerline.enabled;
 
@@ -146,6 +152,69 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
             return;
         }
 
+        // Handle gradient selection mode
+        if (gradientMode) {
+            const exitGradient = () => {
+                setGradientMode(false);
+                setGradientCustomStep(null);
+                setGradientStartHex('');
+                setGradientHexInput('');
+            };
+
+            const applyGradientValue = (value: string) => {
+                const selectedWidget = colorableWidgets.find(widget => widget.id === highlightedItemId);
+                if (selectedWidget) {
+                    onUpdate(setWidgetColor(widgets, selectedWidget.id, value, false));
+                }
+                exitGradient();
+            };
+
+            // Custom start/end hex entry
+            if (gradientCustomStep) {
+                if (key.escape) {
+                    setGradientCustomStep(null);
+                    setGradientHexInput('');
+                } else if (key.return) {
+                    if (gradientHexInput.length === 6) {
+                        if (gradientCustomStep === 'start') {
+                            setGradientStartHex(gradientHexInput);
+                            setGradientHexInput('');
+                            setGradientCustomStep('end');
+                        } else {
+                            applyGradientValue(`gradient:${gradientStartHex}-${gradientHexInput}`);
+                        }
+                    }
+                } else if (key.backspace || key.delete) {
+                    setGradientHexInput(gradientHexInput.slice(0, -1));
+                } else if (shouldInsertInput(input, key) && gradientHexInput.length < 6) {
+                    const upperInput = input.toUpperCase();
+                    if (/^[0-9A-F]$/.test(upperInput)) {
+                        setGradientHexInput(gradientHexInput + upperInput);
+                    }
+                }
+                return;
+            }
+
+            // Preset list navigation (last item is the "Custom" entry)
+            const total = GRADIENT_PRESET_NAMES.length + 1;
+            if (key.escape) {
+                exitGradient();
+            } else if (key.upArrow) {
+                setGradientIndex((gradientIndex - 1 + total) % total);
+            } else if (key.downArrow) {
+                setGradientIndex((gradientIndex + 1) % total);
+            } else if (key.return) {
+                if (gradientIndex < GRADIENT_PRESET_NAMES.length) {
+                    applyGradientValue(`gradient:${GRADIENT_PRESET_NAMES[gradientIndex]}`);
+                } else {
+                    setGradientStartHex('');
+                    setGradientHexInput('');
+                    setGradientCustomStep('start');
+                }
+            }
+            return;
+        }
+
         // Ignore number keys to prevent SelectInput numerical navigation
         if (input && /^[0-9]$/.test(input)) {
             return;
@@ -169,6 +238,15 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
             if (highlightedItemId && highlightedItemId !== 'back' && settings.colorLevel === 2) {
                 setAnsi256InputMode(true);
                 setAnsi256Input('');
+            }
+        } else if (input === 'g' || input === 'G') {
+            // Enter gradient selection mode (foreground only, needs a real color palette)
+            if (highlightedItemId && highlightedItemId !== 'back' && !editingBackground && settings.colorLevel >= 2) {
+                setGradientMode(true);
+                setGradientIndex(0);
+                setGradientCustomStep(null);
+                setGradientStartHex('');
+                setGradientHexInput('');
             }
         } else if ((input === 's' || input === 'S') && !key.ctrl) {
             // Toggle show separators (only if not in powerline mode and no default separator)
@@ -336,6 +414,13 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
                 displayName = `ANSI ${currentColor.substring(8)}`;
             } else if (currentColor.startsWith('hex:')) {
                 displayName = `#${currentColor.substring(4)}`;
+            } else if (currentColor.startsWith('gradient:')) {
+                const body = currentColor.substring(9);
+                if (GRADIENT_PRESET_NAMES.includes(body.toLowerCase())) {
+                    displayName = `Gradient: ${body.toLowerCase()}`;
+                } else {
+                    displayName = `Gradient: ${body}`;
+                }
             } else {
                 const colorOption = colorOptions.find(c => c.value === currentColor);
                 displayName = colorOption ? colorOption.name : currentColor;
@@ -345,6 +430,63 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
             const level = getColorLevelString(settings.colorLevel);
             colorDisplay = applyColors(displayName, currentColor, undefined, false, level);
         }
+    }
+
+    // Gradient selection mode takes over the whole view
+    if (gradientMode) {
+        const level = getColorLevelString(settings.colorLevel);
+        const widgetName = selectedWidget ? getItemLabel(selectedWidget) : '';
+
+        if (gradientCustomStep) {
+            return (
+                <Box flexDirection='column'>
+                    <Text bold>
+                        Custom Gradient
+                        {widgetName ? ` - ${widgetName}` : ''}
+                    </Text>
+                    <Box marginTop={1} flexDirection='column'>
+                        <Text>{gradientCustomStep === 'start' ? 'Enter START hex color (without #):' : 'Enter END hex color (without #):'}</Text>
+                        {gradientCustomStep === 'end' && (
+                            <Text dimColor>
+                                Start: #
+                                {gradientStartHex}
+                            </Text>
+                        )}
+                        <Text>
+                            #
+                            {gradientHexInput}
+                            <Text dimColor>{gradientHexInput.length < 6 ? '_'.repeat(6 - gradientHexInput.length) : ''}</Text>
+                        </Text>
+                        <Text> </Text>
+                        <Text dimColor>Press Enter when done, ESC to go back</Text>
+                    </Box>
+                </Box>
+            );
+        }
+
+        return (
+            <Box flexDirection='column'>
+                <Text bold>
+                    Select Gradient
+                    {widgetName ? ` - ${widgetName}` : ''}
+                </Text>
+                <Box marginTop={1}>
+                    <Text dimColor>↑↓ to select, Enter to apply, ESC to cancel</Text>
+                </Box>
+                <Box marginTop={1} flexDirection='column'>
+                    {GRADIENT_PRESET_NAMES.map((name, idx) => (
+                        <Text key={name}>
+                            {idx === gradientIndex ? '▶ ' : '  '}
+                            {applyColors(name, `gradient:${name}`, undefined, idx === gradientIndex, level)}
+                        </Text>
+                    ))}
+                    <Text key='custom'>
+                        {gradientIndex === GRADIENT_PRESET_NAMES.length ? '▶ ' : '  '}
+                        Custom (enter two hex stops)
+                    </Text>
+                </Box>
+            </Box>
+        );
     }
 
     // Show confirmation dialog if clearing all colors
@@ -433,6 +575,7 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
                         {editingBackground ? 'background' : 'foreground'}
                         , (f) to toggle bg/fg, (b)old,
                         {settings.colorLevel === 3 ? ' (h)ex,' : settings.colorLevel === 2 ? ' (a)nsi256,' : ''}
+                        {!editingBackground && settings.colorLevel >= 2 ? ' (g)radient,' : ''}
                         {' '}
                         (r)eset, (c)lear all, ESC to go back
                     </Text>

--- a/src/tui/components/GlobalOverridesMenu.tsx
+++ b/src/tui/components/GlobalOverridesMenu.tsx
@@ -5,12 +5,15 @@ import {
 } from 'ink';
 import React, { useState } from 'react';
 
+import { getColorLevelString } from '../../types/ColorLevel';
 import type { Settings } from '../../types/Settings';
 import {
     COLOR_MAP,
+    applyColors,
     getChalkColor,
     getColorDisplayName
 } from '../../utils/colors';
+import { GRADIENT_PRESET_NAMES } from '../../utils/gradient';
 import { shouldInsertInput } from '../../utils/input-guards';
 
 import { ConfirmDialog } from './ConfirmDialog';
@@ -30,6 +33,11 @@ export const GlobalOverridesMenu: React.FC<GlobalOverridesMenuProps> = ({ settin
     const [inheritColors, setInheritColors] = useState(settings.inheritSeparatorColors);
     const [globalBold, setGlobalBold] = useState(settings.globalBold);
     const [minimalistMode, setMinimalistMode] = useState(settings.minimalistMode);
+    const [gradientMode, setGradientMode] = useState(false);
+    const [gradientIndex, setGradientIndex] = useState(0);
+    const [gradientCustomStep, setGradientCustomStep] = useState<'start' | 'end' | null>(null);
+    const [gradientStartHex, setGradientStartHex] = useState('');
+    const [gradientHexInput, setGradientHexInput] = useState('');
     const isPowerlineEnabled = settings.powerline.enabled;
 
     // Check if there are any manual separators in the current configuration
@@ -94,6 +102,63 @@ export const GlobalOverridesMenu: React.FC<GlobalOverridesMenuProps> = ({ settin
         } else if (confirmingSeparator) {
             // Skip input handling when confirmation is active - let ConfirmDialog handle it
             return;
+        } else if (gradientMode) {
+            const exitGradient = () => {
+                setGradientMode(false);
+                setGradientCustomStep(null);
+                setGradientStartHex('');
+                setGradientHexInput('');
+            };
+
+            const applyGradientValue = (value: string) => {
+                onUpdate({
+                    ...settings,
+                    overrideForegroundColor: value
+                });
+                exitGradient();
+            };
+
+            if (gradientCustomStep) {
+                if (key.escape) {
+                    setGradientCustomStep(null);
+                    setGradientHexInput('');
+                } else if (key.return) {
+                    if (gradientHexInput.length === 6) {
+                        if (gradientCustomStep === 'start') {
+                            setGradientStartHex(gradientHexInput);
+                            setGradientHexInput('');
+                            setGradientCustomStep('end');
+                        } else {
+                            applyGradientValue(`gradient:${gradientStartHex}-${gradientHexInput}`);
+                        }
+                    }
+                } else if (key.backspace || key.delete) {
+                    setGradientHexInput(gradientHexInput.slice(0, -1));
+                } else if (shouldInsertInput(input, key) && gradientHexInput.length < 6) {
+                    const upperInput = input.toUpperCase();
+                    if (/^[0-9A-F]$/.test(upperInput)) {
+                        setGradientHexInput(gradientHexInput + upperInput);
+                    }
+                }
+                return;
+            }
+
+            const total = GRADIENT_PRESET_NAMES.length + 1;
+            if (key.escape) {
+                exitGradient();
+            } else if (key.upArrow) {
+                setGradientIndex((gradientIndex - 1 + total) % total);
+            } else if (key.downArrow) {
+                setGradientIndex((gradientIndex + 1) % total);
+            } else if (key.return) {
+                if (gradientIndex < GRADIENT_PRESET_NAMES.length) {
+                    applyGradientValue(`gradient:${GRADIENT_PRESET_NAMES[gradientIndex]}`);
+                } else {
+                    setGradientStartHex('');
+                    setGradientHexInput('');
+                    setGradientCustomStep('start');
+                }
+            }
         } else {
             if (key.escape) {
                 onBack();
@@ -153,6 +218,13 @@ export const GlobalOverridesMenu: React.FC<GlobalOverridesMenuProps> = ({ settin
                 };
                 onUpdate(updatedSettings);
             } else if (input === 'g' || input === 'G') {
+                // Enter gradient selection mode
+                setGradientMode(true);
+                setGradientIndex(0);
+                setGradientCustomStep(null);
+                setGradientStartHex('');
+                setGradientHexInput('');
+            } else if (input === 'x' || input === 'X') {
                 // Clear override foreground color
                 const updatedSettings = {
                     ...settings,
@@ -162,6 +234,55 @@ export const GlobalOverridesMenu: React.FC<GlobalOverridesMenuProps> = ({ settin
             }
         }
     });
+
+    if (gradientMode) {
+        const level = getColorLevelString(settings.colorLevel);
+
+        if (gradientCustomStep) {
+            return (
+                <Box flexDirection='column'>
+                    <Text bold>Custom Gradient - Override FG Color</Text>
+                    <Box marginTop={1} flexDirection='column'>
+                        <Text>{gradientCustomStep === 'start' ? 'Enter START hex color (without #):' : 'Enter END hex color (without #):'}</Text>
+                        {gradientCustomStep === 'end' && (
+                            <Text dimColor>
+                                Start: #
+                                {gradientStartHex}
+                            </Text>
+                        )}
+                        <Text>
+                            #
+                            {gradientHexInput}
+                            <Text dimColor>{gradientHexInput.length < 6 ? '_'.repeat(6 - gradientHexInput.length) : ''}</Text>
+                        </Text>
+                        <Text> </Text>
+                        <Text dimColor>Press Enter when done, ESC to go back</Text>
+                    </Box>
+                </Box>
+            );
+        }
+
+        return (
+            <Box flexDirection='column'>
+                <Text bold>Select Gradient - Override FG Color</Text>
+                <Box marginTop={1}>
+                    <Text dimColor>↑↓ to select, Enter to apply, ESC to cancel</Text>
+                </Box>
+                <Box marginTop={1} flexDirection='column'>
+                    {GRADIENT_PRESET_NAMES.map((name, idx) => (
+                        <Text key={name}>
+                            {idx === gradientIndex ? '▶ ' : '  '}
+                            {applyColors(name, `gradient:${name}`, undefined, idx === gradientIndex, level)}
+                        </Text>
+                    ))}
+                    <Text key='custom'>
+                        {gradientIndex === GRADIENT_PRESET_NAMES.length ? '▶ ' : '  '}
+                        Custom (enter two hex stops)
+                    </Text>
+                </Box>
+            </Box>
+        );
+    }
 
     return (
         <Box flexDirection='column'>
@@ -250,6 +371,13 @@ export const GlobalOverridesMenu: React.FC<GlobalOverridesMenuProps> = ({ settin
                             const fgColor = settings.overrideForegroundColor ?? 'none';
                             if (fgColor === 'none') {
                                 return <Text color='gray'>(none)</Text>;
+                            } else if (fgColor.startsWith('gradient:')) {
+                                const body = fgColor.substring(9);
+                                const displayName = GRADIENT_PRESET_NAMES.includes(body.toLowerCase())
+                                    ? `Gradient: ${body.toLowerCase()}`
+                                    : `Gradient: ${body}`;
+                                const level = getColorLevelString(settings.colorLevel);
+                                return <Text>{applyColors(displayName, fgColor, undefined, false, level)}</Text>;
                             } else {
                                 const displayName = getColorDisplayName(fgColor);
                                 const fgChalk = getChalkColor(fgColor, 'ansi16', false);
@@ -257,7 +385,7 @@ export const GlobalOverridesMenu: React.FC<GlobalOverridesMenuProps> = ({ settin
                                 return <Text>{display}</Text>;
                             }
                         })()}
-                        <Text dimColor> - (f) cycle, (g) clear</Text>
+                        <Text dimColor> - (f) cycle, (g) gradient, (x) clear</Text>
                     </Box>
 
                     <Box>

--- a/src/tui/components/PowerlineSetup.tsx
+++ b/src/tui/components/PowerlineSetup.tsx
@@ -169,6 +169,8 @@ export const PowerlineSetup: React.FC<PowerlineSetupProps> = ({
     const hasSeparatorItems = settings.lines.some(line => line.some(
         item => item.type === 'separator' || item.type === 'flex-separator'
     ));
+    const hasGlobalFgOverride = Boolean(settings.overrideForegroundColor && settings.overrideForegroundColor !== 'none');
+    const globalOverrideMessage = hasGlobalFgOverride ? '⚠ Global override for FG active' : null;
 
     useInput((input, key) => {
         if (fontInstallMessage || installingFonts) {
@@ -269,7 +271,15 @@ export const PowerlineSetup: React.FC<PowerlineSetupProps> = ({
     return (
         <Box flexDirection='column'>
             {!confirmingFontInstall && !installingFonts && !fontInstallMessage && (
-                <Text bold>Powerline Setup</Text>
+                <Box>
+                    <Text bold>Powerline Setup</Text>
+                    {globalOverrideMessage && (
+                        <Text color='yellow' dimColor>
+                            {'.  '}
+                            {globalOverrideMessage}
+                        </Text>
+                    )}
+                </Box>
             )}
 
             {confirmingFontInstall ? (
@@ -423,7 +433,7 @@ export const PowerlineSetup: React.FC<PowerlineSetupProps> = ({
 
                             <Box flexDirection='column' marginTop={1}>
                                 <Text dimColor>
-                                    When enabled, global overrides are disabled and powerline separators are used
+                                    Powerline mode uses its own separator system
                                 </Text>
                                 <Text dimColor>
                                     Continue Theme keeps the Powerline color sequence running across lines

--- a/src/tui/components/__tests__/GlobalOverridesMenu.test.ts
+++ b/src/tui/components/__tests__/GlobalOverridesMenu.test.ts
@@ -179,4 +179,121 @@ describe('GlobalOverridesMenu', () => {
             stderr.destroy();
         }
     });
+
+    it('shows foreground override gradient and clear controls on the same line', async () => {
+        const stdin = createMockStdin();
+        const stdout = createMockStdout();
+        const stderr = createMockStdout();
+        const onUpdate = vi.fn();
+        const onBack = vi.fn();
+
+        const instance = render(
+            React.createElement(GlobalOverridesMenu, {
+                settings: DEFAULT_SETTINGS,
+                onUpdate,
+                onBack
+            }),
+            {
+                stdin,
+                stdout,
+                stderr,
+                debug: true,
+                exitOnCtrlC: false,
+                patchConsole: false
+            }
+        );
+
+        try {
+            await flushInk();
+            const output = stdout.getOutput();
+            expect(output).toContain('Override FG Color:');
+            expect(output).toContain('(f) cycle, (g) gradient, (x) clear');
+        } finally {
+            instance.unmount();
+            instance.cleanup();
+            stdin.destroy();
+            stdout.destroy();
+            stderr.destroy();
+        }
+    });
+
+    it('applies a foreground override gradient from the preset selector', async () => {
+        const stdin = createMockStdin();
+        const stdout = createMockStdout();
+        const stderr = createMockStdout();
+        const onUpdate = vi.fn();
+        const onBack = vi.fn();
+
+        const instance = render(
+            React.createElement(GlobalOverridesMenu, {
+                settings: { ...DEFAULT_SETTINGS, colorLevel: 3 },
+                onUpdate,
+                onBack
+            }),
+            {
+                stdin,
+                stdout,
+                stderr,
+                debug: true,
+                exitOnCtrlC: false,
+                patchConsole: false
+            }
+        );
+
+        try {
+            await flushInk();
+            stdin.write('g');
+            await flushInk();
+            expect(stdout.getOutput()).toContain('Select Gradient - Override FG Color');
+
+            stdin.write('\r');
+            await flushInk();
+
+            expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ overrideForegroundColor: 'gradient:atlas' }));
+        } finally {
+            instance.unmount();
+            instance.cleanup();
+            stdin.destroy();
+            stdout.destroy();
+            stderr.destroy();
+        }
+    });
+
+    it('clears the foreground override when (x) is pressed', async () => {
+        const stdin = createMockStdin();
+        const stdout = createMockStdout();
+        const stderr = createMockStdout();
+        const onUpdate = vi.fn();
+        const onBack = vi.fn();
+
+        const instance = render(
+            React.createElement(GlobalOverridesMenu, {
+                settings: { ...DEFAULT_SETTINGS, overrideForegroundColor: 'gradient:atlas' },
+                onUpdate,
+                onBack
+            }),
+            {
+                stdin,
+                stdout,
+                stderr,
+                debug: true,
+                exitOnCtrlC: false,
+                patchConsole: false
+            }
+        );
+
+        try {
+            await flushInk();
+            stdin.write('x');
+            await flushInk();
+
+            expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ overrideForegroundColor: undefined }));
+        } finally {
+            instance.unmount();
+            instance.cleanup();
+            stdin.destroy();
+            stdout.destroy();
+            stderr.destroy();
+        }
+    });
 });

--- a/src/tui/components/__tests__/PowerlineSetup.test.ts
+++ b/src/tui/components/__tests__/PowerlineSetup.test.ts
@@ -179,6 +179,56 @@ describe('PowerlineSetup helpers', () => {
             stderr.destroy();
         }
     });
+
+    it('warns when a global foreground override is active', async () => {
+        const stdin = createMockStdin();
+        const stdout = createMockStdout();
+        const stderr = createMockStdout();
+        const onUpdate = vi.fn<PowerlineSetupProps['onUpdate']>();
+        const onBack = vi.fn();
+        const onInstallFonts = vi.fn();
+        const onClearMessage = vi.fn();
+        const instance = render(
+            React.createElement(PowerlineSetup, {
+                settings: {
+                    ...DEFAULT_SETTINGS,
+                    overrideForegroundColor: 'gradient:atlas',
+                    powerline: {
+                        ...DEFAULT_SETTINGS.powerline,
+                        enabled: true
+                    }
+                },
+                powerlineFontStatus: { installed: true },
+                onUpdate,
+                onBack,
+                onInstallFonts,
+                installingFonts: false,
+                fontInstallMessage: null,
+                onClearMessage
+            }),
+            {
+                stdin,
+                stdout,
+                stderr,
+                debug: true,
+                exitOnCtrlC: false,
+                patchConsole: false
+            }
+        );
+
+        try {
+            await flushInk();
+
+            expect(stdout.getOutput()).toContain('Powerline Setup');
+            expect(stdout.getOutput()).toContain('⚠ Global override for FG active');
+        } finally {
+            instance.unmount();
+            instance.cleanup();
+            stdin.destroy();
+            stdout.destroy();
+            stderr.destroy();
+        }
+    });
 });
 
 describe('PowerlineSeparatorEditor', () => {

--- a/src/utils/__tests__/color-sanitize.test.ts
+++ b/src/utils/__tests__/color-sanitize.test.ts
@@ -67,4 +67,20 @@ describe('color sanitize helpers', () => {
         expect(sanitized[0]?.[1]?.color).toBe('hex:ABCDEF');
         expect(sanitized[0]?.[1]?.backgroundColor).toBeUndefined();
     });
+
+    it('leaves gradient colors untouched at every color level (they self-degrade at render time)', () => {
+        const lines: WidgetItem[][] = [[
+            { id: '1', type: 'model', color: 'gradient:retro' },
+            { id: '2', type: 'context-length', color: 'gradient:FF0000-0000FF' }
+        ]];
+
+        for (const level of [1, 2, 3] as const) {
+            const sanitized = sanitizeLinesForColorLevel(lines, level);
+            expect(sanitized[0]?.[0]?.color).toBe('gradient:retro');
+            expect(sanitized[0]?.[1]?.color).toBe('gradient:FF0000-0000FF');
+        }
+
+        // Gradients are not "custom colors" for sanitize purposes - they degrade at render.
+        expect(hasCustomWidgetColors(lines)).toBe(false);
+    });
 });

--- a/src/utils/__tests__/colors-gradient.test.ts
+++ b/src/utils/__tests__/colors-gradient.test.ts
@@ -1,0 +1,63 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import {
+    applyColors,
+    getColorAnsiCode
+} from '../colors';
+
+const TRUECOLOR_CODE = /\x1b\[38;2;\d+;\d+;\d+m/g;
+const ANSI256_CODE = /\x1b\[38;5;\d+m/g;
+
+function countMatches(text: string, pattern: RegExp): number {
+    return text.match(pattern)?.length ?? 0;
+}
+
+describe('applyColors with a per-widget gradient foreground', () => {
+    const gradient = 'gradient:FF0000-0000FF';
+
+    it('paints each visible character at truecolor and closes with a reset', () => {
+        const out = applyColors('abcd', gradient, undefined, false, 'truecolor');
+        expect(countMatches(out, TRUECOLOR_CODE)).toBe(4);
+        expect(out.endsWith('\x1b[39m')).toBe(true);
+    });
+
+    it('uses 256-color escapes at ansi256 level', () => {
+        const out = applyColors('abc', gradient, undefined, false, 'ansi256');
+        expect(countMatches(out, ANSI256_CODE)).toBe(3);
+        expect(countMatches(out, TRUECOLOR_CODE)).toBe(0);
+    });
+
+    it('collapses to a single solid first-stop code at ansi16', () => {
+        const out = applyColors('abcd', gradient, undefined, false, 'ansi16');
+        // gradient cannot render at ansi16, so the first stop is applied once
+        expect(countMatches(out, TRUECOLOR_CODE)).toBe(1);
+        expect(out).toContain('\x1b[38;2;255;0;0m');
+    });
+
+    it('preserves a resolvable named preset', () => {
+        const out = applyColors('hello', 'gradient:atlas', undefined, false, 'truecolor');
+        expect(countMatches(out, TRUECOLOR_CODE)).toBe(5);
+    });
+});
+
+describe('getColorAnsiCode gradient first-stop fallback (powerline / ansi16 path)', () => {
+    it('collapses a gradient to its first stop as a solid foreground', () => {
+        expect(getColorAnsiCode('gradient:FF0000-0000FF', 'truecolor', false)).toBe('\x1b[38;2;255;0;0m');
+    });
+
+    it('honors the background flag', () => {
+        expect(getColorAnsiCode('gradient:FF0000-0000FF', 'truecolor', true)).toBe('\x1b[48;2;255;0;0m');
+    });
+
+    it('maps the first stop into the 256-color palette at ansi256', () => {
+        expect(getColorAnsiCode('gradient:FF0000-0000FF', 'ansi256', false)).toBe('\x1b[38;5;196m');
+    });
+
+    it('returns empty for an unparseable gradient spec', () => {
+        expect(getColorAnsiCode('gradient:not-a-color', 'truecolor', false)).toBe('');
+    });
+});

--- a/src/utils/__tests__/colors-gradient.test.ts
+++ b/src/utils/__tests__/colors-gradient.test.ts
@@ -31,11 +31,11 @@ describe('applyColors with a per-widget gradient foreground', () => {
         expect(countMatches(out, TRUECOLOR_CODE)).toBe(0);
     });
 
-    it('collapses to a single solid first-stop code at ansi16', () => {
+    it('emits no gradient color at ansi16', () => {
         const out = applyColors('abcd', gradient, undefined, false, 'ansi16');
-        // gradient cannot render at ansi16, so the first stop is applied once
-        expect(countMatches(out, TRUECOLOR_CODE)).toBe(1);
-        expect(out).toContain('\x1b[38;2;255;0;0m');
+        expect(out).toBe('abcd');
+        expect(countMatches(out, TRUECOLOR_CODE)).toBe(0);
+        expect(countMatches(out, ANSI256_CODE)).toBe(0);
     });
 
     it('preserves a resolvable named preset', () => {
@@ -55,6 +55,11 @@ describe('getColorAnsiCode gradient first-stop fallback (powerline / ansi16 path
 
     it('maps the first stop into the 256-color palette at ansi256', () => {
         expect(getColorAnsiCode('gradient:FF0000-0000FF', 'ansi256', false)).toBe('\x1b[38;5;196m');
+    });
+
+    it('returns empty at ansi16 so gradients do not leak higher color levels', () => {
+        expect(getColorAnsiCode('gradient:FF0000-0000FF', 'ansi16', false)).toBe('');
+        expect(getColorAnsiCode('gradient:FF0000-0000FF', 'ansi16', true)).toBe('');
     });
 
     it('returns empty for an unparseable gradient spec', () => {

--- a/src/utils/__tests__/gradient.test.ts
+++ b/src/utils/__tests__/gradient.test.ts
@@ -12,6 +12,7 @@ import {
 import type { WidgetItem } from '../../types/Widget';
 import {
     applyLineGradient,
+    getVisibleText,
     getVisibleWidth
 } from '../ansi';
 import {
@@ -26,7 +27,8 @@ import {
 import {
     calculateMaxWidthsFromPreRendered,
     preRenderAllWidgets,
-    renderStatusLine
+    renderStatusLine,
+    renderStatusLineWithInfo
 } from '../renderer';
 
 const TRUECOLOR_CODE = /\x1b\[38;2;\d+;\d+;\d+m/g;
@@ -276,6 +278,14 @@ describe('renderStatusLine with a gradient override', () => {
         return renderStatusLine(widgets, settings, context, preRenderedLines[0] ?? [], preCalculatedMaxWidths);
     }
 
+    function renderLineWithInfo(widgets: WidgetItem[], settingsOverrides: Partial<Settings> = {}, terminalWidth = 200) {
+        const settings = createSettings(settingsOverrides);
+        const context: RenderContext = { isPreview: false, terminalWidth };
+        const preRenderedLines = preRenderAllWidgets([widgets], settings, context);
+        const preCalculatedMaxWidths = calculateMaxWidthsFromPreRendered(preRenderedLines, settings);
+        return renderStatusLineWithInfo(widgets, settings, context, preRenderedLines[0] ?? [], preCalculatedMaxWidths);
+    }
+
     const widgets: WidgetItem[] = [
         { id: 'a', type: 'custom-text', customText: 'model', color: 'hex:A89278' },
         { id: 'b', type: 'custom-text', customText: ' branch', color: 'hex:A89278' }
@@ -308,5 +318,14 @@ describe('renderStatusLine with a gradient override', () => {
         expect(getVisibleWidth(truncated)).toBeLessThan(getVisibleWidth(full));
         // and the gradient's trailing reset survived
         expect(truncated.endsWith('\x1b[39m')).toBe(true);
+    });
+
+    it('reports truncation after the gradient colors the ellipsis', () => {
+        const gradient = 'gradient:hex:dbbb6f,hex:c4808a,hex:9070d0,hex:b8cad4,hex:4a8a5e';
+        const result = renderLineWithInfo(widgets, { overrideForegroundColor: gradient }, 9);
+
+        expect(result.wasTruncated).toBe(true);
+        expect(result.line.includes('...')).toBe(false);
+        expect(getVisibleText(result.line)).toContain('...');
     });
 });

--- a/src/utils/__tests__/gradient.test.ts
+++ b/src/utils/__tests__/gradient.test.ts
@@ -328,4 +328,25 @@ describe('renderStatusLine with a gradient override', () => {
         expect(result.line.includes('...')).toBe(false);
         expect(getVisibleText(result.line)).toContain('...');
     });
+
+    it('applies global foreground gradients to widget text in powerline mode', () => {
+        const gradient = 'gradient:FF0000-0000FF';
+        const powerlineWidgets: WidgetItem[] = [
+            { id: 'a', type: 'custom-text', customText: 'abc' },
+            { id: 'b', type: 'custom-text', customText: 'def' }
+        ];
+        const line = renderLine(powerlineWidgets, {
+            overrideForegroundColor: gradient,
+            powerline: {
+                ...DEFAULT_SETTINGS.powerline,
+                enabled: true
+            }
+        });
+        const codes = line.match(TRUECOLOR_CODE) ?? [];
+
+        expect(getVisibleText(line)).toContain('abc');
+        expect(getVisibleText(line)).toContain('def');
+        expect(codes).toHaveLength(6);
+        expect(codes[0]).not.toBe(codes[3]);
+    });
 });

--- a/src/utils/__tests__/gradient.test.ts
+++ b/src/utils/__tests__/gradient.test.ts
@@ -1,0 +1,190 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import {
+    DEFAULT_SETTINGS,
+    type Settings
+} from '../../types/Settings';
+import type { WidgetItem } from '../../types/Widget';
+import {
+    applyLineGradient,
+    getVisibleWidth
+} from '../ansi';
+import {
+    gradientCodeAt,
+    parseGradientSpec,
+    rgbToAnsi256,
+    sampleGradient
+} from '../gradient';
+import {
+    calculateMaxWidthsFromPreRendered,
+    preRenderAllWidgets,
+    renderStatusLine
+} from '../renderer';
+
+const TRUECOLOR_CODE = /\x1b\[38;2;\d+;\d+;\d+m/g;
+const ANSI256_CODE = /\x1b\[38;5;\d+m/g;
+
+function countMatches(text: string, pattern: RegExp): number {
+    return text.match(pattern)?.length ?? 0;
+}
+
+describe('parseGradientSpec', () => {
+    it('returns null for non-gradient values', () => {
+        expect(parseGradientSpec(undefined)).toBeNull();
+        expect(parseGradientSpec('')).toBeNull();
+        expect(parseGradientSpec('hex:FF0000')).toBeNull();
+        expect(parseGradientSpec('cyan')).toBeNull();
+    });
+
+    it('returns null when fewer than two stops resolve', () => {
+        expect(parseGradientSpec('gradient:hex:FF0000')).toBeNull();
+        expect(parseGradientSpec('gradient:not-a-color,also-bad')).toBeNull();
+    });
+
+    it('parses hex, #hex, and bare hex stops (whitespace tolerant)', () => {
+        const stops = parseGradientSpec('gradient: hex:FF0000 , #00FF00 , 0000FF ');
+        expect(stops).toEqual([
+            { r: 255, g: 0, b: 0 },
+            { r: 0, g: 255, b: 0 },
+            { r: 0, g: 0, b: 255 }
+        ]);
+    });
+});
+
+describe('sampleGradient', () => {
+    it('returns the endpoints (within OKLab round-trip tolerance)', () => {
+        const stops = [{ r: 10, g: 20, b: 30 }, { r: 200, g: 150, b: 100 }];
+        const start = sampleGradient(stops, 0);
+        const end = sampleGradient(stops, 1);
+        expect(Math.abs(start.r - 10)).toBeLessThanOrEqual(2);
+        expect(Math.abs(end.b - 100)).toBeLessThanOrEqual(2);
+    });
+
+    it('produces a neutral mid-gray at the midpoint of black->white', () => {
+        const mid = sampleGradient([{ r: 0, g: 0, b: 0 }, { r: 255, g: 255, b: 255 }], 0.5);
+        expect(mid.r).toBe(mid.g);
+        expect(mid.g).toBe(mid.b);
+        expect(mid.r).toBeGreaterThan(80);
+        expect(mid.r).toBeLessThan(180);
+    });
+
+    it('clamps out-of-range positions', () => {
+        const stops = [{ r: 0, g: 0, b: 0 }, { r: 255, g: 255, b: 255 }];
+        expect(sampleGradient(stops, -1)).toEqual(sampleGradient(stops, 0));
+        expect(sampleGradient(stops, 2)).toEqual(sampleGradient(stops, 1));
+    });
+});
+
+describe('rgbToAnsi256', () => {
+    it('maps pure colors to the expected palette indices', () => {
+        expect(rgbToAnsi256({ r: 0, g: 0, b: 0 })).toBe(16);
+        expect(rgbToAnsi256({ r: 255, g: 255, b: 255 })).toBe(231);
+        expect(rgbToAnsi256({ r: 255, g: 0, b: 0 })).toBe(196);
+    });
+
+    it('maps mid grays into the grayscale ramp', () => {
+        const index = rgbToAnsi256({ r: 128, g: 128, b: 128 });
+        expect(index).toBeGreaterThanOrEqual(232);
+        expect(index).toBeLessThanOrEqual(255);
+    });
+});
+
+describe('gradientCodeAt', () => {
+    const stops = [{ r: 255, g: 0, b: 0 }, { r: 0, g: 0, b: 255 }];
+
+    it('emits a truecolor escape at truecolor level', () => {
+        expect(gradientCodeAt(stops, 0, 'truecolor')).toMatch(/^\x1b\[38;2;\d+;\d+;\d+m$/);
+    });
+
+    it('emits a 256-color escape at ansi256 level', () => {
+        expect(gradientCodeAt(stops, 0.5, 'ansi256')).toMatch(/^\x1b\[38;5;\d+m$/);
+    });
+});
+
+describe('applyLineGradient', () => {
+    const stops = [{ r: 0, g: 0, b: 0 }, { r: 255, g: 255, b: 255 }];
+
+    it('preserves visible width when coloring a styled line', () => {
+        const line = '\x1b[38;2;255;0;0mhello\x1b[39m world';
+        const out = applyLineGradient(line, stops, 'truecolor');
+        expect(getVisibleWidth(out)).toBe(getVisibleWidth(line));
+    });
+
+    it('emits one foreground code per visible cluster', () => {
+        const out = applyLineGradient('abcdef', stops, 'truecolor');
+        expect(countMatches(out, TRUECOLOR_CODE)).toBe(getVisibleWidth('abcdef'));
+    });
+
+    it('sweeps through distinct colors across the line', () => {
+        const out = applyLineGradient('abcdefghij', stops, 'truecolor');
+        const codes = out.match(TRUECOLOR_CODE) ?? [];
+        expect(new Set(codes).size).toBeGreaterThanOrEqual(2);
+    });
+
+    it('passes OSC 8 hyperlinks through untouched', () => {
+        const link = '\x1b]8;;https://example.com\x1b\\branch\x1b]8;;\x1b\\';
+        const out = applyLineGradient(`a${link}b`, stops, 'truecolor');
+        expect(out).toContain('https://example.com');
+        expect(out).toContain('\x1b]8;;\x1b\\');
+        expect(getVisibleWidth(out)).toBe(getVisibleWidth(`a${link}b`));
+    });
+
+    it('uses 256-color escapes at ansi256 level', () => {
+        const out = applyLineGradient('abc', stops, 'ansi256');
+        expect(countMatches(out, ANSI256_CODE)).toBe(3);
+        expect(countMatches(out, TRUECOLOR_CODE)).toBe(0);
+    });
+
+    it('is a no-op for ansi16, single-character, and empty lines', () => {
+        expect(applyLineGradient('abc', stops, 'ansi16')).toBe('abc');
+        expect(applyLineGradient('x', stops, 'truecolor')).toBe('x');
+        expect(applyLineGradient('', stops, 'truecolor')).toBe('');
+    });
+});
+
+describe('renderStatusLine with a gradient override', () => {
+    function createSettings(overrides: Partial<Settings> = {}): Settings {
+        return {
+            ...DEFAULT_SETTINGS,
+            flexMode: 'full',
+            colorLevel: 3,
+            ...overrides,
+            powerline: {
+                ...DEFAULT_SETTINGS.powerline,
+                ...(overrides.powerline ?? {})
+            }
+        };
+    }
+
+    function renderLine(widgets: WidgetItem[], settingsOverrides: Partial<Settings> = {}): string {
+        const settings = createSettings(settingsOverrides);
+        const context: RenderContext = { isPreview: false, terminalWidth: 200 };
+        const preRenderedLines = preRenderAllWidgets([widgets], settings, context);
+        const preCalculatedMaxWidths = calculateMaxWidthsFromPreRendered(preRenderedLines, settings);
+        return renderStatusLine(widgets, settings, context, preRenderedLines[0] ?? [], preCalculatedMaxWidths);
+    }
+
+    const widgets: WidgetItem[] = [
+        { id: 'a', type: 'custom-text', customText: 'model', color: 'hex:A89278' },
+        { id: 'b', type: 'custom-text', customText: ' branch', color: 'hex:A89278' }
+    ];
+
+    it('paints the whole line with a continuous gradient', () => {
+        const gradient = 'gradient:hex:dbbb6f,hex:c4808a,hex:9070d0,hex:b8cad4,hex:4a8a5e';
+        const line = renderLine(widgets, { overrideForegroundColor: gradient });
+        const codes = line.match(TRUECOLOR_CODE) ?? [];
+        expect(codes.length).toBe(getVisibleWidth(line));
+        expect(new Set(codes).size).toBeGreaterThanOrEqual(2);
+    });
+
+    it('leaves visible width unchanged versus the non-gradient render', () => {
+        const plain = renderLine(widgets);
+        const gradient = renderLine(widgets, { overrideForegroundColor: 'gradient:hex:dbbb6f,hex:4a8a5e' });
+        expect(getVisibleWidth(gradient)).toBe(getVisibleWidth(plain));
+    });
+});

--- a/src/utils/__tests__/gradient.test.ts
+++ b/src/utils/__tests__/gradient.test.ts
@@ -126,6 +126,19 @@ describe('applyGradientToText', () => {
         expect(applyGradientToText('', stops, 'truecolor')).toBe('');
         expect(applyGradientToText('   ', stops, 'truecolor')).toBe('   ');
     });
+
+    it('passes ANSI and OSC 8 escape sequences through untouched', () => {
+        const openLink = '\x1b]8;;https://example.com\x1b\\';
+        const closeLink = '\x1b]8;;\x1b\\';
+        const styledLink = `\x1b[1m${openLink}branch${closeLink}\x1b[22m`;
+        const out = applyGradientToText(styledLink, stops, 'truecolor');
+
+        expect(out).toContain('\x1b[1m');
+        expect(out).toContain(openLink);
+        expect(out).toContain(closeLink);
+        expect(out).toContain('\x1b[22m');
+        expect(countMatches(out, TRUECOLOR_CODE)).toBe('branch'.length);
+    });
 });
 
 describe('sampleGradient', () => {

--- a/src/utils/__tests__/gradient.test.ts
+++ b/src/utils/__tests__/gradient.test.ts
@@ -18,6 +18,7 @@ import {
     GRADIENT_PRESET_NAMES,
     applyGradientToText,
     gradientCodeAt,
+    isGradientSpec,
     parseGradientSpec,
     rgbToAnsi256,
     sampleGradient
@@ -34,6 +35,21 @@ const ANSI256_CODE = /\x1b\[38;5;\d+m/g;
 function countMatches(text: string, pattern: RegExp): number {
     return text.match(pattern)?.length ?? 0;
 }
+
+describe('isGradientSpec', () => {
+    it('is true only for gradient: prefixed values', () => {
+        expect(isGradientSpec('gradient:atlas')).toBe(true);
+        expect(isGradientSpec('gradient:FF0000-0000FF')).toBe(true);
+    });
+
+    it('is false for solid colors, empty, and undefined', () => {
+        expect(isGradientSpec(undefined)).toBe(false);
+        expect(isGradientSpec('')).toBe(false);
+        expect(isGradientSpec('hex:FF0000')).toBe(false);
+        expect(isGradientSpec('ansi256:120')).toBe(false);
+        expect(isGradientSpec('cyan')).toBe(false);
+    });
+});
 
 describe('parseGradientSpec', () => {
     it('returns null for non-gradient values', () => {
@@ -59,6 +75,14 @@ describe('parseGradientSpec', () => {
 
     it('parses dash-separated bare hex stops', () => {
         const stops = parseGradientSpec('gradient:FF0000-0000FF');
+        expect(stops).toEqual([
+            { r: 255, g: 0, b: 0 },
+            { r: 0, g: 0, b: 255 }
+        ]);
+    });
+
+    it('parses dash-separated #-prefixed stops', () => {
+        const stops = parseGradientSpec('gradient:#FF0000-#0000FF');
         expect(stops).toEqual([
             { r: 255, g: 0, b: 0 },
             { r: 0, g: 0, b: 255 }
@@ -126,6 +150,14 @@ describe('sampleGradient', () => {
         expect(sampleGradient(stops, -1)).toEqual(sampleGradient(stops, 0));
         expect(sampleGradient(stops, 2)).toEqual(sampleGradient(stops, 1));
     });
+
+    it('lands on the interior stop of a 3-stop gradient at its position', () => {
+        // t=0.5 across three stops brackets exactly on the middle stop (green).
+        const mid = sampleGradient([{ r: 255, g: 0, b: 0 }, { r: 0, g: 255, b: 0 }, { r: 0, g: 0, b: 255 }], 0.5);
+        expect(Math.abs(mid.r - 0)).toBeLessThanOrEqual(2);
+        expect(Math.abs(mid.g - 255)).toBeLessThanOrEqual(2);
+        expect(Math.abs(mid.b - 0)).toBeLessThanOrEqual(2);
+    });
 });
 
 describe('rgbToAnsi256', () => {
@@ -151,6 +183,11 @@ describe('gradientCodeAt', () => {
 
     it('emits a 256-color escape at ansi256 level', () => {
         expect(gradientCodeAt(stops, 0.5, 'ansi256')).toMatch(/^\x1b\[38;5;\d+m$/);
+    });
+
+    it('falls back to the 256-color path defensively at ansi16', () => {
+        // Callers degrade before this, but if reached, ansi16 must not emit truecolor.
+        expect(gradientCodeAt(stops, 0.5, 'ansi16')).toMatch(/^\x1b\[38;5;\d+m$/);
     });
 });
 
@@ -182,6 +219,15 @@ describe('applyLineGradient', () => {
         expect(getVisibleWidth(out)).toBe(getVisibleWidth(`a${link}b`));
     });
 
+    it('colors both ends of a two-cluster line (denominator of exactly 1)', () => {
+        // totalWidth 2 -> denominator 1: first cluster at t=0, second at t=1.
+        const out = applyLineGradient('ab', stops, 'truecolor');
+        const codes = out.match(TRUECOLOR_CODE) ?? [];
+        expect(codes.length).toBe(2);
+        expect(codes[0]).not.toBe(codes[1]);
+        expect(getVisibleWidth(out)).toBe(2);
+    });
+
     it('uses 256-color escapes at ansi256 level', () => {
         const out = applyLineGradient('abc', stops, 'ansi256');
         expect(countMatches(out, ANSI256_CODE)).toBe(3);
@@ -209,9 +255,9 @@ describe('renderStatusLine with a gradient override', () => {
         };
     }
 
-    function renderLine(widgets: WidgetItem[], settingsOverrides: Partial<Settings> = {}): string {
+    function renderLine(widgets: WidgetItem[], settingsOverrides: Partial<Settings> = {}, terminalWidth = 200): string {
         const settings = createSettings(settingsOverrides);
-        const context: RenderContext = { isPreview: false, terminalWidth: 200 };
+        const context: RenderContext = { isPreview: false, terminalWidth };
         const preRenderedLines = preRenderAllWidgets([widgets], settings, context);
         const preCalculatedMaxWidths = calculateMaxWidthsFromPreRendered(preRenderedLines, settings);
         return renderStatusLine(widgets, settings, context, preRenderedLines[0] ?? [], preCalculatedMaxWidths);
@@ -234,5 +280,20 @@ describe('renderStatusLine with a gradient override', () => {
         const plain = renderLine(widgets);
         const gradient = renderLine(widgets, { overrideForegroundColor: 'gradient:hex:dbbb6f,hex:4a8a5e' });
         expect(getVisibleWidth(gradient)).toBe(getVisibleWidth(plain));
+    });
+
+    it('closes with a reset even when the line is truncated (no color leak)', () => {
+        // Regression: the gradient pass must run AFTER truncation. If it runs before,
+        // truncateStyledText cuts from the right and slices off the trailing \x1b[39m,
+        // so the last color leaks past the status line. A narrow width forces
+        // truncation; the rendered line must still end with the reset.
+        const gradient = 'gradient:hex:dbbb6f,hex:c4808a,hex:9070d0,hex:b8cad4,hex:4a8a5e';
+        const full = renderLine(widgets, { overrideForegroundColor: gradient });
+        const truncated = renderLine(widgets, { overrideForegroundColor: gradient }, 8);
+
+        // truncation actually happened
+        expect(getVisibleWidth(truncated)).toBeLessThan(getVisibleWidth(full));
+        // and the gradient's trailing reset survived
+        expect(truncated.endsWith('\x1b[39m')).toBe(true);
     });
 });

--- a/src/utils/__tests__/gradient.test.ts
+++ b/src/utils/__tests__/gradient.test.ts
@@ -15,6 +15,8 @@ import {
     getVisibleWidth
 } from '../ansi';
 import {
+    GRADIENT_PRESET_NAMES,
+    applyGradientToText,
     gradientCodeAt,
     parseGradientSpec,
     rgbToAnsi256,
@@ -53,6 +55,52 @@ describe('parseGradientSpec', () => {
             { r: 0, g: 255, b: 0 },
             { r: 0, g: 0, b: 255 }
         ]);
+    });
+
+    it('parses dash-separated bare hex stops', () => {
+        const stops = parseGradientSpec('gradient:FF0000-0000FF');
+        expect(stops).toEqual([
+            { r: 255, g: 0, b: 0 },
+            { r: 0, g: 0, b: 255 }
+        ]);
+    });
+
+    it('resolves named presets (case-insensitive) to their stop list', () => {
+        const retro = parseGradientSpec('gradient:retro');
+        expect(retro).toHaveLength(9);
+        expect(parseGradientSpec('gradient:RAINBOW')).toHaveLength(7);
+        // every shipped preset resolves to >= 2 usable stops
+        for (const name of GRADIENT_PRESET_NAMES) {
+            expect((parseGradientSpec(`gradient:${name}`) ?? []).length).toBeGreaterThanOrEqual(2);
+        }
+    });
+});
+
+describe('applyGradientToText', () => {
+    const stops = [{ r: 255, g: 0, b: 0 }, { r: 0, g: 0, b: 255 }];
+
+    it('emits one code per non-whitespace character and leaves whitespace uncolored', () => {
+        const out = applyGradientToText('ab cd', stops, 'truecolor');
+        expect(countMatches(out, TRUECOLOR_CODE)).toBe(4);
+        // the space follows the visible char directly, with no color code in between
+        expect(out).toContain('b ');
+    });
+
+    it('emits no trailing reset (the caller appends it)', () => {
+        const out = applyGradientToText('abc', stops, 'truecolor');
+        expect(out.endsWith('\x1b[39m')).toBe(false);
+    });
+
+    it('restarts the sweep per call (first visible code identical for two calls)', () => {
+        const first = applyGradientToText('abc', stops, 'truecolor').match(TRUECOLOR_CODE)?.[0];
+        const second = applyGradientToText('xyz', stops, 'truecolor').match(TRUECOLOR_CODE)?.[0];
+        expect(first).toBe(second);
+    });
+
+    it('is a no-op for ansi16, empty, and blank-only text', () => {
+        expect(applyGradientToText('abc', stops, 'ansi16')).toBe('abc');
+        expect(applyGradientToText('', stops, 'truecolor')).toBe('');
+        expect(applyGradientToText('   ', stops, 'truecolor')).toBe('   ');
     });
 });
 

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -1,5 +1,10 @@
 import stringWidth from 'string-width';
 
+import {
+    gradientCodeAt,
+    type Rgb
+} from './gradient';
+
 const ESC = '\x1b';
 const BEL = '\x07';
 const C1_CSI = '\x9b';
@@ -473,4 +478,49 @@ export function truncateStyledText(
     }
 
     return output + ellipsis;
+}
+
+// Paint a foreground gradient across the visible characters of a styled line,
+// assigning each display cluster a color based on its column position so the
+// gradient spans the whole line. Escape sequences (SGR, OSC-8 hyperlinks) pass
+// through untouched, and visible width is unchanged, so flex/powerline layout
+// is unaffected. ansi16 has too few colors for a gradient and is left as-is.
+export function applyLineGradient(
+    text: string,
+    stops: Rgb[],
+    colorLevel: 'ansi16' | 'ansi256' | 'truecolor'
+): string {
+    if (stops.length === 0 || colorLevel === 'ansi16') {
+        return text;
+    }
+
+    const totalWidth = getVisibleWidth(text);
+    if (totalWidth <= 1) {
+        return text;
+    }
+
+    const denominator = totalWidth - 1;
+    let output = '';
+    let column = 0;
+    let index = 0;
+
+    while (index < text.length) {
+        const escape = parseEscapeSequence(text, index);
+        if (escape) {
+            output += escape.sequence;
+            index = escape.nextIndex;
+            continue;
+        }
+
+        const cluster = consumeDisplayCluster(text, index);
+        if (!cluster) {
+            break;
+        }
+
+        output += gradientCodeAt(stops, column / denominator, colorLevel) + cluster.text;
+        column += getClusterWidth(cluster.text);
+        index = cluster.nextIndex;
+    }
+
+    return `${output}\x1b[39m`;
 }

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -399,6 +399,11 @@ export function getVisibleWidth(text: string): number {
 
 interface TruncateOptions { ellipsis?: boolean }
 
+export interface LineGradientSegmentResult {
+    text: string;
+    nextColumn: number;
+}
+
 export function truncateStyledText(
     text: string,
     maxWidth: number,
@@ -485,23 +490,31 @@ export function truncateStyledText(
 // gradient spans the whole line. Escape sequences (SGR, OSC-8 hyperlinks) pass
 // through untouched, and visible width is unchanged, so flex/powerline layout
 // is unaffected. ansi16 has too few colors for a gradient and is left as-is.
-export function applyLineGradient(
+export function applyLineGradientSegment(
     text: string,
     stops: Rgb[],
-    colorLevel: 'ansi16' | 'ansi256' | 'truecolor'
-): string {
+    colorLevel: 'ansi16' | 'ansi256' | 'truecolor',
+    startColumn: number,
+    totalWidth: number
+): LineGradientSegmentResult {
+    const visibleWidth = getVisibleWidth(text);
     if (stops.length === 0 || colorLevel === 'ansi16') {
-        return text;
+        return {
+            text,
+            nextColumn: startColumn + visibleWidth
+        };
     }
 
-    const totalWidth = getVisibleWidth(text);
     if (totalWidth <= 1) {
-        return text;
+        return {
+            text,
+            nextColumn: startColumn + visibleWidth
+        };
     }
 
     const denominator = totalWidth - 1;
     let output = '';
-    let column = 0;
+    let column = startColumn;
     let index = 0;
 
     while (index < text.length) {
@@ -522,5 +535,28 @@ export function applyLineGradient(
         index = cluster.nextIndex;
     }
 
-    return `${output}\x1b[39m`;
+    return {
+        text: output,
+        nextColumn: column
+    };
+}
+
+// Paint a foreground gradient across the visible characters of a styled line,
+// assigning each display cluster a color based on its column position so the
+// gradient spans the whole line. Escape sequences (SGR, OSC-8 hyperlinks) pass
+// through untouched, and visible width is unchanged, so flex/powerline layout
+// is unaffected. ansi16 has too few colors for a gradient and is left as-is.
+export function applyLineGradient(
+    text: string,
+    stops: Rgb[],
+    colorLevel: 'ansi16' | 'ansi256' | 'truecolor'
+): string {
+    const totalWidth = getVisibleWidth(text);
+    const result = applyLineGradientSegment(text, stops, colorLevel, 0, totalWidth);
+
+    if (result.text === text) {
+        return text;
+    }
+
+    return `${result.text}\x1b[39m`;
 }

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -4,6 +4,7 @@ import type { ColorEntry } from '../types/ColorEntry';
 
 import {
     applyGradientToText,
+    isGradientSpec,
     parseGradientSpec,
     rgbToAnsi256
 } from './gradient';
@@ -162,8 +163,9 @@ export function applyColors(
     if (foregroundColor) {
         // Per-character gradient foreground. Only representable with a real color
         // palette; at ansi16 (or for an unparseable spec) we fall through to a
-        // solid first stop via getColorAnsiCode below.
-        const gradientStops = foregroundColor.startsWith('gradient:') ? parseGradientSpec(foregroundColor) : null;
+        // solid first stop via getColorAnsiCode below. parseGradientSpec returns
+        // null for non-gradient values, so it doubles as the prefix guard.
+        const gradientStops = parseGradientSpec(foregroundColor);
         if (gradientStops && colorLevel !== 'ansi16') {
             return prefix + applyGradientToText(text, gradientStops, colorLevel) + '\x1b[39m' + suffix;
         }
@@ -188,7 +190,7 @@ export function getColorAnsiCode(colorName: string | undefined, colorLevel: 'ans
     // stop as a solid color. The per-character gradient is produced in applyColors();
     // this path is what the powerline renderer (which calls getColorAnsiCode
     // directly) sees, and the ansi16 fallback for the standard renderer.
-    if (colorName.startsWith('gradient:')) {
+    if (isGradientSpec(colorName)) {
         const stops = parseGradientSpec(colorName);
         const first = stops?.[0];
         if (!first)
@@ -197,6 +199,13 @@ export function getColorAnsiCode(colorName: string | undefined, colorLevel: 'ans
             const code = rgbToAnsi256(first);
             return isBackground ? `\x1b[48;5;${code}m` : `\x1b[38;5;${code}m`;
         }
+        // Note: at colorLevel 'ansi16' this intentionally still emits a truecolor
+        // (38;2/48;2) escape for the first stop rather than a real 16-color SGR — we
+        // don't quantize to the 16-color palette here. Both gradient render paths
+        // degrade before reaching a true ansi16 terminal (the standard renderer makes
+        // applyLineGradient a no-op at ansi16; powerline filters gradient specs out),
+        // so this branch is the defensive fallback and its truecolor output is only
+        // reached at levels that can display it.
         return isBackground ? `\x1b[48;2;${first.r};${first.g};${first.b}m` : `\x1b[38;2;${first.r};${first.g};${first.b}m`;
     }
 

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -162,9 +162,10 @@ export function applyColors(
     // Apply foreground color
     if (foregroundColor) {
         // Per-character gradient foreground. Only representable with a real color
-        // palette; at ansi16 (or for an unparseable spec) we fall through to a
-        // solid first stop via getColorAnsiCode below. parseGradientSpec returns
-        // null for non-gradient values, so it doubles as the prefix guard.
+        // palette; at ansi16 (or for an unparseable spec) we fall through to
+        // getColorAnsiCode below, which suppresses gradient specs at ansi16.
+        // parseGradientSpec returns null for non-gradient values, so it doubles
+        // as the prefix guard.
         const gradientStops = parseGradientSpec(foregroundColor);
         if (gradientStops && colorLevel !== 'ansi16') {
             return prefix + applyGradientToText(text, gradientStops, colorLevel) + '\x1b[39m' + suffix;
@@ -189,23 +190,20 @@ export function getColorAnsiCode(colorName: string | undefined, colorLevel: 'ans
     // A single ANSI code cannot represent a gradient, so collapse to the first
     // stop as a solid color. The per-character gradient is produced in applyColors();
     // this path is what the powerline renderer (which calls getColorAnsiCode
-    // directly) sees, and the ansi16 fallback for the standard renderer.
+    // directly) sees. At ansi16, return no code so Basic/No Color modes do not
+    // receive truecolor escapes from a stored gradient setting.
     if (isGradientSpec(colorName)) {
         const stops = parseGradientSpec(colorName);
         const first = stops?.[0];
         if (!first)
             return '';
+        if (colorLevel === 'ansi16') {
+            return '';
+        }
         if (colorLevel === 'ansi256') {
             const code = rgbToAnsi256(first);
             return isBackground ? `\x1b[48;5;${code}m` : `\x1b[38;5;${code}m`;
         }
-        // Note: at colorLevel 'ansi16' this intentionally still emits a truecolor
-        // (38;2/48;2) escape for the first stop rather than a real 16-color SGR — we
-        // don't quantize to the 16-color palette here. Both gradient render paths
-        // degrade before reaching a true ansi16 terminal (the standard renderer makes
-        // applyLineGradient a no-op at ansi16; powerline filters gradient specs out),
-        // so this branch is the defensive fallback and its truecolor output is only
-        // reached at levels that can display it.
         return isBackground ? `\x1b[48;2;${first.r};${first.g};${first.b}m` : `\x1b[38;2;${first.r};${first.g};${first.b}m`;
     }
 

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -2,6 +2,12 @@ import chalk, { type ChalkInstance } from 'chalk';
 
 import type { ColorEntry } from '../types/ColorEntry';
 
+import {
+    applyGradientToText,
+    parseGradientSpec,
+    rgbToAnsi256
+} from './gradient';
+
 // Re-export for backward compatibility
 export type { ColorEntry };
 
@@ -154,6 +160,14 @@ export function applyColors(
 
     // Apply foreground color
     if (foregroundColor) {
+        // Per-character gradient foreground. Only representable with a real color
+        // palette; at ansi16 (or for an unparseable spec) we fall through to a
+        // solid first stop via getColorAnsiCode below.
+        const gradientStops = foregroundColor.startsWith('gradient:') ? parseGradientSpec(foregroundColor) : null;
+        if (gradientStops && colorLevel !== 'ansi16') {
+            return prefix + applyGradientToText(text, gradientStops, colorLevel) + '\x1b[39m' + suffix;
+        }
+
         const fgCode = getColorAnsiCode(foregroundColor, colorLevel, false);
         if (fgCode) {
             prefix += fgCode;
@@ -168,6 +182,23 @@ export function applyColors(
 export function getColorAnsiCode(colorName: string | undefined, colorLevel: 'ansi16' | 'ansi256' | 'truecolor' = 'ansi16', isBackground = false): string {
     if (!colorName)
         return '';
+
+    // Handle gradient:<name> / gradient:RRGGBB-RRGGBB / gradient:hex:…,… formats.
+    // A single ANSI code cannot represent a gradient, so collapse to the first
+    // stop as a solid color. The per-character gradient is produced in applyColors();
+    // this path is what the powerline renderer (which calls getColorAnsiCode
+    // directly) sees, and the ansi16 fallback for the standard renderer.
+    if (colorName.startsWith('gradient:')) {
+        const stops = parseGradientSpec(colorName);
+        const first = stops?.[0];
+        if (!first)
+            return '';
+        if (colorLevel === 'ansi256') {
+            const code = rgbToAnsi256(first);
+            return isBackground ? `\x1b[48;5;${code}m` : `\x1b[38;5;${code}m`;
+        }
+        return isBackground ? `\x1b[48;2;${first.r};${first.g};${first.b}m` : `\x1b[38;2;${first.r};${first.g};${first.b}m`;
+    }
 
     // Handle ansi256:X format
     if (colorName.startsWith('ansi256:')) {

--- a/src/utils/gradient.ts
+++ b/src/utils/gradient.ts
@@ -40,13 +40,23 @@ export const GRADIENT_PRESETS: Record<string, string[]> = {
 
 export const GRADIENT_PRESET_NAMES: string[] = Object.keys(GRADIENT_PRESETS);
 
+// True when a color value is a gradient spec (`gradient:…`). Centralizes the
+// prefix check that callers use to branch before parsing.
+export function isGradientSpec(value: string | undefined): boolean {
+    return value?.startsWith(GRADIENT_PREFIX) ?? false;
+}
+
 // Parse a gradient foreground spec into RGB color stops. Three forms are
 // accepted, all prefixed `gradient:`
 //   - named preset            `gradient:atlas`              (case-insensitive)
-//   - dash-separated stops     `gradient:RRGGBB-RRGGBB[-…]`  (bare or #-prefixed hex)
-//   - comma-separated stops    `gradient:hex:RRGGBB,#RRGGBB,RRGGBB`
-// Returns null when the value is not a gradient spec or resolves to fewer than
-// two usable stops.
+//   - dash-separated stops     `gradient:RRGGBB-RRGGBB[-…]`
+//   - comma-separated stops    `gradient:RRGGBB,RRGGBB[,…]`
+// The comma vs dash choice is just the delimiter: a body containing a comma splits
+// on commas, otherwise on dashes. Each stop is resolved by `resolveStopToRgb`, so
+// `hex:RRGGBB`, `#RRGGBB`, and bare `RRGGBB` are all valid stop syntaxes in EITHER
+// form (e.g. `gradient:hex:FF0000-hex:0000FF` parses fine) — the comment examples
+// just show the common pairings. Returns null when the value is not a gradient spec
+// or resolves to fewer than two usable stops.
 export function parseGradientSpec(value: string | undefined): Rgb[] | null {
     if (!value?.startsWith(GRADIENT_PREFIX)) {
         return null;
@@ -217,6 +227,27 @@ const WHITESPACE = /\s/;
 //
 // No trailing reset is emitted here - the caller appends `\x1b[39m`. At ansi16
 // (or for empty/blank text) the input is returned unchanged.
+//
+// KNOWN LIMITATION — code points, not grapheme clusters.
+// This walks `text` with `for…of`, which iterates Unicode *code points*, whereas
+// the whole-line `applyLineGradient` (in ansi.ts) walks *display clusters* via
+// `consumeDisplayCluster`. For plain text (ASCII, single-code-point emoji) the two
+// agree. They diverge only for multi-code-point grapheme clusters — ZWJ sequences
+// (👩‍👩‍👧), variation selectors (✏️), regional-indicator flag pairs (🇺🇸): this
+// function assigns a separate gradient step to each code point in the cluster
+// (compressing the sweep there) and emits color codes onto zero-width joiner /
+// selector code points that render nothing. The visible glyph still draws; the
+// cosmetic effect is a locally faster sweep plus a few inert escape bytes.
+//
+// This divergence is deliberately tolerated rather than fixed:
+//   1. Per-widget gradient text is short, author-controlled widget content — ZWJ
+//      emoji are vanishingly rare there (the whole-line path, which is far more
+//      likely to carry arbitrary cwd/branch text, IS cluster-correct).
+//   2. The correct walker (`consumeDisplayCluster`) lives in ansi.ts, and ansi.ts
+//      already imports from this module (gradient.ts) — depending on it back would
+//      introduce a circular import. Unifying the two would require first extracting
+//      the cluster walker into a third, dependency-free module. That refactor is a
+//      tracked follow-up, not a blocker for correct rendering of real status lines.
 export function applyGradientToText(
     text: string,
     stops: Rgb[],

--- a/src/utils/gradient.ts
+++ b/src/utils/gradient.ts
@@ -12,6 +12,16 @@ interface Oklab {
 
 const GRADIENT_PREFIX = 'gradient:';
 const HEX_PATTERN = /^[0-9A-Fa-f]{6}$/;
+const ESC = '\x1b';
+const BEL = '\x07';
+const C1_CSI = '\x9b';
+const C1_OSC = '\x9d';
+const ST = '\x9c';
+
+interface ParsedEscapeSequence {
+    nextIndex: number;
+    sequence: string;
+}
 
 // Named gradient presets, addressable as `gradient:<name>`. The stop lists mirror
 // the named gradients shipped by `gradient-string` (pulled in transitively through
@@ -219,11 +229,105 @@ export function gradientCodeAt(
 
 const WHITESPACE = /\s/;
 
+function isCsiFinalByte(codePoint: number): boolean {
+    return codePoint >= 0x40 && codePoint <= 0x7e;
+}
+
+function consumeCsi(input: string, start: number, bodyStart: number): ParsedEscapeSequence {
+    let index = bodyStart;
+    while (index < input.length) {
+        const codePoint = input.charCodeAt(index);
+        if (isCsiFinalByte(codePoint)) {
+            const end = index + 1;
+            return {
+                nextIndex: end,
+                sequence: input.slice(start, end)
+            };
+        }
+        index++;
+    }
+
+    return {
+        nextIndex: input.length,
+        sequence: input.slice(start)
+    };
+}
+
+function consumeOsc(input: string, start: number, bodyStart: number): ParsedEscapeSequence {
+    let index = bodyStart;
+    while (index < input.length) {
+        const current = input[index];
+        if (!current) {
+            break;
+        }
+
+        if (current === BEL || current === ST) {
+            const end = index + 1;
+            return {
+                nextIndex: end,
+                sequence: input.slice(start, end)
+            };
+        }
+
+        if (current === ESC && input[index + 1] === '\\') {
+            const end = index + 2;
+            return {
+                nextIndex: end,
+                sequence: input.slice(start, end)
+            };
+        }
+
+        index++;
+    }
+
+    return {
+        nextIndex: input.length,
+        sequence: input.slice(start)
+    };
+}
+
+function consumeEscapeSequence(input: string, index: number): ParsedEscapeSequence | null {
+    const current = input[index];
+    if (!current) {
+        return null;
+    }
+
+    if (current === ESC) {
+        const next = input[index + 1];
+        if (next === '[') {
+            return consumeCsi(input, index, index + 2);
+        }
+        if (next === ']') {
+            return consumeOsc(input, index, index + 2);
+        }
+        if (next) {
+            return {
+                nextIndex: index + 2,
+                sequence: input.slice(index, index + 2)
+            };
+        }
+        return {
+            nextIndex: input.length,
+            sequence: current
+        };
+    }
+
+    if (current === C1_CSI) {
+        return consumeCsi(input, index, index + 1);
+    }
+
+    if (current === C1_OSC) {
+        return consumeOsc(input, index, index + 1);
+    }
+
+    return null;
+}
+
 // Apply a gradient across the visible characters of a single widget's text,
 // emitting one opening color code per non-whitespace character. Whitespace is
-// passed through uncolored and does not consume a gradient step (matching
-// gradient-string's behavior). The gradient restarts at t=0 for each call, so
-// every widget spans its own self-contained sweep.
+// passed through uncolored and does not consume a gradient step, and ANSI/OSC
+// escape sequences pass through untouched. The gradient restarts at t=0 for
+// each call, so every widget spans its own self-contained sweep.
 //
 // No trailing reset is emitted here - the caller appends `\x1b[39m`. At ansi16
 // (or for empty/blank text) the input is returned unchanged.
@@ -258,10 +362,24 @@ export function applyGradientToText(
     }
 
     let visibleCount = 0;
-    for (const ch of text) {
+    let scanIndex = 0;
+    while (scanIndex < text.length) {
+        const escape = consumeEscapeSequence(text, scanIndex);
+        if (escape) {
+            scanIndex = escape.nextIndex;
+            continue;
+        }
+
+        const codePoint = text.codePointAt(scanIndex);
+        if (codePoint === undefined) {
+            break;
+        }
+
+        const ch = String.fromCodePoint(codePoint);
         if (!WHITESPACE.test(ch)) {
             visibleCount++;
         }
+        scanIndex += ch.length;
     }
     if (visibleCount === 0) {
         return text;
@@ -270,13 +388,29 @@ export function applyGradientToText(
     const denominator = Math.max(1, visibleCount - 1);
     let result = '';
     let index = 0;
-    for (const ch of text) {
+    let textIndex = 0;
+    while (textIndex < text.length) {
+        const escape = consumeEscapeSequence(text, textIndex);
+        if (escape) {
+            result += escape.sequence;
+            textIndex = escape.nextIndex;
+            continue;
+        }
+
+        const codePoint = text.codePointAt(textIndex);
+        if (codePoint === undefined) {
+            break;
+        }
+
+        const ch = String.fromCodePoint(codePoint);
         if (WHITESPACE.test(ch)) {
             result += ch;
+            textIndex += ch.length;
             continue;
         }
         result += gradientCodeAt(stops, index / denominator, colorLevel) + ch;
         index++;
+        textIndex += ch.length;
     }
 
     return result;

--- a/src/utils/gradient.ts
+++ b/src/utils/gradient.ts
@@ -1,0 +1,171 @@
+export interface Rgb {
+    r: number;
+    g: number;
+    b: number;
+}
+
+interface Oklab {
+    L: number;
+    a: number;
+    b: number;
+}
+
+const GRADIENT_PREFIX = 'gradient:';
+const HEX_PATTERN = /^[0-9A-Fa-f]{6}$/;
+
+// Parse a "gradient:<stop>,<stop>,..." foreground spec into RGB color stops.
+// Stops are hex (`hex:RRGGBB`, `#RRGGBB`, or bare `RRGGBB`). Returns null when
+// the value is not a gradient spec or resolves to fewer than two usable stops.
+export function parseGradientSpec(value: string | undefined): Rgb[] | null {
+    if (!value?.startsWith(GRADIENT_PREFIX)) {
+        return null;
+    }
+
+    const stops = value
+        .slice(GRADIENT_PREFIX.length)
+        .split(',')
+        .map(stop => stop.trim())
+        .filter(stop => stop.length > 0)
+        .map(resolveStopToRgb)
+        .filter((rgb): rgb is Rgb => rgb !== null);
+
+    return stops.length >= 2 ? stops : null;
+}
+
+function hexToRgb(hex: string): Rgb | null {
+    if (!HEX_PATTERN.test(hex)) {
+        return null;
+    }
+    return {
+        r: parseInt(hex.slice(0, 2), 16),
+        g: parseInt(hex.slice(2, 4), 16),
+        b: parseInt(hex.slice(4, 6), 16)
+    };
+}
+
+function resolveStopToRgb(stop: string): Rgb | null {
+    if (stop.startsWith('hex:')) {
+        return hexToRgb(stop.slice(4));
+    }
+    if (stop.startsWith('#')) {
+        return hexToRgb(stop.slice(1));
+    }
+    return hexToRgb(stop);
+}
+
+function srgbToLinear(channel: number): number {
+    const normalized = channel / 255;
+    return normalized <= 0.04045
+        ? normalized / 12.92
+        : ((normalized + 0.055) / 1.055) ** 2.4;
+}
+
+function linearToSrgb(channel: number): number {
+    const value = channel <= 0.0031308
+        ? 12.92 * channel
+        : 1.055 * (channel ** (1 / 2.4)) - 0.055;
+    return Math.round(Math.min(1, Math.max(0, value)) * 255);
+}
+
+// sRGB -> OKLab. Interpolating in OKLab keeps blends perceptually even and
+// avoids the muddy mid-tones of naive sRGB interpolation.
+function rgbToOklab(rgb: Rgb): Oklab {
+    const lr = srgbToLinear(rgb.r);
+    const lg = srgbToLinear(rgb.g);
+    const lb = srgbToLinear(rgb.b);
+
+    const l = 0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb;
+    const m = 0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb;
+    const s = 0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb;
+
+    const lCbrt = Math.cbrt(l);
+    const mCbrt = Math.cbrt(m);
+    const sCbrt = Math.cbrt(s);
+
+    return {
+        L: 0.2104542553 * lCbrt + 0.7936177850 * mCbrt - 0.0040720468 * sCbrt,
+        a: 1.9779984951 * lCbrt - 2.4285922050 * mCbrt + 0.4505937099 * sCbrt,
+        b: 0.0259040371 * lCbrt + 0.7827717662 * mCbrt - 0.8086757660 * sCbrt
+    };
+}
+
+function oklabToRgb(lab: Oklab): Rgb {
+    const lCbrt = lab.L + 0.3963377774 * lab.a + 0.2158037573 * lab.b;
+    const mCbrt = lab.L - 0.1055613458 * lab.a - 0.0638541728 * lab.b;
+    const sCbrt = lab.L - 0.0894841775 * lab.a - 1.2914855480 * lab.b;
+
+    const l = lCbrt ** 3;
+    const m = mCbrt ** 3;
+    const s = sCbrt ** 3;
+
+    return {
+        r: linearToSrgb(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s),
+        g: linearToSrgb(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s),
+        b: linearToSrgb(-0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s)
+    };
+}
+
+// Sample the gradient at position t in [0, 1], interpolating in OKLab between
+// the two bracketing stops.
+export function sampleGradient(stops: Rgb[], t: number): Rgb {
+    const first = stops[0];
+    if (first === undefined) {
+        return { r: 0, g: 0, b: 0 };
+    }
+    if (stops.length === 1) {
+        return first;
+    }
+
+    const clamped = Math.min(1, Math.max(0, t));
+    const scaled = clamped * (stops.length - 1);
+    const lowerIndex = Math.min(stops.length - 2, Math.floor(scaled));
+    const lower = stops[lowerIndex];
+    const upper = stops[lowerIndex + 1];
+    if (lower === undefined || upper === undefined) {
+        return first;
+    }
+
+    const fraction = scaled - lowerIndex;
+    const labLower = rgbToOklab(lower);
+    const labUpper = rgbToOklab(upper);
+
+    return oklabToRgb({
+        L: labLower.L + (labUpper.L - labLower.L) * fraction,
+        a: labLower.a + (labUpper.a - labLower.a) * fraction,
+        b: labLower.b + (labUpper.b - labLower.b) * fraction
+    });
+}
+
+// Map an RGB color to the nearest xterm-256 palette index (6x6x6 cube plus the
+// grayscale ramp) for ansi256 terminals.
+export function rgbToAnsi256(rgb: Rgb): number {
+    if (rgb.r === rgb.g && rgb.g === rgb.b) {
+        if (rgb.r < 8) {
+            return 16;
+        }
+        if (rgb.r > 248) {
+            return 231;
+        }
+        return Math.round(((rgb.r - 8) / 247) * 24) + 232;
+    }
+
+    return 16
+        + 36 * Math.round((rgb.r / 255) * 5)
+        + 6 * Math.round((rgb.g / 255) * 5)
+        + Math.round((rgb.b / 255) * 5);
+}
+
+// Build the SGR foreground escape for the gradient color at position t. ansi16
+// has too few colors for a gradient, so callers should degrade before this; it
+// falls back to the 256-color path defensively.
+export function gradientCodeAt(
+    stops: Rgb[],
+    t: number,
+    colorLevel: 'ansi16' | 'ansi256' | 'truecolor'
+): string {
+    const rgb = sampleGradient(stops, t);
+    if (colorLevel === 'truecolor') {
+        return `\x1b[38;2;${rgb.r};${rgb.g};${rgb.b}m`;
+    }
+    return `\x1b[38;5;${rgbToAnsi256(rgb)}m`;
+}

--- a/src/utils/gradient.ts
+++ b/src/utils/gradient.ts
@@ -13,17 +13,54 @@ interface Oklab {
 const GRADIENT_PREFIX = 'gradient:';
 const HEX_PATTERN = /^[0-9A-Fa-f]{6}$/;
 
-// Parse a "gradient:<stop>,<stop>,..." foreground spec into RGB color stops.
-// Stops are hex (`hex:RRGGBB`, `#RRGGBB`, or bare `RRGGBB`). Returns null when
-// the value is not a gradient spec or resolves to fewer than two usable stops.
+// Named gradient presets, addressable as `gradient:<name>`. The stop lists mirror
+// the named gradients shipped by `gradient-string` (pulled in transitively through
+// `ink-gradient`), reproduced here as raw hex so the renderer can interpolate them
+// without going through the React/Ink layer.
+// Source: gradient-string (MIT) - https://github.com/bokub/gradient-string
+//
+// `gradient-string` renders `rainbow` and `pastel` via a full HSV hue-spin. We
+// interpolate in OKLab (no hue-spin), so those two are re-expressed as explicit
+// multi-stop hue wheels that sweep the spectrum directly.
+export const GRADIENT_PRESETS: Record<string, string[]> = {
+    atlas: ['#feac5e', '#c779d0', '#4bc0c8'],
+    cristal: ['#bdfff3', '#4ac29a'],
+    teen: ['#77a1d3', '#79cbca', '#e684ae'],
+    mind: ['#473b7b', '#3584a7', '#30d2be'],
+    morning: ['#ff5f6d', '#ffc371'],
+    vice: ['#5ee7df', '#b490ca'],
+    passion: ['#f43b47', '#453a94'],
+    fruit: ['#ff4e50', '#f9d423'],
+    instagram: ['#833ab4', '#fd1d1d', '#fcb045'],
+    retro: ['#3f51b1', '#5a55ae', '#7b5fac', '#8f6aae', '#a86aa4', '#cc6b8e', '#f18271', '#f3a469', '#f7c978'],
+    summer: ['#fdbb2d', '#22c1c3'],
+    rainbow: ['#ff0000', '#ffff00', '#00ff00', '#00ffff', '#0000ff', '#ff00ff', '#ff0000'],
+    pastel: ['#aee9d8', '#cdeeb0', '#f6f0a8', '#f7c8a8', '#f3aecb', '#c3b6f0', '#aee9d8']
+};
+
+export const GRADIENT_PRESET_NAMES: string[] = Object.keys(GRADIENT_PRESETS);
+
+// Parse a gradient foreground spec into RGB color stops. Three forms are
+// accepted, all prefixed `gradient:`
+//   - named preset            `gradient:atlas`              (case-insensitive)
+//   - dash-separated stops     `gradient:RRGGBB-RRGGBB[-…]`  (bare or #-prefixed hex)
+//   - comma-separated stops    `gradient:hex:RRGGBB,#RRGGBB,RRGGBB`
+// Returns null when the value is not a gradient spec or resolves to fewer than
+// two usable stops.
 export function parseGradientSpec(value: string | undefined): Rgb[] | null {
     if (!value?.startsWith(GRADIENT_PREFIX)) {
         return null;
     }
 
-    const stops = value
-        .slice(GRADIENT_PREFIX.length)
-        .split(',')
+    const body = value.slice(GRADIENT_PREFIX.length).trim();
+    if (!body) {
+        return null;
+    }
+
+    const preset = GRADIENT_PRESETS[body.toLowerCase()];
+    const rawStops = preset ?? body.split(body.includes(',') ? ',' : '-');
+
+    const stops = rawStops
         .map(stop => stop.trim())
         .filter(stop => stop.length > 0)
         .map(resolveStopToRgb)
@@ -168,4 +205,48 @@ export function gradientCodeAt(
         return `\x1b[38;2;${rgb.r};${rgb.g};${rgb.b}m`;
     }
     return `\x1b[38;5;${rgbToAnsi256(rgb)}m`;
+}
+
+const WHITESPACE = /\s/;
+
+// Apply a gradient across the visible characters of a single widget's text,
+// emitting one opening color code per non-whitespace character. Whitespace is
+// passed through uncolored and does not consume a gradient step (matching
+// gradient-string's behavior). The gradient restarts at t=0 for each call, so
+// every widget spans its own self-contained sweep.
+//
+// No trailing reset is emitted here - the caller appends `\x1b[39m`. At ansi16
+// (or for empty/blank text) the input is returned unchanged.
+export function applyGradientToText(
+    text: string,
+    stops: Rgb[],
+    colorLevel: 'ansi16' | 'ansi256' | 'truecolor'
+): string {
+    if (colorLevel === 'ansi16' || text.length === 0) {
+        return text;
+    }
+
+    let visibleCount = 0;
+    for (const ch of text) {
+        if (!WHITESPACE.test(ch)) {
+            visibleCount++;
+        }
+    }
+    if (visibleCount === 0) {
+        return text;
+    }
+
+    const denominator = Math.max(1, visibleCount - 1);
+    let result = '';
+    let index = 0;
+    for (const ch of text) {
+        if (WHITESPACE.test(ch)) {
+            result += ch;
+            continue;
+        }
+        result += gradientCodeAt(stops, index / denominator, colorLevel) + ch;
+        index++;
+    }
+
+    return result;
 }

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -9,6 +9,7 @@ import type { Settings } from '../types/Settings';
 
 import {
     applyLineGradient,
+    getVisibleText,
     getVisibleWidth,
     stripSgrCodes,
     truncateStyledText
@@ -619,7 +620,7 @@ export function renderStatusLineWithInfo(
 ): RenderResult {
     const line = renderStatusLine(widgets, settings, context, preRenderedWidgets, preCalculatedMaxWidths);
     // Check if line contains the truncation ellipsis
-    const wasTruncated = line.includes('...');
+    const wasTruncated = getVisibleText(line).includes('...');
     return { line, wasTruncated };
 }
 

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -20,7 +20,10 @@ import {
     getPowerlineTheme
 } from './colors';
 import { calculateContextPercentage } from './context-percentage';
-import { parseGradientSpec } from './gradient';
+import {
+    isGradientSpec,
+    parseGradientSpec
+} from './gradient';
 import { getTerminalWidth } from './terminal';
 import { getWidget } from './widgets';
 
@@ -35,7 +38,8 @@ export function formatTokens(count: number): string {
 
 // Paint a foreground gradient across a finished line when overrideForegroundColor
 // is a gradient spec (e.g. "gradient:hex:FF0000,hex:0000FF"); a no-op otherwise.
-// Applied after assembly but before truncation so the gradient spans the full line.
+// Applied as the final step, after truncation, so the trailing reset is not sliced
+// off (see the call site for why ordering matters).
 function maybeApplyForegroundGradient(
     line: string,
     settings: Settings,
@@ -226,7 +230,7 @@ function renderPowerlineStatusLine(
             // Apply override FG color if set (overrides theme). A gradient: spec is a
             // standard-mode whole-line gradient, not a solid color — ignore it in powerline.
             if (settings.overrideForegroundColor && settings.overrideForegroundColor !== 'none'
-                && !settings.overrideForegroundColor.startsWith('gradient:')) {
+                && !isGradientSpec(settings.overrideForegroundColor)) {
                 fgColor = settings.overrideForegroundColor;
             }
 
@@ -660,7 +664,7 @@ export function renderStatusLine(
         let fgColor = foregroundColor;
         const fgOverride = settings.overrideForegroundColor;
         if (fgOverride && fgOverride !== 'none') {
-            if (!fgOverride.startsWith('gradient:')) {
+            if (!isGradientSpec(fgOverride)) {
                 fgColor = fgOverride;
             } else if (colorLevel !== 'ansi16') {
                 fgColor = undefined;
@@ -925,9 +929,6 @@ export function renderStatusLine(
         }
     }
 
-    // Apply a foreground gradient across the whole line if configured
-    statusLine = maybeApplyForegroundGradient(statusLine, settings, colorLevel);
-
     // Truncate if the line exceeds the terminal width
     // Use terminalWidth if available (already accounts for flex mode adjustments), otherwise use detectedWidth
     const maxWidth = terminalWidth ?? detectedWidth;
@@ -939,6 +940,16 @@ export function renderStatusLine(
             statusLine = truncateStyledText(statusLine, maxWidth, { ellipsis: true });
         }
     }
+
+    // Apply a foreground gradient across the whole line if configured. This runs
+    // AFTER truncation, not before: truncateStyledText cuts from the right and
+    // appends a raw "..." with no trailing reset, so a gradient applied earlier
+    // would have its closing \x1b[39m sliced off — leaking the last color past the
+    // line. Gradient codes are zero-width (getVisibleWidth strips them), so the
+    // truncation measurement above is unaffected by deferring the gradient, and
+    // coloring the already-truncated line sweeps the ellipsis too and keeps the
+    // reset at the true end.
+    statusLine = maybeApplyForegroundGradient(statusLine, settings, colorLevel);
 
     return statusLine;
 }

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -8,6 +8,7 @@ import { getColorLevelString } from '../types/ColorLevel';
 import type { Settings } from '../types/Settings';
 
 import {
+    applyLineGradient,
     getVisibleWidth,
     stripSgrCodes,
     truncateStyledText
@@ -19,6 +20,7 @@ import {
     getPowerlineTheme
 } from './colors';
 import { calculateContextPercentage } from './context-percentage';
+import { parseGradientSpec } from './gradient';
 import { getTerminalWidth } from './terminal';
 import { getWidget } from './widgets';
 
@@ -29,6 +31,18 @@ export function formatTokens(count: number): string {
     if (count >= 1000)
         return `${(count / 1000).toFixed(1)}k`;
     return count.toString();
+}
+
+// Paint a foreground gradient across a finished line when overrideForegroundColor
+// is a gradient spec (e.g. "gradient:hex:FF0000,hex:0000FF"); a no-op otherwise.
+// Applied after assembly but before truncation so the gradient spans the full line.
+function maybeApplyForegroundGradient(
+    line: string,
+    settings: Settings,
+    colorLevel: 'ansi16' | 'ansi256' | 'truecolor'
+): string {
+    const stops = parseGradientSpec(settings.overrideForegroundColor);
+    return stops ? applyLineGradient(line, stops, colorLevel) : line;
 }
 
 function resolveEffectiveTerminalWidth(
@@ -209,8 +223,10 @@ function renderPowerlineStatusLine(
                 }
             }
 
-            // Apply override FG color if set (overrides theme)
-            if (settings.overrideForegroundColor && settings.overrideForegroundColor !== 'none') {
+            // Apply override FG color if set (overrides theme). A gradient: spec is a
+            // standard-mode whole-line gradient, not a solid color — ignore it in powerline.
+            if (settings.overrideForegroundColor && settings.overrideForegroundColor !== 'none'
+                && !settings.overrideForegroundColor.startsWith('gradient:')) {
                 fgColor = settings.overrideForegroundColor;
             }
 
@@ -636,10 +652,19 @@ export function renderStatusLine(
 
     // Helper to apply colors with optional background and bold override
     const applyColorsWithOverride = (text: string, foregroundColor?: string, backgroundColor?: string, bold?: boolean): string => {
-        // Override foreground color takes precedence over EVERYTHING, including passed foreground color
+        // Override foreground color takes precedence over EVERYTHING, including passed foreground
+        // color — except a gradient: spec, which is not a solid color. The gradient is applied as a
+        // whole-line pass after assembly, so when it will render (color levels above ansi16) we emit
+        // no per-widget foreground and let the gradient own it; at ansi16 the gradient is a no-op, so
+        // the widget's own foreground is kept.
         let fgColor = foregroundColor;
-        if (settings.overrideForegroundColor && settings.overrideForegroundColor !== 'none') {
-            fgColor = settings.overrideForegroundColor;
+        const fgOverride = settings.overrideForegroundColor;
+        if (fgOverride && fgOverride !== 'none') {
+            if (!fgOverride.startsWith('gradient:')) {
+                fgColor = fgOverride;
+            } else if (colorLevel !== 'ansi16') {
+                fgColor = undefined;
+            }
         }
 
         // Override background color takes precedence over EVERYTHING, including passed background color
@@ -899,6 +924,9 @@ export function renderStatusLine(
             statusLine = finalElements.join('');
         }
     }
+
+    // Apply a foreground gradient across the whole line if configured
+    statusLine = maybeApplyForegroundGradient(statusLine, settings, colorLevel);
 
     // Truncate if the line exceeds the terminal width
     // Use terminalWidth if available (already accounts for flex mode adjustments), otherwise use detectedWidth

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -9,6 +9,7 @@ import type { Settings } from '../types/Settings';
 
 import {
     applyLineGradient,
+    applyLineGradientSegment,
     getVisibleText,
     getVisibleWidth,
     stripSgrCodes,
@@ -133,6 +134,7 @@ function renderPowerlineStatusLine(
 
     // Get color level from settings
     const colorLevel = getColorLevelString(settings.colorLevel);
+    const overrideForegroundGradientStops = parseGradientSpec(settings.overrideForegroundColor);
 
     // Filter out separator and flex-separator widgets in powerline mode
     const filteredWidgets = widgets.filter(widget => widget.type !== 'separator' && widget.type !== 'flex-separator'
@@ -228,8 +230,9 @@ function renderPowerlineStatusLine(
                 }
             }
 
-            // Apply override FG color if set (overrides theme). A gradient: spec is a
-            // standard-mode whole-line gradient, not a solid color — ignore it in powerline.
+            // Apply solid override FG color if set (overrides theme). Gradient
+            // overrides are applied to widget text during rendering below so
+            // powerline separators keep their foreground/background contrast.
             if (settings.overrideForegroundColor && settings.overrideForegroundColor !== 'none'
                 && !isGradientSpec(settings.overrideForegroundColor)) {
                 fgColor = settings.overrideForegroundColor;
@@ -293,6 +296,14 @@ function renderPowerlineStatusLine(
         }
     }
 
+    const powerlineGradientWidth = overrideForegroundGradientStops && colorLevel !== 'ansi16'
+        ? widgetElements.reduce((sum, element) => {
+            const isPreserveColors = element.widget.type === 'custom-command' && element.widget.preserveColors;
+            return isPreserveColors ? sum : sum + getVisibleWidth(element.content);
+        }, 0)
+        : 0;
+    let powerlineGradientColumn = 0;
+
     // Build the final powerline string
     let result = '';
 
@@ -332,14 +343,30 @@ function renderPowerlineStatusLine(
         if (shouldBold && !isPreserveColors) {
             widgetContent += '\x1b[1m';
         }
-        if (widget.fgColor && !isPreserveColors) {
+        const textGradientStops = !isPreserveColors && powerlineGradientWidth > 1
+            ? overrideForegroundGradientStops
+            : null;
+
+        if (widget.fgColor && !isPreserveColors && !textGradientStops) {
             widgetContent += getColorAnsiCode(widget.fgColor, colorLevel, false);
         }
         // Always apply background for consistency in powerline mode
         if (widget.bgColor) {
             widgetContent += getColorAnsiCode(widget.bgColor, colorLevel, true);
         }
-        widgetContent += widget.content;
+        if (textGradientStops) {
+            const gradientResult = applyLineGradientSegment(
+                widget.content,
+                textGradientStops,
+                colorLevel,
+                powerlineGradientColumn,
+                powerlineGradientWidth
+            );
+            widgetContent += gradientResult.text;
+            powerlineGradientColumn = gradientResult.nextColumn;
+        } else {
+            widgetContent += widget.content;
+        }
         // Reset colors after content
         // For custom commands with preserveColors, also reset text attributes like dim
         if (isPreserveColors) {


### PR DESCRIPTION
<img width="910" height="260" alt="CleanShot 2026-05-30 at 11 00 16@2x" src="https://github.com/user-attachments/assets/ad8a7425-27ca-4bbf-8472-0ff5f1d613bd" />


## What

Adds foreground **gradients** to ccstatusline at **two scopes**, on one shared OKLab engine:

- **Line-spanning** — `overrideForegroundColor: "gradient:…"` paints the whole status line with one continuous sweep; each visible character is colored by its **column across the line**.
- **Per-widget** — `widget.color: "gradient:…"` gives a single widget its own self-contained sweep, alongside the existing solid colors. Configurable in the TUI (`g` in the color menu).

```jsonc
// whole line:
"overrideForegroundColor": "gradient:hex:dbbb6f,hex:c4808a,hex:9070d0,hex:b8cad4,hex:4a8a5e"
// one widget:
{ "type": "model", "color": "gradient:atlas" }
```

Three spec forms: a **named preset** (`gradient:atlas`, `gradient:rainbow`, …), **dash** stops (`gradient:RRGGBB-RRGGBB`), or **comma** stops (`gradient:hex:…,#…,…`). Two or more stops.

## Why one core

This **converges two same-day PRs**. #404 by @akkaz (opened first) added gradient as a *per-widget color* with named presets (reproduced from `gradient-string`, MIT) and a ColorMenu picker; this PR added the *line-spanning* form. Both create `src/utils/gradient.ts`, so they'd conflict. Rather than compete, they're meshed onto a single engine that offers both scopes.

Colors interpolate in **OKLab** for perceptually even blends — no muddy mid-tones, no `tinygradient`/HSV dependency. `rainbow`/`pastel` (originally HSV hue-spins) are re-expressed as explicit multi-stop hue wheels so OKLab reproduces them. **Zero new dependencies.**

## How

- **`gradient.ts`** — `parseGradientSpec` (presets + dash + comma → `Rgb[]`), OKLab `sampleGradient`, `rgbToAnsi256`, `gradientCodeAt`, `applyGradientToText` (per-widget), plus `GRADIENT_PRESETS`.
- **`colors.ts`** — per-widget gradient in `applyColors`; `getColorAnsiCode` collapses a gradient to its **first stop** as a solid (what the powerline renderer and the ansi16 path see).
- **`ansi.ts`** — `applyLineGradient` reuses the existing `parseEscapeSequence` / `consumeDisplayCluster` walkers, so **OSC-8 hyperlinks pass through** and **visible width is unchanged** (`flexMode` unaffected).
- **`renderer.ts`** — line-span pass after assembly, before truncation; suppresses a widget's solid fg when a line-span gradient owns the line.
- **`ColorMenu.tsx`** — `g` opens a gradient picker (preset list + custom hex), foreground-only, colorLevel ≥ 2.

**Precedence:** line-span override > per-widget `color: gradient:` > solid.

### Color levels & scope
- **truecolor** → `38;2;r;g;b`; **ansi256** → nearest 6×6×6 / grayscale; **ansi16** → per-widget degrades to a solid first stop, line-span is a no-op.
- Gradients **self-degrade at render time**, so `color-sanitize` leaves them untouched at every level.
- **Powerline:** separators derive fg from bg, so a line-span gradient is not applied there; per-widget gradients degrade to their first-stop solid. (Full powerline support is a follow-up.)

## Tests
`bun test` green (1426 pass). Covers preset/dash/comma parsing, OKLab sampling, ansi256 mapping, per-widget `applyGradientToText` (whitespace-skipped, restart-per-call), line-span width-invariance, OSC-8 passthrough, the per-widget `applyColors` path at all levels, first-stop fallback, and the self-degrade-across-levels sanitize behavior. `bun run lint` + `bun tsc --noEmit` clean.

## Credit
Per-widget gradients, the preset list, and the TUI picker come from **#404 by @akkaz** — this PR carries that design forward on the shared OKLab core. 🙏

## Follow-ups (not in this PR)
- TUI authoring for the line-span `overrideForegroundColor` gradient
- Powerline support (gradient over text glyphs only, skipping separators)
- Per-line scoping; direction/reverse modifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)
