### PR TITLE
fix: stop refetching usage every render on accounts without rate-limit windows

### DIFF
--- a/src/utils/__tests__/usage-fetch.test.ts
+++ b/src/utils/__tests__/usage-fetch.test.ts
@@ -357,6 +357,23 @@ describe('fetchUsageData error handling', () => {
             disabled_reason: null
         }
     });
+    // Mirrors a real Enterprise-account response: every rate-limit window is
+    // null because Enterprise plans have no 5-hour/7-day windows (#343).
+    const enterpriseNullWindowsResponseBody = JSON.stringify({
+        five_hour: null,
+        seven_day: null,
+        seven_day_oauth_apps: null,
+        seven_day_sonnet: null,
+        seven_day_opus: null,
+        extra_usage: {
+            is_enabled: true,
+            monthly_limit: 50000,
+            used_credits: 0,
+            utilization: null,
+            currency: 'USD',
+            disabled_reason: null
+        }
+    });
     const rateLimitedResponseBody = JSON.stringify({
         error: {
             message: 'Rate limited. Please try again later.',
@@ -696,6 +713,52 @@ describe('fetchUsageData error handling', () => {
                 weeklyResetAt: '2030-01-07T00:00:00.000Z',
                 extraUsageEnabled: true,
                 extraUsageUsed: 542
+            });
+            expect(result.second).toEqual(result.first);
+            expect(result.requestCount).toBe(1);
+
+            const cachedResult = harness.runProbe({
+                claudeConfigDir: home.claudeConfig,
+                home: home.home,
+                mode: 'unexpected',
+                nowMs: nowMs + 10000,
+                pathDir: home.bin,
+                requiredFields
+            });
+
+            expect(cachedResult.first).toEqual(result.first);
+            expect(cachedResult.second).toEqual(result.first);
+            expect(cachedResult.requestCount).toBe(0);
+        } finally {
+            harness.cleanup();
+        }
+    });
+
+    it('treats null rate-limit windows as complete for window reset fields', () => {
+        const harness = createProbeHarness();
+
+        try {
+            const home = harness.createTokenHome('enterprise-null-windows');
+            const requiredFields = ['sessionUsage', 'sessionResetAt', 'weeklyUsage', 'weeklyResetAt', 'weeklySonnetResetAt', 'weeklyOpusResetAt'];
+            const result = harness.runProbe({
+                claudeConfigDir: home.claudeConfig,
+                home: home.home,
+                mode: 'success',
+                nowMs,
+                pathDir: home.bin,
+                requiredFields,
+                responseBody: enterpriseNullWindowsResponseBody
+            });
+
+            expect(result.first).toEqual({
+                sessionUsage: 0,
+                weeklyUsage: 0,
+                weeklySonnetUsage: 0,
+                weeklyOpusUsage: 0,
+                extraUsageEnabled: true,
+                extraUsageLimit: 50000,
+                extraUsageCurrency: 'USD',
+                extraUsageUsed: 0
             });
             expect(result.second).toEqual(result.first);
             expect(result.requestCount).toBe(1);

--- a/src/utils/usage-fetch.ts
+++ b/src/utils/usage-fetch.ts
@@ -33,6 +33,17 @@ const EXTRA_USAGE_DETAIL_FIELDS = new Set<UsageDataField>([
     'extraUsageUtilization'
 ]);
 
+// Maps each window reset field to the utilization field parsed from the same
+// API bucket. A null bucket (Enterprise accounts have no rate-limit windows,
+// #343) parses to utilization 0 with no resets_at, so once the utilization is
+// cached the missing timestamp is conclusive and refetching cannot produce it.
+const WINDOW_RESET_FIELD_SENTINELS: Partial<Record<UsageDataField, UsageDataField>> = {
+    sessionResetAt: 'sessionUsage',
+    weeklyResetAt: 'weeklyUsage',
+    weeklySonnetResetAt: 'weeklySonnetUsage',
+    weeklyOpusResetAt: 'weeklyOpusUsage'
+};
+
 const UsageCredentialsSchema = z.object({ claudeAiOauth: z.object({ accessToken: z.string().nullable().optional() }).optional() });
 const UsageLockErrorSchema = z.enum(['timeout', 'rate-limited', 'parse-error']);
 const UsageLockSchema = z.object({
@@ -182,6 +193,11 @@ function cacheUsageData(data: UsageData, now: number): UsageData {
 
 function hasRequiredUsageField(data: UsageData, field: UsageDataField): boolean {
     if (data[field] !== undefined) {
+        return true;
+    }
+
+    const windowSentinel = WINDOW_RESET_FIELD_SENTINELS[field];
+    if (windowSentinel !== undefined && data[windowSentinel] !== undefined) {
         return true;
     }
 


### PR DESCRIPTION
Closes #343

Enterprise accounts have no 5-hour/7-day rate-limit windows, so the usage API returns `five_hour: null` and `seven_day*: null` (#343). Those buckets parse to utilization `0` with no `resets_at`, which leaves the cache permanently "incomplete" for any widget that requires a reset timestamp: `fetchUsageData` then bypasses the cache and hits the live API on **every render**. At a 15s refresh interval Anthropic starts answering 429 with `Retry-After: 300`, and the lock makes the usage/money widgets flicker `[Rate limited]` / `[Timeout]` indefinitely.

Observed on a real Enterprise account: the API answers 200 with all windows null, the cache holds `{"sessionUsage":0,...}` with no reset fields, and the lock sits at `{"blockedUntil":...,"error":"rate-limited"}` in a permanent refetch/backoff cycle.

| Area                  | Change                                                                                                                                                                                           |
| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `usage-fetch.ts`      | a missing window reset field counts as satisfied once its paired utilization is cached: a null bucket parses to utilization 0 with no `resets_at`, so refetching can never produce the timestamp |
| `usage-fetch.test.ts` | probe test with the Enterprise response shape: first run fetches once, a second probe 10s later is served entirely from cache (zero requests)                                                    |

Notes:

- Same conclusiveness idea as #416, which covers the sibling `monthly_limit: null` case; the two PRs touch the same function and either rebases trivially on the other.
- No rendering changes; widgets display exactly what they did before, they just stop hammering the API.

