### PR TITLE
fix: deduplicate token metrics by message.id to prevent multi-counting

### DIFF
--- a/src/types/TokenMetrics.ts
+++ b/src/types/TokenMetrics.ts
@@ -6,7 +6,7 @@ export interface TokenUsage {
 }
 
 export interface TranscriptLine {
-    message?: { usage?: TokenUsage; stop_reason?: string | null };
+    message?: { usage?: TokenUsage; stop_reason?: string | null; id?: string };
     isSidechain?: boolean;
     timestamp?: string;
     isApiErrorMessage?: boolean;

--- a/src/utils/jsonl-metrics.ts
+++ b/src/utils/jsonl-metrics.ts
@@ -186,12 +186,30 @@ export async function getTokenMetrics(transcriptPath: string): Promise<TokenMetr
             }
         }
 
-        const entriesToCount = hasStopReasonField
-            ? parsedEntries.filter((data, index) => {
+        // Two dedup layers in a single pass:
+        // 1. stop_reason: skip streaming intermediate rows (stop_reason: null),
+        //    except the latest unfinished entry for live updates.
+        // 2. message.id: Claude Code writes one JSONL entry per content block
+        //    (thinking / text / tool_use), each carrying the same message.id and
+        //    a full usage snapshot with a non-null stop_reason. Keep only the
+        //    first row per message.id. Rows without an id are counted as-is.
+        const seenMessageIds = new Set<string>();
+        const entriesToCount = parsedEntries.filter((data, index) => {
+            if (hasStopReasonField) {
                 const stopReason = data.message?.stop_reason;
-                return Boolean(stopReason) || (stopReason === null && index === parsedEntries.length - 1);
-            })
-            : parsedEntries;
+                if (!stopReason && !(stopReason === null && index === parsedEntries.length - 1)) {
+                    return false;
+                }
+            }
+            const messageId = data.message?.id;
+            if (messageId) {
+                if (seenMessageIds.has(messageId)) {
+                    return false;
+                }
+                seenMessageIds.add(messageId);
+            }
+            return true;
+        });
 
         for (const data of entriesToCount) {
             const usage = data.message?.usage;
@@ -301,6 +319,15 @@ function collectSpeedMetricsFromLines(lines: string[], ignoreSidechain: boolean)
     let lastUserTimestamp: Date | null = null;
     let latestTimestampMs: number | null = null;
 
+    // Claude Code writes one JSONL entry per content block (thinking / text /
+    // tool_use), each carrying the same `message.id` and a copy of the whole
+    // `usage` snapshot from the finished API response. Summing every assistant
+    // row would double/triple-count a single turn's tokens. Dedupe by
+    // `message.id`: the first row seeds usage + interval start; later rows for
+    // the same id only extend the interval end to the turn's final timestamp.
+    // Rows without a message.id fall back to per-row counting.
+    const requestByMessageId = new Map<string, SpeedRequest>();
+
     for (const line of lines) {
         const data = parseJsonlLine(line) as TranscriptLine | null;
         if (!data || data.isApiErrorMessage) {
@@ -327,6 +354,25 @@ function collectSpeedMetricsFromLines(lines: string[], ignoreSidechain: boolean)
         if (data.type === 'assistant' && data.message?.usage) {
             const inputTokens = data.message.usage.input_tokens || 0;
             const outputTokens = data.message.usage.output_tokens || 0;
+            const messageId = data.message.id;
+            const entryMs = entryTimestamp ? entryTimestamp.getTime() : null;
+
+            if (messageId) {
+                const existing = requestByMessageId.get(messageId);
+                if (existing) {
+                    // Same turn, later content-block row: extend the interval
+                    // end to the latest block timestamp. Usage is identical, so
+                    // no token update needed.
+                    if (entryMs !== null) {
+                        existing.assistantTimestampMs = entryMs;
+                        if (existing.interval && entryMs > existing.interval.endMs) {
+                            existing.interval.endMs = entryMs;
+                        }
+                    }
+                    continue;
+                }
+            }
+
             let interval: SpeedInterval | null = null;
             if (entryTimestamp && lastUserTimestamp) {
                 const startMs = lastUserTimestamp.getTime();
@@ -336,12 +382,16 @@ function collectSpeedMetricsFromLines(lines: string[], ignoreSidechain: boolean)
                 }
             }
 
-            requests.push({
+            const request: SpeedRequest = {
                 inputTokens,
                 outputTokens,
-                assistantTimestampMs: entryTimestamp ? entryTimestamp.getTime() : null,
+                assistantTimestampMs: entryMs,
                 interval
-            });
+            };
+            requests.push(request);
+            if (messageId) {
+                requestByMessageId.set(messageId, request);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

Claude Code writes one JSONL transcript entry per content block within a single API response. A typical assistant turn with thinking + text + tool_use produces 2–4 JSONL rows, each carrying:

- The same `message.id`
- A full copy of the `usage` snapshot (identical `input_tokens`, `output_tokens` across all rows)
- A non-null `stop_reason` (e.g. `"tool_use"` or `"end_turn"`)

Both `getTokenMetrics` and `collectSpeedMetricsFromLines` sum every assistant row that has a `usage` field without checking whether multiple rows belong to the same API response. This causes **token counts and speed metrics to be inflated by 1.4–2.5×** depending on the average number of content blocks per turn.

The existing `stop_reason`-based dedup in `getTokenMetrics` does not help because all rows from the same response carry the same non-null `stop_reason`.

### Measured impact (real transcripts)

| Metric | Before fix | After fix | Inflation factor |
|--------|-----------|-----------|-----------------|
| `requestCount` | 114 | 61 | 1.87× |
| `outputTokens` | 69,720 | 29,888 | 2.33× |
| `outTps` | 85.5 t/s | 36.6 t/s | 2.34× |

Verified across 20 models with 50k+ assistant rows — all affected (1.36×–2.46× depending on model's tendency to produce multi-block responses).

## Fix

Deduplicate by `message.id` in both code paths:

1. **`collectSpeedMetricsFromLines`** (speed metrics): maintain a `Map<messageId, SpeedRequest>`. First row per id seeds the request with usage and interval. Subsequent rows for the same id only extend `interval.endMs` to the turn's final timestamp. Rows without a `message.id` fall back to per-row counting.

2. **`getTokenMetrics`** (token totals): single-pass filter that applies both the existing `stop_reason` check and a `Set<messageId>` dedup, keeping only the first row per id.

3. **`TranscriptLine` type**: add optional `id?: string` to `message`.

## Testing

- All 1,589 existing tests pass
- Verified against real transcripts: deduplicated `requestCount` matches the actual number of unique turns (confirmed via `message.id` grouping)
- Smoke-tested full statusline rendering with patched build