### PR TITLE
fix: silence stderr on best-effort package-manager probes

### DIFF
--- a/src/utils/__tests__/global-command-resolution.test.ts
+++ b/src/utils/__tests__/global-command-resolution.test.ts
@@ -71,6 +71,32 @@ describe('global command resolution', () => {
         ]);
     });
 
+    it('silences child stderr on best-effort probes so failures cannot leak to the terminal', () => {
+        const execFileSyncSpy = mockExecFileSync({
+            'which -a ccstatusline': '/home/alice/.bun/bin/ccstatusline\n',
+            'bun pm bin -g': '/home/alice/.bun/bin\n'
+        });
+
+        inspectGlobalCommandResolution('bun', { platform: 'linux' });
+
+        expect(execFileSyncSpy).toHaveBeenCalled();
+        for (const call of execFileSyncSpy.mock.calls) {
+            const options = call[2] as { stdio?: string[] };
+            expect(options.stdio).toEqual(['ignore', 'pipe', 'ignore']);
+        }
+    });
+
+    it('treats a probe that throws with stderr output as not found without surfacing an error', () => {
+        vi.spyOn(childProcess, 'execFileSync').mockImplementation(() => {
+            throw new Error('error: No package.json was found for directory "C:\\Users\\alice\\.bun\\install\\global"');
+        });
+
+        const resolution = inspectGlobalCommandResolution('bun', { platform: 'win32' });
+
+        expect(resolution.resolvedPaths).toEqual([]);
+        expect(resolution.expectedBinDir).toBeNull();
+    });
+
     it('warns when multiple PATH directories contain ccstatusline', () => {
         mockExecFileSync({
             'which -a ccstatusline': '/home/alice/.bun/bin/ccstatusline\n/usr/local/bin/ccstatusline\n',

--- a/src/utils/global-command-resolution.ts
+++ b/src/utils/global-command-resolution.ts
@@ -55,12 +55,14 @@ export function getCommandResolutionPaths(
             ? execFileSync('where', [command], {
                 encoding: 'utf-8',
                 timeout: COMMAND_LOOKUP_TIMEOUT_MS,
-                windowsHide: true
+                windowsHide: true,
+                stdio: ['ignore', 'pipe', 'ignore']
             })
             : execFileSync('which', ['-a', command], {
                 encoding: 'utf-8',
                 timeout: COMMAND_LOOKUP_TIMEOUT_MS,
-                windowsHide: true
+                windowsHide: true,
+                stdio: ['ignore', 'pipe', 'ignore']
             });
 
         return splitCommandOutput(output);
@@ -76,6 +78,7 @@ function getNpmGlobalBinDir(platform: NodeJS.Platform): string | null {
             encoding: 'utf-8',
             timeout: COMMAND_LOOKUP_TIMEOUT_MS,
             windowsHide: true,
+            stdio: ['ignore', 'pipe', 'ignore'],
             ...getPackageManagerShellOptions(executable, platform)
         }).trim();
 
@@ -93,10 +96,14 @@ function getNpmGlobalBinDir(platform: NodeJS.Platform): string | null {
 
 function getBunGlobalBinDir(): string | null {
     try {
+        // bun writes an error to stderr when its global dir was never
+        // initialized (no `bun add -g` ever run); silence it so best-effort
+        // probing cannot leak into the TUI terminal.
         const binDir = execFileSync('bun', ['pm', 'bin', '-g'], {
             encoding: 'utf-8',
             timeout: COMMAND_LOOKUP_TIMEOUT_MS,
-            windowsHide: true
+            windowsHide: true,
+            stdio: ['ignore', 'pipe', 'ignore']
         }).trim();
 
         return binDir || null;

--- a/src/utils/global-package-manager.ts
+++ b/src/utils/global-package-manager.ts
@@ -183,6 +183,7 @@ function getNpmGlobalPackageVersion(platform: NodeJS.Platform): string | null {
             encoding: 'utf-8',
             timeout: VERSION_LOOKUP_TIMEOUT_MS,
             windowsHide: true,
+            stdio: ['ignore', 'pipe', 'ignore'],
             ...getPackageManagerShellOptions(executable, platform)
         }).trim();
 


### PR DESCRIPTION
## Problem

On a machine where `bun` is on PATH but its global directory was never initialized (the user never ran `bun add -g` — e.g. they installed ccstatusline via `npm install -g`), launching the config TUI prints bun's error straight into the terminal:

```
error: No package.json was found for directory "C:\Users\alice\.bun\install\global"
```

(Reported downstream in a localized fork: huangguang1999/ccstatusline-zh#39, with screenshots.)

## Root cause

Installation inspection probes `bun pm bin -g` (plus `where`/`which`, `npm prefix -g`, `npm root -g`) through `execFileSync` **without an `stdio` option**. Node's default inherits the child's stderr into the parent terminal, so even though the thrown error is caught (`catch { return null; }`), the stderr text has already leaked. On Windows, `where` similarly writes `INFO: Could not find files...` to stderr when nothing matches.

Other probes in the codebase already suppress stderr (e.g. `usage-fetch.ts` uses `stdio: ['pipe', 'pipe', 'ignore']`) — these calls just missed the pattern.

## Fix

Add `stdio: ['ignore', 'pipe', 'ignore']` to the best-effort probe calls (stdout stays piped for the return value). No behavior change: these functions already treat any failure as "not found".

## Tests

- New test asserting every probe `execFileSync` call carries stderr suppression (regression guard).
- New test simulating the exact bun error and asserting graceful "not found" degradation.
- `bun run lint` clean, `bun test` 1630 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)