### PR TITLE
fix(config): non-destructive recovery + loud warning for invalid settings.json

### DIFF
--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -14,6 +14,7 @@ import { getVisibleText } from './utils/ansi';
 import { updateColorMap } from './utils/colors';
 import { getCompactionCount } from './utils/compaction';
 import {
+    getConfigLoadError,
     initConfigPath,
     loadSettings,
     saveSettings
@@ -26,6 +27,7 @@ import {
 } from './utils/jsonl';
 import { advanceGlobalPowerlineThemeIndex } from './utils/powerline-theme-index';
 import {
+    buildConfigWarningBadge,
     calculateMaxWidthsFromPreRendered,
     preRenderAllWidgets,
     renderStatusLine
@@ -88,6 +90,7 @@ async function ensureWindowsUtf8CodePage() {
 
 async function renderMultipleLines(data: StatusJSON) {
     const settings = await loadSettings();
+    const configError = getConfigLoadError();
 
     // Set global chalk level based on settings
     chalk.level = settings.colorLevel;
@@ -171,6 +174,7 @@ async function renderMultipleLines(data: StatusJSON) {
     // Render each line using pre-rendered content
     let globalSeparatorIndex = 0;
     let globalPowerlineThemeIndex = 0;
+    let configBadgePrepended = false;
     for (let i = 0; i < lines.length; i++) {
         const lineItems = lines[i];
         if (lineItems && lineItems.length > 0) {
@@ -181,12 +185,18 @@ async function renderMultipleLines(data: StatusJSON) {
                 globalSeparatorIndex,
                 globalPowerlineThemeIndex
             };
-            const line = renderStatusLine(lineItems, settings, lineContext, preRenderedWidgets, preCalculatedMaxWidths);
+            let line = renderStatusLine(lineItems, settings, lineContext, preRenderedWidgets, preCalculatedMaxWidths);
 
             // Only output the line if it has content (not just ANSI codes)
             // Strip ANSI codes to check if there's actual text
             const strippedLine = getVisibleText(line).trim();
             if (strippedLine.length > 0) {
+                if (configError && !configBadgePrepended) {
+                    // On the error path settings are always inMemoryDefaults(), whose separators render as ' | '.
+                    line = `${buildConfigWarningBadge(settings.colorLevel)} | ${line}`;
+                    configBadgePrepended = true;
+                }
+
                 // Replace all spaces with non-breaking spaces to prevent VSCode trimming
                 let outputLine = line.replace(/ /g, '\u00A0');
 
@@ -200,6 +210,11 @@ async function renderMultipleLines(data: StatusJSON) {
                 }
             }
         }
+    }
+
+    // Defensive fallback: if no content line was emitted, ensure the warning is not lost
+    if (configError && !configBadgePrepended) {
+        console.log('\x1b[0m' + buildConfigWarningBadge(settings.colorLevel).replace(/ /g, '\u00A0'));
     }
 
     // Check if there's an update message to display

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -90,50 +90,79 @@ describe('config utilities', () => {
         );
     });
 
-    it('backs up invalid JSON and recovers with defaults', async () => {
+    it('uses defaults in memory and preserves invalid JSON without overwriting', async () => {
         const { settingsPath, backupPath, configDir } = getSettingsPaths();
         fs.mkdirSync(configDir, { recursive: true });
         fs.writeFileSync(settingsPath, '{ invalid json', 'utf-8');
 
         const settings = await loadSettings();
 
+        // Defaults are returned in memory.
         expect(settings.version).toBe(CURRENT_VERSION);
-        expect(fs.existsSync(backupPath)).toBe(true);
-        expect(fs.readFileSync(backupPath, 'utf-8')).toBe('{ invalid json');
 
-        const recovered = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as { version?: number };
-        expect(recovered.version).toBe(CURRENT_VERSION);
+        // The invalid file is left exactly as the user wrote it (not overwritten).
+        expect(fs.readFileSync(settingsPath, 'utf-8')).toBe('{ invalid json');
+
+        // No backup is created: recovery is non-destructive, so the original is the backup.
+        expect(fs.existsSync(backupPath)).toBe(false);
+
+        // A diagnostic is still emitted.
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-            'Failed to parse settings.json, backing up and using defaults'
-        );
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-            expect.stringContaining('Bad settings backed up to')
-        );
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-            expect.stringContaining('Default settings written to')
+            expect.stringContaining('Failed to parse settings.json')
         );
     });
 
-    it('backs up invalid v1 payloads and recovers with defaults', async () => {
+    it('uses defaults in memory and preserves an invalid v1 payload', async () => {
         const { settingsPath, backupPath, configDir } = getSettingsPaths();
         fs.mkdirSync(configDir, { recursive: true });
-        fs.writeFileSync(settingsPath, JSON.stringify({ flexMode: 123 }), 'utf-8');
+        const original = JSON.stringify({ flexMode: 123 });
+        fs.writeFileSync(settingsPath, original, 'utf-8');
 
         const settings = await loadSettings();
 
         expect(settings.version).toBe(CURRENT_VERSION);
-        expect(fs.existsSync(backupPath)).toBe(true);
-        const recovered = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as { version?: number };
-        expect(recovered.version).toBe(CURRENT_VERSION);
+        expect(fs.readFileSync(settingsPath, 'utf-8')).toBe(original);
+        expect(fs.existsSync(backupPath)).toBe(false);
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-            'Invalid v1 settings format:',
+            expect.stringContaining('Invalid v1 settings format'),
             expect.anything()
         );
+    });
+
+    it('uses defaults in memory when schema validation fails', async () => {
+        const { settingsPath, backupPath, configDir } = getSettingsPaths();
+        fs.mkdirSync(configDir, { recursive: true });
+        // Has a version (skips v1 branch), version === CURRENT_VERSION (no migration),
+        // but `lines: 42` is not an array, so SettingsSchema validation fails.
+        const original = JSON.stringify({ version: CURRENT_VERSION, lines: 42 });
+        fs.writeFileSync(settingsPath, original, 'utf-8');
+
+        const settings = await loadSettings();
+
+        expect(settings.version).toBe(CURRENT_VERSION);
+        expect(fs.readFileSync(settingsPath, 'utf-8')).toBe(original);
+        expect(fs.existsSync(backupPath)).toBe(false);
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-            expect.stringContaining('Bad settings backed up to')
+            expect.stringContaining('Failed to parse settings, using defaults'),
+            expect.anything()
         );
+    });
+
+    it('uses defaults in memory when the settings file cannot be read', async () => {
+        const { settingsPath, backupPath, configDir } = getSettingsPaths();
+        fs.mkdirSync(configDir, { recursive: true });
+        // Make settings.json a directory so readFile throws (EISDIR) -> outer catch path.
+        fs.mkdirSync(settingsPath, { recursive: true });
+
+        const settings = await loadSettings();
+
+        expect(settings.version).toBe(CURRENT_VERSION);
+        // The path is left as-is (still a directory) — nothing was written over it.
+        expect(fs.statSync(settingsPath).isDirectory()).toBe(true);
+        expect(fs.existsSync(backupPath)).toBe(false);
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-            expect.stringContaining('Default settings written to')
+            expect.stringContaining('Error loading settings'),
+            expect.anything()
         );
     });
 

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -15,6 +15,7 @@ import {
 import {
     CURRENT_VERSION,
     DEFAULT_SETTINGS,
+    type InstallationMetadata,
     type Settings
 } from '../../types/Settings';
 
@@ -25,6 +26,7 @@ let loadSettings: () => Promise<Settings>;
 let saveSettings: (settings: Settings) => Promise<void>;
 let initConfigPath: (filePath?: string) => void;
 let getConfigLoadError: () => string | null;
+let saveInstallationMetadata: (metadata: InstallationMetadata | undefined) => Promise<void>;
 let consoleErrorSpy: MockInstance<typeof console.error>;
 
 function getSettingsPaths(): { configDir: string; settingsPath: string; backupPath: string } {
@@ -47,6 +49,7 @@ describe('config utilities', () => {
         saveSettings = configModule.saveSettings;
         initConfigPath = configModule.initConfigPath;
         getConfigLoadError = configModule.getConfigLoadError;
+        saveInstallationMetadata = configModule.saveInstallationMetadata;
     });
 
     beforeEach(() => {
@@ -211,6 +214,34 @@ describe('config utilities', () => {
         expect(fs.readdirSync(configDir).filter(name => name.endsWith('.tmp'))).toEqual([]);
         // The failure is recorded so the statusline can warn.
         expect(getConfigLoadError()).not.toBeNull();
+    });
+
+    it('does not overwrite an unreadable settings.json when recording installation metadata', async () => {
+        const { settingsPath, backupPath, configDir } = getSettingsPaths();
+        fs.mkdirSync(configDir, { recursive: true });
+        const original = '{ invalid json';
+        fs.writeFileSync(settingsPath, original, 'utf-8');
+
+        await saveInstallationMetadata({ method: 'pinned' });
+
+        // The unreadable file is preserved, not overwritten with defaults+metadata.
+        expect(fs.readFileSync(settingsPath, 'utf-8')).toBe(original);
+        expect(fs.existsSync(backupPath)).toBe(false);
+    });
+
+    it('records installation metadata when settings.json is valid', async () => {
+        const { settingsPath, configDir } = getSettingsPaths();
+        fs.mkdirSync(configDir, { recursive: true });
+        fs.writeFileSync(
+            settingsPath,
+            JSON.stringify({ version: CURRENT_VERSION, lines: [[], [], []] }),
+            'utf-8'
+        );
+
+        await saveInstallationMetadata({ method: 'pinned' });
+
+        const saved = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as { installation?: { method?: string } };
+        expect(saved.installation?.method).toBe('pinned');
     });
 
     it('always saves current version in saveSettings', async () => {

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -203,6 +203,55 @@ describe('config utilities', () => {
         expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
 
+    it('saves settings without leaving a temp file behind', async () => {
+        const { settingsPath, configDir } = getSettingsPaths();
+
+        await saveSettings({ ...DEFAULT_SETTINGS });
+
+        // Final file is complete and valid.
+        const saved = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as { version?: number };
+        expect(saved.version).toBe(CURRENT_VERSION);
+
+        // No temporary write-file is left in the config directory.
+        const leftovers = fs.readdirSync(configDir).filter(name => name.endsWith('.tmp'));
+        expect(leftovers).toEqual([]);
+    });
+
+    it('migration write-back leaves no temp file behind', async () => {
+        const { settingsPath, configDir } = getSettingsPaths();
+        fs.mkdirSync(configDir, { recursive: true });
+        fs.writeFileSync(
+            settingsPath,
+            JSON.stringify({
+                version: 2,
+                lines: [[{ id: 'widget-1', type: 'model' }]]
+            }),
+            'utf-8'
+        );
+
+        await loadSettings();
+
+        const migrated = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as { version?: number };
+        expect(migrated.version).toBe(CURRENT_VERSION);
+        const leftovers = fs.readdirSync(configDir).filter(name => name.endsWith('.tmp'));
+        expect(leftovers).toEqual([]);
+    });
+
+    it('cleans up the temp file and rethrows when the write cannot be renamed into place', async () => {
+        const { settingsPath, configDir } = getSettingsPaths();
+        fs.mkdirSync(configDir, { recursive: true });
+        // Make the target a directory so the final rename always fails, exercising
+        // the cleanup-on-error path in writeSettingsJson.
+        fs.mkdirSync(settingsPath, { recursive: true });
+
+        await expect(saveSettings({ ...DEFAULT_SETTINGS })).rejects.toThrow();
+
+        // The target is untouched and no temp file is left behind.
+        expect(fs.statSync(settingsPath).isDirectory()).toBe(true);
+        const leftovers = fs.readdirSync(configDir).filter(name => name.endsWith('.tmp'));
+        expect(leftovers).toEqual([]);
+    });
+
     it('silently rewrites legacy git-pr widget type to git-review on load', async () => {
         const { settingsPath, configDir } = getSettingsPaths();
         fs.mkdirSync(configDir, { recursive: true });

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -192,6 +192,27 @@ describe('config utilities', () => {
         expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
 
+    it('does not overwrite the file when a migration produces an invalid result', async () => {
+        const { settingsPath, backupPath, configDir } = getSettingsPaths();
+        fs.mkdirSync(configDir, { recursive: true });
+        // A v2 config whose migrated v3 form fails schema validation: the v2->v3 migration
+        // copies fields through, so `lines: 42` survives into the v3 result and fails the schema.
+        const original = JSON.stringify({ version: 2, lines: 42 });
+        fs.writeFileSync(settingsPath, original, 'utf-8');
+
+        const settings = await loadSettings();
+
+        // Falls back to defaults in memory.
+        expect(settings.version).toBe(CURRENT_VERSION);
+        // The original file is preserved — the invalid migration was NOT written over it.
+        expect(fs.readFileSync(settingsPath, 'utf-8')).toBe(original);
+        // No backup, and no temp residue from an aborted write.
+        expect(fs.existsSync(backupPath)).toBe(false);
+        expect(fs.readdirSync(configDir).filter(name => name.endsWith('.tmp'))).toEqual([]);
+        // The failure is recorded so the statusline can warn.
+        expect(getConfigLoadError()).not.toBeNull();
+    });
+
     it('always saves current version in saveSettings', async () => {
         const { settingsPath } = getSettingsPaths();
 

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -24,6 +24,7 @@ const ORIGINAL_CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR;
 let loadSettings: () => Promise<Settings>;
 let saveSettings: (settings: Settings) => Promise<void>;
 let initConfigPath: (filePath?: string) => void;
+let getConfigLoadError: () => string | null;
 let consoleErrorSpy: MockInstance<typeof console.error>;
 
 function getSettingsPaths(): { configDir: string; settingsPath: string; backupPath: string } {
@@ -45,6 +46,7 @@ describe('config utilities', () => {
         loadSettings = configModule.loadSettings;
         saveSettings = configModule.saveSettings;
         initConfigPath = configModule.initConfigPath;
+        getConfigLoadError = configModule.getConfigLoadError;
     });
 
     beforeEach(() => {
@@ -250,6 +252,46 @@ describe('config utilities', () => {
         expect(fs.statSync(settingsPath).isDirectory()).toBe(true);
         const leftovers = fs.readdirSync(configDir).filter(name => name.endsWith('.tmp'));
         expect(leftovers).toEqual([]);
+    });
+
+    it('sets getConfigLoadError when settings.json contains invalid JSON', async () => {
+        const { configDir, settingsPath } = getSettingsPaths();
+        fs.mkdirSync(configDir, { recursive: true });
+        fs.writeFileSync(settingsPath, '{ bad json', 'utf-8');
+
+        await loadSettings();
+
+        const err = getConfigLoadError();
+        expect(err).not.toBeNull();
+        expect(err).toContain('settings.json');
+    });
+
+    it('sets getConfigLoadError when settings.json has invalid schema', async () => {
+        const { configDir, settingsPath } = getSettingsPaths();
+        fs.mkdirSync(configDir, { recursive: true });
+        fs.writeFileSync(settingsPath, JSON.stringify({ version: CURRENT_VERSION, lines: 42 }), 'utf-8');
+
+        await loadSettings();
+
+        expect(getConfigLoadError()).not.toBeNull();
+    });
+
+    it('clears getConfigLoadError after loading a valid current-version config', async () => {
+        const { configDir, settingsPath } = getSettingsPaths();
+        fs.mkdirSync(configDir, { recursive: true });
+        // Write a valid config so we don't go through first-run path
+        fs.writeFileSync(settingsPath, JSON.stringify({ version: CURRENT_VERSION, lines: [[], [], []] }), 'utf-8');
+
+        await loadSettings();
+
+        expect(getConfigLoadError()).toBeNull();
+    });
+
+    it('leaves getConfigLoadError null on first-run (no file)', async () => {
+        // No file written — loadSettings triggers writeDefaultSettings
+        await loadSettings();
+
+        expect(getConfigLoadError()).toBeNull();
     });
 
     it('silently rewrites legacy git-pr widget type to git-review on load', async () => {

--- a/src/utils/__tests__/renderer-config-warning.test.ts
+++ b/src/utils/__tests__/renderer-config-warning.test.ts
@@ -1,0 +1,35 @@
+import chalk from 'chalk';
+import {
+    afterEach,
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import { updateColorMap } from '../colors';
+import { buildConfigWarningBadge } from '../renderer';
+
+describe('buildConfigWarningBadge', () => {
+    const originalLevel = chalk.level;
+
+    afterEach(() => {
+        chalk.level = originalLevel;
+        updateColorMap();
+    });
+
+    it('returns plain text with no ANSI escapes when colorLevel is 0', () => {
+        chalk.level = 0;
+        updateColorMap();
+        const result = buildConfigWarningBadge(0);
+        expect(result).toBe('⚠ invalid config');
+        expect(result).not.toContain('\x1b');
+    });
+
+    it('contains the text and ANSI escapes when colorLevel is 2', () => {
+        chalk.level = 2;
+        updateColorMap();
+        const result = buildConfigWarningBadge(2);
+        expect(result).toContain('invalid config');
+        expect(result).toContain('\x1b');
+    });
+});

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -40,20 +40,12 @@ export function isCustomConfigPath(): boolean {
 interface SettingsPaths {
     configDir: string;
     settingsPath: string;
-    settingsBackupPath: string;
 }
 
 function getSettingsPaths(): SettingsPaths {
-    const configDir = path.dirname(settingsPath);
-    const parsedPath = path.parse(settingsPath);
-    const backupBaseName = parsedPath.ext
-        ? `${parsedPath.name}.bak`
-        : `${parsedPath.base}.bak`;
-
     return {
-        configDir,
-        settingsPath,
-        settingsBackupPath: path.join(configDir, backupBaseName)
+        configDir: path.dirname(settingsPath),
+        settingsPath
     };
 }
 
@@ -62,38 +54,22 @@ async function writeSettingsJson(settings: unknown, paths: SettingsPaths): Promi
     await writeFile(paths.settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
 }
 
-async function backupBadSettings(paths: SettingsPaths): Promise<void> {
-    try {
-        if (fs.existsSync(paths.settingsPath)) {
-            const content = await readFile(paths.settingsPath, 'utf-8');
-            await writeFile(paths.settingsBackupPath, content, 'utf-8');
-            console.error(`Bad settings backed up to ${paths.settingsBackupPath}`);
-        }
-    } catch (error) {
-        console.error('Failed to backup bad settings:', error);
-    }
+function inMemoryDefaults(): Settings {
+    // Defaults held in memory only (version included via the schema default).
+    // Returned on recovery without writing, so a malformed file is preserved.
+    return SettingsSchema.parse({});
 }
 
 async function writeDefaultSettings(paths: SettingsPaths): Promise<Settings> {
-    const defaults = SettingsSchema.parse({});
-    const settingsWithVersion = {
-        ...defaults,
-        version: CURRENT_VERSION
-    };
-
+    const defaults = inMemoryDefaults();
     try {
-        await writeSettingsJson(settingsWithVersion, paths);
+        await writeSettingsJson(defaults, paths);
         console.error(`Default settings written to ${paths.settingsPath}`);
     } catch (error) {
         console.error('Failed to write default settings:', error);
     }
 
     return defaults;
-}
-
-async function recoverWithDefaults(paths: SettingsPaths): Promise<Settings> {
-    await backupBadSettings(paths);
-    return await writeDefaultSettings(paths);
 }
 
 export async function loadSettings(): Promise<Settings> {
@@ -110,9 +86,8 @@ export async function loadSettings(): Promise<Settings> {
         try {
             rawData = JSON.parse(content);
         } catch {
-            // If we can't parse the JSON, backup and write defaults
-            console.error('Failed to parse settings.json, backing up and using defaults');
-            return await recoverWithDefaults(paths);
+            console.error('Failed to parse settings.json, using defaults (file left unchanged)');
+            return inMemoryDefaults();
         }
 
         // Check if this is a v1 config (no version field)
@@ -121,8 +96,8 @@ export async function loadSettings(): Promise<Settings> {
             // Parse as v1 to validate before migration
             const v1Result = SettingsSchema_v1.safeParse(rawData);
             if (!v1Result.success) {
-                console.error('Invalid v1 settings format:', v1Result.error);
-                return await recoverWithDefaults(paths);
+                console.error('Invalid v1 settings format, using defaults (file left unchanged):', v1Result.error);
+                return inMemoryDefaults();
             }
 
             // Migrate v1 to current version and save the migrated settings back to disk
@@ -138,8 +113,8 @@ export async function loadSettings(): Promise<Settings> {
         // Parse with main schema which will apply all defaults
         const result = SettingsSchema.safeParse(rawData);
         if (!result.success) {
-            console.error('Failed to parse settings:', result.error);
-            return await recoverWithDefaults(paths);
+            console.error('Failed to parse settings, using defaults (file left unchanged):', result.error);
+            return inMemoryDefaults();
         }
 
         return {
@@ -147,9 +122,8 @@ export async function loadSettings(): Promise<Settings> {
             lines: upgradeLegacyWidgetTypes(result.data.lines)
         };
     } catch (error) {
-        // Any other error, backup and write defaults
-        console.error('Error loading settings:', error);
-        return await recoverWithDefaults(paths);
+        console.error('Error loading settings, using defaults:', error);
+        return inMemoryDefaults();
     }
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -195,6 +195,15 @@ export async function saveInstallationMetadata(metadata: InstallationMetadata | 
     }
 
     const settings = await loadSettings();
+
+    // If the existing settings.json couldn't be read, don't overwrite it just to
+    // record installation metadata — that would discard the user's (recoverable)
+    // file. Metadata is non-critical and is persisted on the next clean save.
+    if (getConfigLoadError() !== null) {
+        console.error('Skipping installation-metadata write: settings.json is unreadable (left unchanged).');
+        return;
+    }
+
     const settingsWithVersion: Settings & { version: number } = {
         ...settings,
         version: CURRENT_VERSION

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -26,6 +26,11 @@ const unlink = fs.promises.unlink;
 const DEFAULT_SETTINGS_PATH = path.join(os.homedir(), '.config', 'ccstatusline', 'settings.json');
 
 let settingsPath = DEFAULT_SETTINGS_PATH;
+let lastLoadError: string | null = null;
+
+export function getConfigLoadError(): string | null {
+    return lastLoadError;
+}
 
 export function initConfigPath(filePath?: string): void {
     settingsPath = filePath ? path.resolve(filePath) : DEFAULT_SETTINGS_PATH;
@@ -89,6 +94,7 @@ async function writeDefaultSettings(paths: SettingsPaths): Promise<Settings> {
 }
 
 export async function loadSettings(): Promise<Settings> {
+    lastLoadError = null;
     const paths = getSettingsPaths();
 
     try {
@@ -103,6 +109,7 @@ export async function loadSettings(): Promise<Settings> {
             rawData = JSON.parse(content);
         } catch {
             console.error('Failed to parse settings.json, using defaults (file left unchanged)');
+            lastLoadError = 'settings.json is not valid JSON';
             return inMemoryDefaults();
         }
 
@@ -113,6 +120,7 @@ export async function loadSettings(): Promise<Settings> {
             const v1Result = SettingsSchema_v1.safeParse(rawData);
             if (!v1Result.success) {
                 console.error('Invalid v1 settings format, using defaults (file left unchanged):', v1Result.error);
+                lastLoadError = 'settings.json is not in a valid format';
                 return inMemoryDefaults();
             }
 
@@ -130,6 +138,7 @@ export async function loadSettings(): Promise<Settings> {
         const result = SettingsSchema.safeParse(rawData);
         if (!result.success) {
             console.error('Failed to parse settings, using defaults:', result.error);
+            lastLoadError = 'settings.json is not in a valid format';
             return inMemoryDefaults();
         }
 
@@ -139,6 +148,7 @@ export async function loadSettings(): Promise<Settings> {
         };
     } catch (error) {
         console.error('Error loading settings, using defaults:', error);
+        lastLoadError = 'settings.json could not be read';
         return inMemoryDefaults();
     }
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -20,6 +20,8 @@ import { upgradeLegacyWidgetTypes } from './widgets';
 const readFile = fs.promises.readFile;
 const writeFile = fs.promises.writeFile;
 const mkdir = fs.promises.mkdir;
+const rename = fs.promises.rename;
+const unlink = fs.promises.unlink;
 
 const DEFAULT_SETTINGS_PATH = path.join(os.homedir(), '.config', 'ccstatusline', 'settings.json');
 
@@ -51,7 +53,21 @@ function getSettingsPaths(): SettingsPaths {
 
 async function writeSettingsJson(settings: unknown, paths: SettingsPaths): Promise<void> {
     await mkdir(paths.configDir, { recursive: true });
-    await writeFile(paths.settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+
+    // Write to a unique temp file in the same directory, then atomically rename
+    // over the target. A concurrent reader (e.g. the statusline render path firing
+    // mid-save) sees either the complete old file or the complete new file, never a
+    // torn write. Same idiom as git.ts:writePersistentCache.
+    const tempPath = `${paths.settingsPath}.${process.pid}.${Date.now()}.tmp`;
+    try {
+        await writeFile(tempPath, JSON.stringify(settings, null, 2), 'utf-8');
+        await rename(tempPath, paths.settingsPath);
+    } catch (error) {
+        try {
+            await unlink(tempPath);
+        } catch { /* best-effort cleanup; ignore */ }
+        throw error;
+    }
 }
 
 function inMemoryDefaults(): Settings {
@@ -113,7 +129,7 @@ export async function loadSettings(): Promise<Settings> {
         // Parse with main schema which will apply all defaults
         const result = SettingsSchema.safeParse(rawData);
         if (!result.success) {
-            console.error('Failed to parse settings, using defaults (file left unchanged):', result.error);
+            console.error('Failed to parse settings, using defaults:', result.error);
             return inMemoryDefaults();
         }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -93,6 +93,16 @@ async function writeDefaultSettings(paths: SettingsPaths): Promise<Settings> {
     return defaults;
 }
 
+/**
+ * Load ccstatusline settings from disk.
+ *
+ * Recovery contract: if the file cannot be read or fails validation, loadSettings
+ * NEVER overwrites it — it returns built-in defaults in memory, records the reason
+ * (see getConfigLoadError), and leaves the file untouched for the user to fix. The
+ * file is written only when it is missing (first run), or when a readable config is
+ * migrated to the current version AND the migrated result validates first. All writes
+ * go through writeSettingsJson, which is atomic (temp file + rename).
+ */
 export async function loadSettings(): Promise<Settings> {
     lastLoadError = null;
     const paths = getSettingsPaths();
@@ -115,6 +125,7 @@ export async function loadSettings(): Promise<Settings> {
 
         // Check if this is a v1 config (no version field)
         const hasVersion = typeof rawData === 'object' && rawData !== null && 'version' in rawData;
+        let migrated = false;
         if (!hasVersion) {
             // Parse as v1 to validate before migration
             const v1Result = SettingsSchema_v1.safeParse(rawData);
@@ -124,22 +135,28 @@ export async function loadSettings(): Promise<Settings> {
                 return inMemoryDefaults();
             }
 
-            // Migrate v1 to current version and save the migrated settings back to disk
+            // Migrate v1 to the current version (persisted below, only once it validates)
             rawData = migrateConfig(rawData, CURRENT_VERSION);
-            await writeSettingsJson(rawData, paths);
+            migrated = true;
         } else if (needsMigration(rawData, CURRENT_VERSION)) {
-            // Handle migrations for versioned configs (v2+) and save the migrated settings back to disk
+            // Migrate versioned configs (v2+) to current (persisted below, only once it validates)
             rawData = migrateConfig(rawData, CURRENT_VERSION);
-            await writeSettingsJson(rawData, paths);
+            migrated = true;
         }
 
         // At this point, data should be in current format with version field
         // Parse with main schema which will apply all defaults
         const result = SettingsSchema.safeParse(rawData);
         if (!result.success) {
-            console.error('Failed to parse settings, using defaults:', result.error);
+            console.error('Failed to parse settings, using defaults (file left unchanged):', result.error);
             lastLoadError = 'settings.json is not in a valid format';
             return inMemoryDefaults();
+        }
+
+        // Persist a migration only after the migrated result validates, so a faulty
+        // migration can never overwrite the user's original file.
+        if (migrated) {
+            await writeSettingsJson(rawData, paths);
         }
 
         return {

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -4,7 +4,10 @@ import type {
     RenderContext,
     WidgetItem
 } from '../types';
-import { getColorLevelString } from '../types/ColorLevel';
+import {
+    getColorLevelString,
+    type ColorLevel
+} from '../types/ColorLevel';
 import type { Settings } from '../types/Settings';
 
 import {
@@ -36,6 +39,12 @@ export function formatTokens(count: number): string {
     if (count >= 1000)
         return `${(count / 1000).toFixed(1)}k`;
     return count.toString();
+}
+
+// Build a red warning badge indicating that settings.json could not be loaded.
+// Passes colorLevel through so color is suppressed when the terminal has no color support.
+export function buildConfigWarningBadge(colorLevel: ColorLevel): string {
+    return applyColors('⚠ invalid config', 'red', undefined, false, getColorLevelString(colorLevel));
 }
 
 // Paint a foreground gradient across a finished line when overrideForegroundColor


### PR DESCRIPTION
## Summary

Fixes #393. Today a single malformed `settings.json` silently wipes the user's entire
ccstatusline configuration. This PR makes configuration loading **non-destructive** — an
unreadable config is never overwritten — surfaces the failure **loudly** in the statusline
instead of swallowing it, and makes every config write **atomic**.

## The problem

`loadSettings()` runs on the statusline render path, i.e. on **every prompt**. Before this
PR, when `settings.json` failed to parse or validate, recovery backed the file up to
`settings.bak` and then **overwrote `settings.json` with defaults**. Because that happens
automatically on the render path, one bad edit — a stray comma, a trailing brace — silently
replaced the user's whole configuration with defaults. The only trace was a `console.error`
to stderr, which the piped statusline never shows. As #393 puts it: *"it took me some time
to figure out … all your changes are lost."*

## The fix

Three principles, applied to every path through config load/save:

1. **Never overwrite a config we can't read.** On any unreadable or invalid input, fall back
   to built-in defaults **in memory only** and leave the file exactly as it is on disk — so
   the user can correct the typo and their configuration returns on the next render, with no
   backup to hunt down and no restore step. (This extends a pattern already in the codebase:
   the legacy `git-pr` → `git-review` widget rewrite is likewise applied in memory on load
   and only persisted on the next save.)
2. **Fail loudly, not silently.** When recovery happens, the statusline prepends a red
   `⚠ invalid config` badge, so the problem is obvious instead of masquerading as a working
   (default) bar. The detailed reason still goes to stderr.
3. **Write atomically.** Config writes now go through a temp file + `rename` — the same idiom
   already used by `writePersistentCache()` in `git.ts` — so a reader on the render path can
   never observe a half-written file (which itself used to trip the reset).

## Behavior, before and after

| Scenario | Before this PR | After this PR |
|----------|----------------|---------------|
| File missing (first run) | write defaults | write defaults *(now atomic)* |
| Valid current config | load and use | load and use |
| Valid but older version | migrate → **write** → validate | migrate → validate → **write only if valid** |
| Invalid JSON | `.bak` + **overwrite with defaults** | **defaults in memory; file untouched** + `⚠` badge |
| Schema-invalid | `.bak` + **overwrite with defaults** | **defaults in memory; file untouched** + `⚠` badge |
| Unreadable file | `.bak` + **overwrite with defaults** | **defaults in memory; file untouched** + `⚠` badge |
| Migration yields an invalid result | **overwrites with the bad migration** | **defaults in memory; file untouched** + `⚠` badge |
| Recording install metadata over an unreadable file | overwrite with defaults + metadata | **skip the write; file untouched** |
| Any write (defaults / migration / save) | direct `writeFile` (can tear) | temp file + atomic `rename` |

On an invalid config the statusline now reads:

```
⚠ invalid config | Model: Opus 4.6 | Ctx: 15.5k | ⎇ main
```

## A note on the removed `.bak`

The previous recovery backed the bad file up to `settings.bak` before overwriting it. Since
recovery no longer overwrites anything, that backup would just be a copy of the original —
which is now left in place — so it has been removed. Happy to restore a `.bak` snapshot if
you'd prefer to keep one.

## Testing

- New/updated unit tests in `config.test.ts` and a new `renderer-config-warning.test.ts`
  cover: every recovery path preserving the file on disk (and writing no `.bak`); the
  migration-validates-before-persist guard; the install-metadata guard; atomic writes leaving
  no temp residue (and cleaning up on a failed rename); and the warning badge (red, and plain
  at color level 0).
- **Cross-platform matrix:** the suite was run on a **Linux / macOS / Windows** matrix. It is
  fully green on Linux and macOS, and every test exercising this change — including the atomic
  temp-file + `rename` path — passes on Windows as well. **This change introduces no new test
  failures on any platform.**

Closes #393
