### PR TITLE
✨ feat(widgets): honor maxWidth in Git Branch and Git Root Dir

### DIFF
--- a/src/widgets/GitBranch.ts
+++ b/src/widgets/GitBranch.ts
@@ -27,6 +27,13 @@ import {
     handleToggleNoGitAction,
     isHideNoGitEnabled
 } from './shared/git-no-git';
+import {
+    MAX_WIDTH_ACTION,
+    applyMaxWidth,
+    getMaxWidthKeybind,
+    getMaxWidthModifier,
+    renderMaxWidthEditor
+} from './shared/max-width';
 import { isMetadataFlagEnabled } from './shared/metadata';
 import {
     formatSymbolPrefix,
@@ -78,6 +85,9 @@ export class GitBranchWidget implements Widget {
             modifiers.push('hide \'no git\'');
         if (isLink)
             modifiers.push('repo link');
+        const maxWidthText = getMaxWidthModifier(item);
+        if (maxWidthText)
+            modifiers.push(maxWidthText);
         return {
             displayText: this.getDisplayName(),
             modifierText: makeModifierText(modifiers)
@@ -111,7 +121,7 @@ export class GitBranchWidget implements Widget {
             return hideNoGit ? null : `${prefix}no git`;
         }
 
-        const displayText = item.rawValue ? branch : `${prefix}${branch}`;
+        const displayText = applyMaxWidth(item.rawValue ? branch : `${prefix}${branch}`, item.maxWidth);
 
         if (isLink) {
             const origin = getRemoteInfo('origin', context);
@@ -134,11 +144,15 @@ export class GitBranchWidget implements Widget {
         return [
             ...getHideNoGitKeybinds(),
             { key: 'l', label: '(l)ink to repo', action: TOGGLE_LINK_ACTION },
+            getMaxWidthKeybind(),
             getSymbolKeybind()
         ];
     }
 
     renderEditor(props: WidgetEditorProps) {
+        if (props.action === MAX_WIDTH_ACTION) {
+            return renderMaxWidthEditor(props);
+        }
         return renderSymbolOverrideEditor(props, DEFAULT_SYMBOL);
     }
 

--- a/src/widgets/GitRootDir.ts
+++ b/src/widgets/GitRootDir.ts
@@ -4,6 +4,7 @@ import type {
     CustomKeybind,
     Widget,
     WidgetEditorDisplay,
+    WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
 import {
@@ -24,6 +25,13 @@ import {
     handleToggleNoGitAction,
     isHideNoGitEnabled
 } from './shared/git-no-git';
+import {
+    MAX_WIDTH_ACTION,
+    applyMaxWidth,
+    getMaxWidthKeybind,
+    getMaxWidthModifier,
+    renderMaxWidthEditor
+} from './shared/max-width';
 import { isMetadataFlagEnabled } from './shared/metadata';
 
 const IDE_LINK_KEY = 'linkToIDE';
@@ -47,6 +55,9 @@ export class GitRootDirWidget implements Widget {
             modifiers.push('hide \'no git\'');
         if (ideLinkMode)
             modifiers.push(IDE_LINK_LABELS[ideLinkMode]);
+        const maxWidthText = getMaxWidthModifier(item);
+        if (maxWidthText)
+            modifiers.push(maxWidthText);
         return {
             displayText: this.getDisplayName(),
             modifierText: makeModifierText(modifiers)
@@ -78,7 +89,7 @@ export class GitRootDirWidget implements Widget {
             return hideNoGit ? null : 'no git';
         }
 
-        const name = this.getRootDirName(rootDir);
+        const name = applyMaxWidth(this.getRootDirName(rootDir), item.maxWidth);
 
         if (ideLinkMode) {
             return renderOsc8Link(buildIdeFileUrl(rootDir, ideLinkMode), name);
@@ -102,8 +113,16 @@ export class GitRootDirWidget implements Widget {
     getCustomKeybinds(): CustomKeybind[] {
         return [
             ...getHideNoGitKeybinds(),
-            { key: 'l', label: '(l)ink to IDE', action: TOGGLE_LINK_ACTION }
+            { key: 'l', label: '(l)ink to IDE', action: TOGGLE_LINK_ACTION },
+            getMaxWidthKeybind()
         ];
+    }
+
+    renderEditor(props: WidgetEditorProps) {
+        if (props.action === MAX_WIDTH_ACTION) {
+            return renderMaxWidthEditor(props);
+        }
+        return null;
     }
 
     supportsRawValue(): boolean { return false; }

--- a/src/widgets/__tests__/GitBranch.test.ts
+++ b/src/widgets/__tests__/GitBranch.test.ts
@@ -33,6 +33,7 @@ function render(options: {
     hideNoGit?: boolean;
     isPreview?: boolean;
     linkToRepo?: boolean;
+    maxWidth?: number;
     metadata?: Record<string, string>;
     rawValue?: boolean;
 } = {}) {
@@ -50,6 +51,7 @@ function render(options: {
         id: 'git-branch',
         type: 'git-branch',
         rawValue: options.rawValue,
+        maxWidth: options.maxWidth,
         metadata: Object.keys(metadata).length > 0 ? metadata : undefined
     };
 
@@ -172,6 +174,44 @@ describe('GitBranchWidget', () => {
         mockExecFileSync.mockReturnValueOnce('main');
 
         expect(render({ metadata: { linkToRepo: 'false', linkToGitHub: 'true' } })).toBe('⎇ main');
+    });
+
+    describe('max width', () => {
+        const widget = new GitBranchWidget();
+
+        it.each([
+            { name: 'truncates the branch with an ellipsis', maxWidth: 10, expected: 'feature...' },
+            { name: 'leaves the branch untouched when it fits', maxWidth: 100, expected: 'feature/worktree' }
+        ])('$name', ({ maxWidth, expected }) => {
+            mockExecFileSync.mockReturnValueOnce('true\n');
+            mockExecFileSync.mockReturnValueOnce('feature/worktree');
+
+            expect(render({ rawValue: true, maxWidth })).toBe(expected);
+        });
+
+        it('truncates the visible link label but keeps the full link target', () => {
+            mockExecFileSync.mockReturnValueOnce('true\n');
+            mockExecFileSync.mockReturnValueOnce('feature/worktree');
+            mockExecFileSync.mockReturnValueOnce('git@github.com:owner/repo.git');
+
+            expect(render({ rawValue: true, linkToRepo: true, maxWidth: 10 })).toBe(renderOsc8Link(
+                'https://github.com/owner/repo/tree/feature/worktree',
+                'feature...'
+            ));
+        });
+
+        it('shows the max-width modifier in the editor display', () => {
+            expect(widget.getEditorDisplay({ id: 'git-branch', type: 'git-branch', maxWidth: 12 }).modifierText)
+                .toBe('(max:12)');
+        });
+
+        it('exposes the width keybind', () => {
+            expect(widget.getCustomKeybinds()).toContainEqual({
+                key: 'w',
+                label: '(w)idth',
+                action: 'edit-max-width'
+            });
+        });
     });
 
     describe('toggle action', () => {

--- a/src/widgets/__tests__/GitRootDir.test.ts
+++ b/src/widgets/__tests__/GitRootDir.test.ts
@@ -31,7 +31,7 @@ const mockExecFileSync = execFileSync as unknown as {
     mockReturnValueOnce: (value: string) => void;
 };
 
-function render(options: { cwd?: string; hideNoGit?: boolean; isPreview?: boolean } = {}) {
+function render(options: { cwd?: string; hideNoGit?: boolean; isPreview?: boolean; maxWidth?: number } = {}) {
     const widget = new GitRootDirWidget();
     const context: RenderContext = {
         isPreview: options.isPreview,
@@ -40,6 +40,7 @@ function render(options: { cwd?: string; hideNoGit?: boolean; isPreview?: boolea
     const item: WidgetItem = {
         id: 'git-root-dir',
         type: 'git-root-dir',
+        maxWidth: options.maxWidth,
         metadata: options.hideNoGit ? { hideNoGit: 'true' } : undefined
     };
 
@@ -201,5 +202,56 @@ describe('GitRootDirWidget', () => {
         const widget = new GitRootDirWidget();
 
         expect(widget.supportsRawValue()).toBe(false);
+    });
+
+    describe('max width', () => {
+        const widget = new GitRootDirWidget();
+
+        it.each([
+            { name: 'should truncate the directory name to the configured width', maxWidth: 10, expected: 'my-very...' },
+            { name: 'should leave the directory name untouched when it fits', maxWidth: 100, expected: 'my-very-long-repo-name' }
+        ])('$name', ({ maxWidth, expected }) => {
+            mockExecFileSync.mockReturnValueOnce('true\n');
+            mockExecFileSync.mockReturnValueOnce('/some/path/my-very-long-repo-name');
+
+            expect(render({ maxWidth })).toBe(expected);
+        });
+
+        it('should truncate the visible IDE link label but keep the full link target', () => {
+            mockExecFileSync.mockReturnValueOnce('true\n');
+            mockExecFileSync.mockReturnValueOnce('/some/path/my-very-long-repo-name');
+
+            expect(widget.render({
+                id: 'git-root-dir',
+                type: 'git-root-dir',
+                maxWidth: 10,
+                metadata: { linkToIDE: 'vscode' }
+            }, {}, DEFAULT_SETTINGS)).toBe(renderOsc8Link(
+                buildIdeFileUrl('/some/path/my-very-long-repo-name', 'vscode'),
+                'my-very...'
+            ));
+        });
+
+        it('should show the max-width modifier in the editor display', () => {
+            expect(widget.getEditorDisplay({ id: 'git-root-dir', type: 'git-root-dir', maxWidth: 12 }).modifierText)
+                .toBe('(max:12)');
+        });
+
+        it('should expose the width keybind', () => {
+            expect(widget.getCustomKeybinds()).toContainEqual({
+                key: 'w',
+                label: '(w)idth',
+                action: 'edit-max-width'
+            });
+        });
+
+        it('should open the width editor for the width action', () => {
+            expect(widget.renderEditor({
+                widget: { id: 'git-root-dir', type: 'git-root-dir' },
+                onComplete: vi.fn(),
+                onCancel: vi.fn(),
+                action: 'edit-max-width'
+            })).not.toBeNull();
+        });
     });
 });

--- a/src/widgets/shared/max-width.tsx
+++ b/src/widgets/shared/max-width.tsx
@@ -1,0 +1,76 @@
+import {
+    Box,
+    Text,
+    useInput
+} from 'ink';
+import React, { useState } from 'react';
+
+import type {
+    CustomKeybind,
+    WidgetEditorProps,
+    WidgetItem
+} from '../../types/Widget';
+import { truncateStyledText } from '../../utils/ansi';
+import { shouldInsertInput } from '../../utils/input-guards';
+
+export const MAX_WIDTH_ACTION = 'edit-max-width';
+
+const MAX_WIDTH_KEYBIND: CustomKeybind = {
+    key: 'w',
+    label: '(w)idth',
+    action: MAX_WIDTH_ACTION
+};
+
+export function getMaxWidthKeybind(): CustomKeybind {
+    return MAX_WIDTH_KEYBIND;
+}
+
+export function getMaxWidthModifier(item: WidgetItem): string | null {
+    return item.maxWidth ? `max:${item.maxWidth}` : null;
+}
+
+// Caps a widget's rendered text to maxWidth visible columns, appending an
+// ellipsis. ANSI- and OSC8-aware via truncateStyledText, so callers may pass
+// already-styled text; for hyperlinked widgets prefer truncating the visible
+// label before wrapping so the link target stays intact.
+export function applyMaxWidth(text: string, maxWidth: number | undefined): string {
+    return maxWidth && maxWidth > 0 ? truncateStyledText(text, maxWidth, { ellipsis: true }) : text;
+}
+
+export function renderMaxWidthEditor(props: WidgetEditorProps): React.ReactElement {
+    return <MaxWidthEditor {...props} />;
+}
+
+const MaxWidthEditor: React.FC<WidgetEditorProps> = ({ widget, onComplete, onCancel }) => {
+    const [widthInput, setWidthInput] = useState(widget.maxWidth?.toString() ?? '');
+
+    useInput((input, key) => {
+        if (key.return) {
+            const width = parseInt(widthInput, 10);
+            if (!isNaN(width) && width > 0) {
+                onComplete({ ...widget, maxWidth: width });
+            } else {
+                const { maxWidth, ...rest } = widget;
+                void maxWidth; // Intentionally unused
+                onComplete(rest);
+            }
+        } else if (key.escape) {
+            onCancel();
+        } else if (key.backspace) {
+            setWidthInput(widthInput.slice(0, -1));
+        } else if (shouldInsertInput(input, key) && /\d/.test(input)) {
+            setWidthInput(widthInput + input);
+        }
+    });
+
+    return (
+        <Box flexDirection='column'>
+            <Box>
+                <Text>Enter max width (blank for no limit): </Text>
+                <Text>{widthInput}</Text>
+                <Text backgroundColor='gray' color='black'>{' '}</Text>
+            </Box>
+            <Text dimColor>Press Enter to save, ESC to cancel</Text>
+        </Box>
+    );
+};


### PR DESCRIPTION
On a single-line status bar a long branch or repository name pushes the model, context and usage widgets past the terminal edge, where ccstatusline truncates the whole line with `...`. ✂️ Today only the Custom Command widget can cap its own output, so the native git widgets have no way to yield space. The long-branch reports in #349 and #350, along with the narrow-terminal truncation in #61 and #312, all land on this same limitation.

The `maxWidth` field already lives on every widget in the schema, yet only Custom Command reads it. This change lets Git Branch and Git Root Dir honor it too: each truncates its own visible text to the configured width with an ellipsis, so the widgets after it stay on screen. ✨ A shared `max-width` helper carries the truncation, the `(w)idth` keybind, the editor and the `max:N` modifier, matching the Custom Command pattern so the behavior and TUI feel consistent. For hyperlinked widgets only the visible label is shortened, and the link target stays whole.

Nothing changes when `maxWidth` is unset. Truncation goes through `truncateStyledText`, so it stays ANSI- and OSC8-aware.