### PR TITLE
🐛 fix(usage): clear in-flight lock on a successful fetch

### DIFF
--- a/src/utils/__tests__/usage-fetch.test.ts
+++ b/src/utils/__tests__/usage-fetch.test.ts
@@ -724,6 +724,39 @@ describe('fetchUsageData error handling', () => {
         }
     });
 
+    it('preserves the in-flight lock after a successful fetch missing required fields', () => {
+        const harness = createProbeHarness();
+
+        try {
+            const home = harness.createTokenHome('success-missing-required-fields');
+            const result = harness.runProbe({
+                claudeConfigDir: home.claudeConfig,
+                home: home.home,
+                mode: 'success',
+                nowMs,
+                pathDir: home.bin,
+                requiredFields: ['weeklySonnetUsage'],
+                responseBody: successResponseBody
+            });
+
+            expect(result.first).toEqual({
+                sessionUsage: 42,
+                sessionResetAt: '2030-01-01T00:00:00.000Z',
+                weeklyUsage: 17,
+                weeklyResetAt: '2030-01-07T00:00:00.000Z'
+            });
+            expect(result.second).toEqual({ error: 'timeout' });
+            expect(result.cacheExists).toBe(true);
+            expect(result.requestCount).toBe(1);
+            expect(parseLockContents(result.lockContents)).toEqual({
+                blockedUntil: Math.floor(nowMs / 1000) + 30,
+                error: 'timeout'
+            });
+        } finally {
+            harness.cleanup();
+        }
+    });
+
     it('refetches a fresh cache when the token fingerprint changes (account switch)', () => {
         const harness = createProbeHarness();
 

--- a/src/utils/__tests__/usage-fetch.test.ts
+++ b/src/utils/__tests__/usage-fetch.test.ts
@@ -674,11 +674,17 @@ describe('fetchUsageData error handling', () => {
             expect(result.second).toEqual(result.first);
             expect(result.requestCount).toBe(1);
 
+            // The probe writes usage.json with a real-wall-clock mtime, so derive
+            // 'now' from it (not the mocked epoch) to keep the cache within
+            // CACHE_MAX_AGE. This exercises the file-cache fast path a real later
+            // render takes, rather than depending on a lingering lock to suppress
+            // the refetch.
+            const cacheMtimeMs = fs.statSync(path.join(home.home, '.cache', 'ccstatusline', 'usage.json')).mtimeMs;
             const cachedResult = harness.runProbe({
                 claudeConfigDir: home.claudeConfig,
                 home: home.home,
                 mode: 'unexpected',
-                nowMs: nowMs + 10000,
+                nowMs: cacheMtimeMs + 10000,
                 pathDir: home.bin,
                 requiredFields
             });
@@ -686,6 +692,33 @@ describe('fetchUsageData error handling', () => {
             expect(cachedResult.first).toEqual(result.first);
             expect(cachedResult.second).toEqual(result.first);
             expect(cachedResult.requestCount).toBe(0);
+        } finally {
+            harness.cleanup();
+        }
+    });
+
+    it('clears the in-flight lock after a successful fetch', () => {
+        const harness = createProbeHarness();
+
+        try {
+            const home = harness.createTokenHome('success-clears-lock');
+            const result = harness.runProbe({
+                claudeConfigDir: home.claudeConfig,
+                home: home.home,
+                mode: 'success',
+                nowMs,
+                pathDir: home.bin,
+                responseBody: successResponseBody
+            });
+
+            // fetchUsageData writes a short 'timeout' lock before the request as an
+            // in-flight guard. A successful fetch must remove it; otherwise the lock
+            // lingers for LOCK_MAX_AGE and a later cache miss (e.g. an account switch
+            // invalidating the fingerprint) reports a spurious [Timeout] while the
+            // API is healthy.
+            expect(result.cacheExists).toBe(true);
+            expect(result.lockExists).toBe(false);
+            expect(result.lockContents).toBeNull();
         } finally {
             harness.cleanup();
         }
@@ -849,11 +882,17 @@ describe('fetchUsageData error handling', () => {
             expect(result.second).toEqual(result.first);
             expect(result.requestCount).toBe(1);
 
+            // The probe writes usage.json with a real-wall-clock mtime, so derive
+            // 'now' from it (not the mocked epoch) to keep the cache within
+            // CACHE_MAX_AGE. This exercises the file-cache fast path a real later
+            // render takes, rather than depending on a lingering lock to suppress
+            // the refetch.
+            const cacheMtimeMs = fs.statSync(path.join(home.home, '.cache', 'ccstatusline', 'usage.json')).mtimeMs;
             const cachedResult = harness.runProbe({
                 claudeConfigDir: home.claudeConfig,
                 home: home.home,
                 mode: 'unexpected',
-                nowMs: nowMs + 10000,
+                nowMs: cacheMtimeMs + 10000,
                 pathDir: home.bin,
                 requiredFields
             });
@@ -895,11 +934,17 @@ describe('fetchUsageData error handling', () => {
             expect(result.second).toEqual(result.first);
             expect(result.requestCount).toBe(1);
 
+            // The probe writes usage.json with a real-wall-clock mtime, so derive
+            // 'now' from it (not the mocked epoch) to keep the cache within
+            // CACHE_MAX_AGE. This exercises the file-cache fast path a real later
+            // render takes, rather than depending on a lingering lock to suppress
+            // the refetch.
+            const cacheMtimeMs = fs.statSync(path.join(home.home, '.cache', 'ccstatusline', 'usage.json')).mtimeMs;
             const cachedResult = harness.runProbe({
                 claudeConfigDir: home.claudeConfig,
                 home: home.home,
                 mode: 'unexpected',
-                nowMs: nowMs + 10000,
+                nowMs: cacheMtimeMs + 10000,
                 pathDir: home.bin,
                 requiredFields
             });

--- a/src/utils/usage-fetch.ts
+++ b/src/utils/usage-fetch.ts
@@ -428,6 +428,14 @@ function writeUsageLock(blockedUntil: number, error: UsageLockError): void {
     }
 }
 
+function clearUsageLock(): void {
+    try {
+        fs.rmSync(LOCK_FILE, { force: true });
+    } catch {
+        // Ignore lock file errors
+    }
+}
+
 function readActiveUsageLock(now: number): { blockedUntil: number; error: UsageLockError } | null {
     let hasValidJsonLock = false;
 
@@ -663,6 +671,12 @@ export async function fetchUsageData(options: FetchUsageDataOptions = {}): Promi
         } catch {
             // Ignore cache write errors
         }
+
+        // Clear the in-flight lock written above: a successful fetch supersedes
+        // it. Leaving it behind keeps a 'timeout'-labelled lock active for up to
+        // LOCK_MAX_AGE, so a later cache miss (e.g. an account switch invalidating
+        // the fingerprint) surfaces a spurious [Timeout] while the API is healthy.
+        clearUsageLock();
 
         return cacheUsageData(usageData, now);
     } catch {

--- a/src/utils/usage-fetch.ts
+++ b/src/utils/usage-fetch.ts
@@ -672,11 +672,12 @@ export async function fetchUsageData(options: FetchUsageDataOptions = {}): Promi
             // Ignore cache write errors
         }
 
-        // Clear the in-flight lock written above: a successful fetch supersedes
-        // it. Leaving it behind keeps a 'timeout'-labelled lock active for up to
-        // LOCK_MAX_AGE, so a later cache miss (e.g. an account switch invalidating
-        // the fingerprint) surfaces a spurious [Timeout] while the API is healthy.
-        clearUsageLock();
+        // Clear the in-flight lock written above only once this response satisfies
+        // the caller's requested fields. Incomplete 200 responses are cached but
+        // still need the short throttle so later renders do not refetch every time.
+        if (hasRequiredUsageFields(usageData, requiredFields)) {
+            clearUsageLock();
+        }
 
         return cacheUsageData(usageData, now);
     } catch {


### PR DESCRIPTION
Switching Claude accounts could leave the usage widgets stuck on `[Timeout]` for up to 30 seconds even though the API was healthy and the new account would have fetched fine. 🔐 The trigger is the in-flight guard `fetchUsageData` writes before every API call: a `usage.lock` carrying `{ error: 'timeout', blockedUntil: now + LOCK_MAX_AGE }`. On a successful fetch the cache is written and returned, but that pre-fetch lock is never removed, so it lingers for the full `LOCK_MAX_AGE`.

Inside that window any render that misses the file cache falls through to `readActiveUsageLock` and returns `getStaleUsageOrError('timeout', …)`. An account switch is the clearest case: the fresh cache is rejected because the new token fails `tokenHashMatches`, the old account's cache is also rejected by fingerprint, and the leftover lock turns the result into `{ error: 'timeout' }`. The label is misleading too, since `usage.lock` reads `timeout` after a fetch that actually succeeded.

The fix clears the lock once the successful response has been cached. ✨ Genuine error and rate-limit backoff locks are written on their own paths and stay untouched, so the existing "don't serve a mismatched account cache during an active lock" backoff behaviour is preserved.

Fixes #486