### PR TITLE
fix: add homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,6 @@
   ],
   "patchedDependencies": {
     "ink@6.2.0": "patches/ink@6.2.0.patch"
-  }
+  },
+  "homepage": "https://github.com/sirmalloc/ccstatusline"
 }


### PR DESCRIPTION
Added missing homepage and bugs metadata to package.json. Fixes charles-microbounties #1462.