### PR TITLE
fix: keep usage-fetch tests from touching the real user cache

### DIFF
--- a/src/utils/__tests__/usage-fetch.test.ts
+++ b/src/utils/__tests__/usage-fetch.test.ts
@@ -21,6 +21,7 @@ interface UsageProbeResult {
     requestCount: number;
     proxyAgentConfigured: boolean;
     requestHost: string | null;
+    homedir: string;
     lockContents: string | null;
 }
 
@@ -150,6 +151,7 @@ process.stdout.write(JSON.stringify({
     requestCount,
     proxyAgentConfigured,
     requestHost,
+    homedir: os.homedir(),
     lockContents: fs.existsSync(lockFile) ? fs.readFileSync(lockFile, 'utf8') : null
 }));
 `;
@@ -190,6 +192,10 @@ process.stdout.write(JSON.stringify({
             env: {
                 ...process.env,
                 HOME: options.home,
+                // os.homedir() prefers USERPROFILE on Windows; inheriting the
+                // real one lets the probe escape into the user's actual home
+                // and read/write the live ~/.cache/ccstatusline
+                USERPROFILE: options.home,
                 PATH: options.pathDir ?? '/nonexistent',
                 TEST_REQUIRED_FIELDS_JSON: JSON.stringify(options.requiredFields ?? []),
                 TEST_NOW_MS: String(options.nowMs),
@@ -197,13 +203,22 @@ process.stdout.write(JSON.stringify({
                 TEST_RESPONSE_BODY: options.responseBody ?? '',
                 TEST_RESPONSE_HEADERS_JSON: JSON.stringify(options.responseHeaders ?? {}),
                 TEST_STATUS_CODE: String(options.statusCode ?? (options.mode === 'success' ? 200 : 500)),
-                ...(options.claudeConfigDir ? { CLAUDE_CONFIG_DIR: options.claudeConfigDir } : {}),
-                ...(options.httpsProxy !== undefined ? { HTTPS_PROXY: options.httpsProxy } : {}),
-                ...(options.lowercaseHttpsProxy !== undefined ? { https_proxy: options.lowercaseHttpsProxy } : {})
+                // Pinned (undefined removes an inherited value) so the
+                // developer's real CLAUDE_CONFIG_DIR and proxy settings never
+                // reach the probes
+                CLAUDE_CONFIG_DIR: options.claudeConfigDir,
+                HTTPS_PROXY: options.httpsProxy,
+                https_proxy: options.lowercaseHttpsProxy
             }
         });
 
-        return JSON.parse(output) as UsageProbeResult;
+        const result = JSON.parse(output) as UsageProbeResult;
+
+        // A probe resolving a different home has escaped its sandbox and would
+        // read or write the real user's ~/.cache/ccstatusline
+        expect(result.homedir).toBe(options.home);
+
+        return result;
     }
 
     function cleanup(): void {
@@ -425,7 +440,9 @@ describe('fetchUsageData error handling', () => {
             expect(lowercaseProxyResult.first).toEqual(successResult.first);
             expect(lowercaseProxyResult.second).toEqual(successResult.first);
             expect(lowercaseProxyResult.requestCount).toBe(1);
-            expect(lowercaseProxyResult.proxyAgentConfigured).toBe(false);
+            // Windows environment variables are case-insensitive, so a
+            // lowercase https_proxy is indistinguishable from HTTPS_PROXY there
+            expect(lowercaseProxyResult.proxyAgentConfigured).toBe(process.platform === 'win32');
 
             const blankProxyResult = harness.runProbe({
                 claudeConfigDir: blankProxyHome.claudeConfig,

--- a/src/utils/__tests__/usage-fetch.test.ts
+++ b/src/utils/__tests__/usage-fetch.test.ts
@@ -187,29 +187,41 @@ process.stdout.write(JSON.stringify({
     }
 
     function runProbe(options: ProbeOptions): UsageProbeResult {
+        const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => {
+            const normalizedKey = key.toUpperCase();
+            return normalizedKey !== 'CLAUDE_CONFIG_DIR' && normalizedKey !== 'HTTPS_PROXY';
+        }));
+
+        Object.assign(env, {
+            HOME: options.home,
+            // os.homedir() prefers USERPROFILE on Windows; inheriting the
+            // real one lets the probe escape into the user's actual home
+            // and read/write the live ~/.cache/ccstatusline
+            USERPROFILE: options.home,
+            PATH: options.pathDir ?? '/nonexistent',
+            TEST_REQUIRED_FIELDS_JSON: JSON.stringify(options.requiredFields ?? []),
+            TEST_NOW_MS: String(options.nowMs),
+            TEST_REQUEST_MODE: options.mode ?? 'success',
+            TEST_RESPONSE_BODY: options.responseBody ?? '',
+            TEST_RESPONSE_HEADERS_JSON: JSON.stringify(options.responseHeaders ?? {}),
+            TEST_STATUS_CODE: String(options.statusCode ?? (options.mode === 'success' ? 200 : 500))
+        });
+
+        if (options.claudeConfigDir !== undefined) {
+            env.CLAUDE_CONFIG_DIR = options.claudeConfigDir;
+        }
+
+        if (options.httpsProxy !== undefined) {
+            env.HTTPS_PROXY = options.httpsProxy;
+        }
+
+        if (options.lowercaseHttpsProxy !== undefined) {
+            env.https_proxy = options.lowercaseHttpsProxy;
+        }
+
         const output = realExecFileSync(process.execPath, [probeScriptPath], {
             encoding: 'utf8',
-            env: {
-                ...process.env,
-                HOME: options.home,
-                // os.homedir() prefers USERPROFILE on Windows; inheriting the
-                // real one lets the probe escape into the user's actual home
-                // and read/write the live ~/.cache/ccstatusline
-                USERPROFILE: options.home,
-                PATH: options.pathDir ?? '/nonexistent',
-                TEST_REQUIRED_FIELDS_JSON: JSON.stringify(options.requiredFields ?? []),
-                TEST_NOW_MS: String(options.nowMs),
-                TEST_REQUEST_MODE: options.mode ?? 'success',
-                TEST_RESPONSE_BODY: options.responseBody ?? '',
-                TEST_RESPONSE_HEADERS_JSON: JSON.stringify(options.responseHeaders ?? {}),
-                TEST_STATUS_CODE: String(options.statusCode ?? (options.mode === 'success' ? 200 : 500)),
-                // Pinned (undefined removes an inherited value) so the
-                // developer's real CLAUDE_CONFIG_DIR and proxy settings never
-                // reach the probes
-                CLAUDE_CONFIG_DIR: options.claudeConfigDir,
-                HTTPS_PROXY: options.httpsProxy,
-                https_proxy: options.lowercaseHttpsProxy
-            }
+            env
         });
 
         const result = JSON.parse(output) as UsageProbeResult;


### PR DESCRIPTION
Closes #437.

Running `bun test` corrupts the developer's live statusline on Windows: the usage-fetch probe subprocesses override `HOME` but inherit the real `USERPROFILE`, which `os.homedir()` prefers there. Every run wrote fixture data and stale locks into the real `~/.cache/ccstatusline`, so the running statusline showed `[Timeout]` until the lock expired and fixture percentages until the cache aged out. It also made all 11 tests in the file fail on Windows.

Fixes, all inside the test file:

- pin `USERPROFILE` alongside `HOME` in the probe env (the actual escape)
- pin `CLAUDE_CONFIG_DIR` / `HTTPS_PROXY` / `https_proxy` so inherited developer settings never reach probes
- every probe now reports `os.homedir()` and the harness asserts it matches the sandbox home, so a future isolation escape fails loudly instead of silently corrupting user state
- the lowercase `https_proxy` assertion is platform-aware: Windows env vars are case-insensitive, so it is indistinguishable from `HTTPS_PROXY` there

Windows: this file goes from 0/11 to 11/11 passing. POSIX behavior unchanged.

