### PR TITLE
feat: print version and exit on --version

### DIFF
--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -42,7 +42,10 @@ import {
     getWidgetSpeedWindowSeconds,
     isWidgetSpeedWindowEnabled
 } from './utils/speed-window';
-import { getTerminalWidth } from './utils/terminal';
+import {
+    getPackageVersion,
+    getTerminalWidth
+} from './utils/terminal';
 import { prefetchUsageDataIfNeeded } from './utils/usage-prefetch';
 
 function hasSessionDurationInStatusJson(data: StatusJSON): boolean {
@@ -274,6 +277,12 @@ async function handleHook(): Promise<void> {
 }
 
 async function main() {
+    // Print version and exit (#461). Standard CLI behavior, runs before any other mode.
+    if (process.argv.includes('--version')) {
+        console.log(getPackageVersion());
+        process.exit(0);
+    }
+
     // Parse --config before anything else
     initConfigPath(parseConfigArg());
 


### PR DESCRIPTION
## Summary

`ccstatusline --version` currently launches the interactive TUI instead of reporting the version. The entry point only branches on `--hook` and then TTY-vs-piped mode, so an unrecognized flag falls through to the TUI. This adds a `--version` check at the top of `main()` that prints the version and exits, which is the expected behavior for a CLI/TUI.

Closes #461.

## Approach

A single guard before mode detection in `src/ccstatusline.ts`, reusing the existing `getPackageVersion()` helper from `src/utils/terminal.ts`:

- `getPackageVersion()` returns the build-substituted version and falls back to reading `package.json`, so `--version` is correct both from the published build and when run from source.
- No new dependency, and it is consistent with the existing manual `--config` / `--hook` argument handling.

## Test plan

- `bun run lint` passes (tsc + eslint, `--max-warnings=0`).
- `--version` prints the version and exits 0:
  - from source: `bun run src/ccstatusline.ts --version` -> `2.2.22`
  - from the built artifact: `node dist/ccstatusline.js --version` -> `2.2.22`
- Piped status-line rendering is unchanged (the guard runs and returns before mode detection); the TUI still launches with no args.