### PR TITLE
test: make the suite pass on Windows hosts

### DIFF
--- a/src/utils/__tests__/claude-settings.test.ts
+++ b/src/utils/__tests__/claude-settings.test.ts
@@ -32,7 +32,7 @@ import {
     setRefreshInterval,
     uninstallStatusLine
 } from '../claude-settings';
-import { initConfigPath } from '../config';
+import * as config from '../config';
 
 const ORIGINAL_CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR;
 let testClaudeConfigDir = '';
@@ -60,11 +60,12 @@ function writeRawClaudeSettings(content: string): void {
 beforeEach(() => {
     testClaudeConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-claude-settings-'));
     process.env.CLAUDE_CONFIG_DIR = testClaudeConfigDir;
-    initConfigPath(path.join(testClaudeConfigDir, 'ccstatusline-settings.json'));
+    config.initConfigPath(path.join(testClaudeConfigDir, 'ccstatusline-settings.json'));
 });
 
 afterEach(() => {
-    initConfigPath();
+    vi.restoreAllMocks();
+    config.initConfigPath();
     if (testClaudeConfigDir) {
         fs.rmSync(testClaudeConfigDir, { recursive: true, force: true });
     }
@@ -198,49 +199,55 @@ describe('Claude config paths', () => {
 
 describe('buildCommand via installStatusLine', () => {
     it('should use base command when no custom config path', async () => {
-        initConfigPath();
+        config.initConfigPath();
         await installStatusLine({ commandMode: 'auto-npx' });
         expect(readInstalledCommand()).toBe(CCSTATUSLINE_COMMANDS.NPM);
     });
 
     it('should append --config with simple path (no quoting needed)', async () => {
-        initConfigPath('/tmp/settings.json');
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+        vi.spyOn(config, 'getConfigPath').mockReturnValue('/tmp/settings.json');
         await installStatusLine({ commandMode: 'auto-npx' });
         expect(readInstalledCommand()).toBe(`${CCSTATUSLINE_COMMANDS.NPM} --config /tmp/settings.json`);
     });
 
     it('should quote path with spaces', async () => {
-        initConfigPath('/my path/settings.json');
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+        vi.spyOn(config, 'getConfigPath').mockReturnValue('/my path/settings.json');
         await installStatusLine({ commandMode: 'auto-npx' });
         expect(readInstalledCommand()).toBe(`${CCSTATUSLINE_COMMANDS.NPM} --config '/my path/settings.json'`);
     });
 
     it('should quote path with parentheses', async () => {
-        initConfigPath('/my(path)/settings.json');
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+        vi.spyOn(config, 'getConfigPath').mockReturnValue('/my(path)/settings.json');
         await installStatusLine({ commandMode: 'auto-npx' });
         expect(readInstalledCommand()).toBe(`${CCSTATUSLINE_COMMANDS.NPM} --config '/my(path)/settings.json'`);
     });
 
     it('should escape embedded single quotes in path', async () => {
-        initConfigPath('/my\'path/settings.json');
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+        vi.spyOn(config, 'getConfigPath').mockReturnValue('/my\'path/settings.json');
         await installStatusLine({ commandMode: 'auto-npx' });
         expect(readInstalledCommand()).toBe(`${CCSTATUSLINE_COMMANDS.NPM} --config '/my'\\''path/settings.json'`);
     });
 
     it('should use bunx command when commandMode is auto-bunx', async () => {
-        initConfigPath('/my path/settings.json');
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+        vi.spyOn(config, 'getConfigPath').mockReturnValue('/my path/settings.json');
         await installStatusLine({ commandMode: 'auto-bunx' });
         expect(readInstalledCommand()).toBe(`${CCSTATUSLINE_COMMANDS.BUNX} --config '/my path/settings.json'`);
     });
 
     it('should generate global command with custom config path', () => {
-        initConfigPath('/my path/settings.json');
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+        vi.spyOn(config, 'getConfigPath').mockReturnValue('/my path/settings.json');
         expect(buildStatusLineCommand('global')).toBe(`${CCSTATUSLINE_COMMANDS.GLOBAL} --config '/my path/settings.json'`);
     });
 
     it('should install global command for pinned installs and save metadata', async () => {
         const configPath = path.join(testClaudeConfigDir, 'pinned-settings.json');
-        initConfigPath(configPath);
+        config.initConfigPath(configPath);
 
         await installStatusLine({
             commandMode: 'global',
@@ -260,7 +267,7 @@ describe('buildCommand via installStatusLine', () => {
 
     it('should sync hooks on install when settings include hook-enabled widgets', async () => {
         const configPath = path.join(testClaudeConfigDir, 'ccstatusline-settings.json');
-        initConfigPath(configPath);
+        config.initConfigPath(configPath);
         const settingsWithSkills = {
             ...DEFAULT_SETTINGS,
             lines: [[{ id: 'skills-1', type: 'skills' }], [], []]
@@ -290,7 +297,7 @@ describe('buildCommand via installStatusLine', () => {
 
     it('should sync hooks from the final global statusline command', async () => {
         const configPath = path.join(testClaudeConfigDir, 'global-settings.json');
-        initConfigPath(configPath);
+        config.initConfigPath(configPath);
         fs.writeFileSync(configPath, JSON.stringify({
             ...DEFAULT_SETTINGS,
             lines: [[{ id: 'skills-1', type: 'skills' }], [], []]
@@ -320,13 +327,13 @@ describe('buildCommand via installStatusLine', () => {
 
 describe('installStatusLine refreshInterval', () => {
     it('should set refreshInterval to 10 when version is supported', async () => {
-        initConfigPath();
+        config.initConfigPath();
         await installStatusLine({ commandMode: 'auto-npx', supportsRefreshInterval: true });
         expect(readInstalledRefreshInterval()).toBe(10);
     });
 
     it('should not set refreshInterval when version is unsupported', async () => {
-        initConfigPath();
+        config.initConfigPath();
         await installStatusLine({ commandMode: 'auto-npx', supportsRefreshInterval: false });
         expect(readInstalledRefreshInterval()).toBeUndefined();
     });

--- a/src/utils/__tests__/config-dir.test.ts
+++ b/src/utils/__tests__/config-dir.test.ts
@@ -28,7 +28,7 @@ describe('initConfigPath / getConfigPath', () => {
 
     it('should return a custom settings path when a file path is provided', () => {
         initConfigPath('/tmp/my-ccsl/settings.json');
-        expect(getConfigPath()).toBe('/tmp/my-ccsl/settings.json');
+        expect(getConfigPath()).toBe(path.resolve('/tmp/my-ccsl/settings.json'));
         expect(isCustomConfigPath()).toBe(true);
     });
 

--- a/src/utils/__tests__/terminal.test.ts
+++ b/src/utils/__tests__/terminal.test.ts
@@ -27,6 +27,18 @@ describe('terminal utils', () => {
         mockReturnValueOnce: (value: string) => void;
     };
 
+    // process.platform is read by the width probe. Pin it with defineProperty
+    // and restore after each test; vi.spyOn on the getter does not reliably
+    // re-apply across tests. Probing is disabled on win32, so the
+    // ancestor-walk/stty/tput tests pin POSIX and the win32 tests pin win32.
+    const ORIGINAL_PLATFORM = process.platform;
+    const setPlatform = (value: NodeJS.Platform): void => {
+        Object.defineProperty(process, 'platform', { value, configurable: true, writable: true, enumerable: true });
+    };
+    const pinPosixPlatform = (): void => {
+        setPlatform('darwin');
+    };
+
     beforeEach(() => {
         vi.clearAllMocks();
         vi.restoreAllMocks();
@@ -36,9 +48,11 @@ describe('terminal utils', () => {
     afterEach(() => {
         vi.restoreAllMocks();
         delete process.env.CCSTATUSLINE_WIDTH;
+        setPlatform(ORIGINAL_PLATFORM);
     });
 
     it('returns width from the immediate parent tty when available', () => {
+        pinPosixPlatform();
         mockExecSync.mockImplementation((command: string) => {
             if (command === `ps -o ppid= -p ${process.pid}`) {
                 return '1234\n';
@@ -64,6 +78,7 @@ describe('terminal utils', () => {
     });
 
     it('walks ancestor processes until it finds a valid tty', () => {
+        pinPosixPlatform();
         mockExecSync.mockImplementation((command: string) => {
             if (command === `ps -o ppid= -p ${process.pid}`) {
                 return '1234\n';
@@ -92,6 +107,7 @@ describe('terminal utils', () => {
     });
 
     it('falls back through stty variants when the first form returns no value', () => {
+        pinPosixPlatform();
         // Simulates BSD/macOS, where `stty -F` exits with an error and yields
         // empty output via the `2>/dev/null | awk` pipeline; `stty -f` succeeds.
         mockExecSync.mockImplementation((command: string) => {
@@ -118,6 +134,7 @@ describe('terminal utils', () => {
     });
 
     it('falls back to tput cols when ancestor probing fails', () => {
+        pinPosixPlatform();
         mockExecSync.mockImplementationOnce(() => { throw new Error('ps unavailable'); });
         mockExecSync.mockReturnValueOnce('90\n');
 
@@ -126,6 +143,7 @@ describe('terminal utils', () => {
     });
 
     it('returns null when ancestor and fallback probes fail', () => {
+        pinPosixPlatform();
         mockExecSync.mockImplementation((command: string) => {
             if (command === `ps -o ppid= -p ${process.pid}`) {
                 return '1234\n';
@@ -156,6 +174,7 @@ describe('terminal utils', () => {
     });
 
     it('detects availability when an ancestor tty probe succeeds', () => {
+        pinPosixPlatform();
         mockExecSync.mockImplementation((command: string) => {
             if (command === `ps -o ppid= -p ${process.pid}`) {
                 return '1234\n';
@@ -184,6 +203,7 @@ describe('terminal utils', () => {
     });
 
     it('returns false for availability when all probes fail', () => {
+        pinPosixPlatform();
         mockExecSync.mockImplementationOnce(() => { throw new Error('tty unavailable'); });
         mockExecSync.mockImplementationOnce(() => { throw new Error('tput unavailable'); });
 
@@ -198,6 +218,7 @@ describe('terminal utils', () => {
     });
 
     it('ignores a non-positive CCSTATUSLINE_WIDTH and falls back to probing', () => {
+        pinPosixPlatform();
         process.env.CCSTATUSLINE_WIDTH = '0';
 
         mockExecSync.mockImplementation((command: string) => {
@@ -220,6 +241,7 @@ describe('terminal utils', () => {
     });
 
     it('ignores a non-numeric CCSTATUSLINE_WIDTH and falls back to probing', () => {
+        pinPosixPlatform();
         process.env.CCSTATUSLINE_WIDTH = 'wide';
 
         mockExecSync.mockImplementation((command: string) => {
@@ -242,7 +264,7 @@ describe('terminal utils', () => {
     });
 
     it('CCSTATUSLINE_WIDTH override applies on Windows where probing is disabled', () => {
-        vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+        setPlatform('win32');
         process.env.CCSTATUSLINE_WIDTH = '180';
 
         expect(getTerminalWidth()).toBe(180);
@@ -251,7 +273,7 @@ describe('terminal utils', () => {
     });
 
     it('disables width detection on Windows', () => {
-        vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+        setPlatform('win32');
 
         expect(getTerminalWidth()).toBeNull();
         expect(canDetectTerminalWidth()).toBe(false);

--- a/src/utils/__tests__/usage-token.test.ts
+++ b/src/utils/__tests__/usage-token.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
+import * as path from 'path';
 import type { Mock } from 'vitest';
 import {
     afterEach,
@@ -22,7 +23,7 @@ vi.mock('child_process', () => ({
     spawnSync: vi.fn()
 }));
 
-const CREDENTIALS_FILE = '/fake/claude/.credentials.json';
+const CREDENTIALS_FILE = path.join('/fake/claude', '.credentials.json');
 const mockedExecFileSync = execFileSync as unknown as Mock;
 
 function makeTokenPayload(token: string): string {


### PR DESCRIPTION
Closes #453

16 specs fail on a Windows host but pass on POSIX CI. The production code is already platform-aware; only the specs assumed POSIX. Test-only, no production code touched.

- **terminal (7)**: pin `process.platform` to a POSIX value for the ancestor-walk/stty/tput specs, via a `defineProperty` setter restored in `afterEach` (the previous `vi.spyOn` on the getter did not re-apply reliably across specs); the win32 specs use the same setter. This also fixes a leaked `mockImplementationOnce` from an early-returning spec that, on win32, never consumed its queued throws and poisoned a later spec.
- **claude-settings (6)**: pin platform + stub `getConfigPath()` to a literal POSIX path so the `--config` quoting specs exercise the POSIX branch without `path.resolve` drive-prefixing.
- **usage-token (2)**: build the credentials-file constant via `path.join` so it matches the source's `path.join(...)` on any OS.
- **config-dir (1)**: assert `path.resolve(...)` (the source resolves the path), matching the sibling relative-path spec.

`bun run lint` clean; `bun test` now fully green on Windows (1549/1549) and unchanged on POSIX.
