### PR TITLE
fix(context-bar): render counts >= 1M as "1.0M" instead of "1000k"

### DIFF
--- a/src/utils/__tests__/renderer-format-tokens.test.ts
+++ b/src/utils/__tests__/renderer-format-tokens.test.ts
@@ -33,4 +33,11 @@ describe('formatTokens', () => {
     it('still renders just below the boundary as k', () => {
         expect(formatTokens(999949)).toBe('999.9k');
     });
+
+    it('uses whole-number k and rolls up to M at decimals=0', () => {
+        expect(formatTokens(711000, 0)).toBe('711k');
+        expect(formatTokens(999499, 0)).toBe('999k');
+        expect(formatTokens(999500, 0)).toBe('1.0M');
+        expect(formatTokens(1000000, 0)).toBe('1.0M');
+    });
 });

--- a/src/utils/format-tokens.ts
+++ b/src/utils/format-tokens.ts
@@ -1,8 +1,12 @@
-export function formatTokens(count: number): string {
-    // 999_950+ rounds to "1000.0k" at one decimal place; render it as "1.0M" instead.
-    if (count >= 999950)
+// Format a token count with `decimals` places in the "k" range. Once the k
+// value would round up to "1000" at that precision (within half a displayed
+// unit of 1M), promote to "1.0M" instead — at decimals=1 that boundary is
+// 999_950 ("1000.0k" -> "1.0M"), at decimals=0 it is 999_500 ("1000k" -> "1.0M").
+// decimals defaults to 1; callers wanting a compact whole-number k pass 0.
+export function formatTokens(count: number, decimals = 1): string {
+    if (count >= 1000000 - 500 / 10 ** decimals)
         return `${(count / 1000000).toFixed(1)}M`;
     if (count >= 1000)
-        return `${(count / 1000).toFixed(1)}k`;
+        return `${(count / 1000).toFixed(decimals)}k`;
     return count.toString();
 }

--- a/src/widgets/ContextBar.ts
+++ b/src/widgets/ContextBar.ts
@@ -11,6 +11,7 @@ import {
     getContextConfig,
     getModelContextIdentifier
 } from '../utils/model-context';
+import { formatTokens } from '../utils/renderer';
 import { makeUsageProgressBar } from '../utils/usage';
 
 import { makeSliderBar } from './shared/usage-display';
@@ -110,17 +111,17 @@ export class ContextBarWidget implements Widget {
 
         const percent = (used / total) * 100;
         const clampedPercent = Math.max(0, Math.min(100, percent));
-        const usedK = Math.round(used / 1000);
-        const totalK = Math.round(total / 1000);
+        const usedDisplay = formatTokens(used, 0);
+        const totalDisplay = formatTokens(total, 0);
 
         if (isBarSliderMode(displayMode)) {
             const slider = makeSliderBar(clampedPercent);
-            const sliderDisplay = displayMode === 'slider' ? `${slider} ${usedK}k/${totalK}k (${Math.round(clampedPercent)}%)` : slider;
+            const sliderDisplay = displayMode === 'slider' ? `${slider} ${usedDisplay}/${totalDisplay} (${Math.round(clampedPercent)}%)` : slider;
             return item.rawValue ? sliderDisplay : `Context: ${sliderDisplay}`;
         }
 
         const barWidth = displayMode === 'progress' ? 32 : 16;
-        const display = `${makeUsageProgressBar(clampedPercent, barWidth)} ${usedK}k/${totalK}k (${Math.round(clampedPercent)}%)`;
+        const display = `${makeUsageProgressBar(clampedPercent, barWidth)} ${usedDisplay}/${totalDisplay} (${Math.round(clampedPercent)}%)`;
 
         return item.rawValue ? display : `Context: ${display}`;
     }

--- a/src/widgets/__tests__/ContextBar.test.ts
+++ b/src/widgets/__tests__/ContextBar.test.ts
@@ -71,7 +71,7 @@ describe('ContextBarWidget', () => {
         };
         const widget = new ContextBarWidget();
 
-        expect(widget.render({ id: 'ctx', type: 'context-bar' }, context, DEFAULT_SETTINGS)).toBe('Context: [bar:5.0:16] 50k/1000k (5%)');
+        expect(widget.render({ id: 'ctx', type: 'context-bar' }, context, DEFAULT_SETTINGS)).toBe('Context: [bar:5.0:16] 50k/1.0M (5%)');
     });
 
     it('uses 1M in parentheses model IDs in fallback mode', () => {
@@ -87,7 +87,7 @@ describe('ContextBarWidget', () => {
         };
         const widget = new ContextBarWidget();
 
-        expect(widget.render({ id: 'ctx', type: 'context-bar' }, context, DEFAULT_SETTINGS)).toBe('Context: [bar:5.0:16] 50k/1000k (5%)');
+        expect(widget.render({ id: 'ctx', type: 'context-bar' }, context, DEFAULT_SETTINGS)).toBe('Context: [bar:5.0:16] 50k/1.0M (5%)');
     });
 
     it('clamps usage percentage to 100 when context length exceeds total', () => {


### PR DESCRIPTION
Closes #449.

`ContextBar` formatted used/total with `Math.round(n / 1000) + 'k'`, so a 1M context window rendered as `1000k` (e.g. `504k/1000k`) — the only token readout ignoring the `M` rollup `formatTokens` already does.

`formatTokens` gains an optional `decimals` arg (default `1`, behavior-preserving for every existing caller, including the #444 999950 boundary); the bar calls `formatTokens(n, 0)`, keeping its compact whole-number `k` and gaining the rollup, e.g. `711k/1.0M`.

Tested: `bun run lint` clean; `bun test` green except the same Windows-environment failures `main` has.