### PR TITLE
feat(widget): add optional glyph to Current Working Dir

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -209,7 +209,7 @@ Widget-specific shortcuts:
 - **Compaction Counter**: `f` cycle format, `n` toggle Nerd Font icon in icon mode, `s` toggle trigger split (auto/manual/unknown), `t` toggle tokens reclaimed, `h` hide when zero
 - **Cache widgets** (Cache Hit Rate, Cache Read, Cache Write): `t` toggle turn/session scope, `h` hide when empty
 - **Voice Status**: `f` cycle format, `n` toggle Nerd Font microphone icons
-- **Current Working Dir**: `h` home abbreviation, `s` segment editor, `f` fish-style path
+- **Current Working Dir**: `h` home abbreviation, `s` segment editor, `f` fish-style path, `g` optional leading glyph (off by default; pair with raw value to replace the `cwd:` label with the glyph)
 - **Skills**: `v` cycle view mode, `h` hide when empty, `l` edit list limit in list mode
 - **Input Speed / Output Speed / Total Speed**: `w` edit the rolling window in seconds
 - **Custom Text / Custom Symbol**: `e` edit text or symbol

--- a/src/widgets/CurrentWorkingDir.tsx
+++ b/src/widgets/CurrentWorkingDir.tsx
@@ -17,6 +17,13 @@ import type {
 } from '../types/Widget';
 import { shouldInsertInput } from '../utils/input-guards';
 
+import {
+    SYMBOL_OVERRIDE_ACTION,
+    formatSymbolPrefix,
+    getSymbolKeybind,
+    renderSymbolOverrideEditor
+} from './shared/symbol-override';
+
 export class CurrentWorkingDirWidget implements Widget {
     getDefaultColor(): string { return 'blue'; }
     getDescription(): string { return 'Shows the current working directory'; }
@@ -108,6 +115,7 @@ export class CurrentWorkingDirWidget implements Widget {
         const segments = item.metadata?.segments ? parseInt(item.metadata.segments, 10) : undefined;
         const fishStyle = item.metadata?.fishStyle === 'true';
         const abbreviateHome = item.metadata?.abbreviateHome === 'true';
+        const symbolPrefix = formatSymbolPrefix(item, '');
 
         if (context.isPreview) {
             let previewPath: string;
@@ -132,7 +140,7 @@ export class CurrentWorkingDirWidget implements Widget {
                 previewPath = '/Users/example/Documents/Projects/my-project';
             }
 
-            return item.rawValue ? previewPath : `cwd: ${previewPath}`;
+            return item.rawValue ? `${symbolPrefix}${previewPath}` : `${symbolPrefix}cwd: ${previewPath}`;
         }
 
         const cwd = context.data?.cwd;
@@ -169,18 +177,22 @@ export class CurrentWorkingDirWidget implements Widget {
             }
         }
 
-        return item.rawValue ? displayPath : `cwd: ${displayPath}`;
+        return item.rawValue ? `${symbolPrefix}${displayPath}` : `${symbolPrefix}cwd: ${displayPath}`;
     }
 
     getCustomKeybinds(): CustomKeybind[] {
         return [
             { key: 'h', label: '(h)ome ~', action: 'toggle-abbreviate-home' },
             { key: 's', label: '(s)egments', action: 'edit-segments' },
-            { key: 'f', label: '(f)ish style', action: 'toggle-fish-style' }
+            { key: 'f', label: '(f)ish style', action: 'toggle-fish-style' },
+            getSymbolKeybind()
         ];
     }
 
     renderEditor(props: WidgetEditorProps): React.ReactElement {
+        if (props.action === SYMBOL_OVERRIDE_ACTION) {
+            return renderSymbolOverrideEditor(props, '');
+        }
         return <CurrentWorkingDirEditor {...props} />;
     }
 

--- a/src/widgets/__tests__/CurrentWorkingDir.test.ts
+++ b/src/widgets/__tests__/CurrentWorkingDir.test.ts
@@ -56,13 +56,15 @@ describe('CurrentWorkingDirWidget', () => {
 
     const createItem = (
         metadata?: Record<string, string>,
-        rawValue = false
+        rawValue = false,
+        character?: string
     ): WidgetItem => ({
         id: 'test',
         type: 'current-working-dir',
         backgroundColor: 'bgBlue',
         rawValue,
-        metadata
+        metadata,
+        character
     });
 
     describe('abbreviateHome', () => {
@@ -214,6 +216,45 @@ describe('CurrentWorkingDirWidget', () => {
             expect(homeKeybind).toBeDefined();
             expect(homeKeybind?.label).toBe('(h)ome ~');
             expect(homeKeybind?.action).toBe('toggle-abbreviate-home');
+        });
+
+        it('should expose a (g)lyph symbol-override keybind', () => {
+            const keybinds = widget.getCustomKeybinds();
+            const glyphKeybind = keybinds.find(k => k.key === 'g');
+            expect(glyphKeybind).toBeDefined();
+            expect(glyphKeybind?.action).toBe('edit-symbol-override');
+        });
+    });
+
+    describe('glyph symbol override', () => {
+        it('renders no glyph prefix by default, leaving the cwd: label intact', () => {
+            const item = createItem(undefined, false);
+            const result = widget.render(item, createContext('/var/www/site'), defaultSettings);
+            expect(result).toBe('cwd: /var/www/site');
+        });
+
+        it('prefixes the labeled output with the configured glyph', () => {
+            const item = createItem(undefined, false, '📁');
+            const result = widget.render(item, createContext('/var/www/site'), defaultSettings);
+            expect(result).toBe('📁 cwd: /var/www/site');
+        });
+
+        it('keeps the glyph in raw value mode while dropping the cwd: label', () => {
+            const item = createItem(undefined, true, '📁');
+            const result = widget.render(item, createContext('/var/www/site'), defaultSettings);
+            expect(result).toBe('📁 /var/www/site');
+        });
+
+        it('composes the glyph with raw value and segment truncation', () => {
+            const item = createItem({ segments: '2' }, true, '📁');
+            const result = widget.render(item, createContext('/var/www/html/my-project'), defaultSettings);
+            expect(result).toBe('📁 .../html/my-project');
+        });
+
+        it('shows the glyph in preview mode', () => {
+            const item = createItem(undefined, true, '📁');
+            const result = widget.render(item, createContext(undefined, true), defaultSettings);
+            expect(result).toBe('📁 /Users/example/Documents/Projects/my-project');
         });
     });
 });


### PR DESCRIPTION
## What

Adds an optional, user-configurable glyph to the **Current Working Dir** widget, wired through the same shared `symbol-override` module the Git/JJ widgets already use (the `(g)lyph` editor key).

Motivated by #478, which asked for (1) a folder icon and (2) configurable last-N path segments. The second half already ships as the widget's existing `segments` option, so this PR is scoped to just the icon.

## Behavior

The **default symbol is empty**, so output is unchanged (`cwd: <path>`) unless the user opts in — nothing is emitted for people without a Nerd Font installed, so there's no tofu by default. The glyph composes with the existing `raw value` and `segments` options:

| Widget config | Output |
| --- | --- |
| _(default, no glyph)_ | `cwd: /Users/me/dev/forks/ccstatusline` |
| glyph `📁` | `📁 cwd: /Users/me/dev/forks/ccstatusline` |
| glyph `📁` + raw value | `📁 /Users/me/dev/forks/ccstatusline` |
| glyph `📁` + raw value + segments 2 | `📁 .../forks/ccstatusline` |

## Design note (raw-value behavior)

The glyph is applied in **both** normal and raw-value mode; raw value drops only the built-in `cwd:` label. This intentionally differs from `GitBranch`, where raw value also strips the symbol. The reason: `CurrentWorkingDir` already has a distinct text label (`cwd:`) that raw value targets, and keeping the glyph in raw mode is what lets `glyph + raw value` render the icon *in place of* the label — which is exactly the ask in #478. If raw value stripped the glyph, that result would be unreachable. Happy to match GitBranch's behavior instead if you'd prefer the consistency.

## Tests

New `glyph symbol override` cases in `CurrentWorkingDir.test.ts` cover: default output unchanged, glyph prefix, glyph kept in raw mode, glyph + segments composition, preview, and the `(g)lyph` keybind. `bun run lint` clean; full suite green.
