### PR TITLE
feat(widgets): add Caveman Mode badge widget

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -26,6 +26,7 @@ bun run example
 - **Model** / **Output Style** / **Version** - Show the active Claude model, output style, and Claude Code CLI version. Model names omit trailing context suffixes like `(1M context)`; use **Context Window** when you want the total window size shown.
 - **Claude Session ID** / **Session Name** / **Claude Account Email** - Show session identifiers plus the currently signed-in Claude account email.
 - **Voice Status** - Show whether Claude Code voice input is enabled. It can render as an icon, icon plus text, plain text, or `voice on/off`, with optional Nerd Font microphone icons.
+- **Caveman Mode** - Show the [caveman](https://github.com/JuliusBrussee/caveman) plugin's active compression mode as a badge (`[CAVEMAN]`, `[CAVEMAN:ULTRA]`) with an optional lifetime token-savings suffix. Hidden when caveman is inactive.
 - **Thinking Effort** / **Vim Mode** / **Skills** - Show Claude thinking effort, the current vim editing mode, and skill activity from hook data. Thinking Effort reads live status JSON first, then `/model` or `/effort` transcript output, then settings fallback; it supports `low`, `medium`, `high`, `xhigh`, and `max`, shows `default` when no effort is set, and marks unknown future values with `?`. Claude Code reports Ultracode as `xhigh` in status line data; it does not expose Ultracode as a separate effort level.
 - **Session Clock** / **Session Cost** - Show elapsed session time and the current session cost in USD.
 
@@ -209,6 +210,7 @@ Widget-specific shortcuts:
 - **Compaction Counter**: `f` cycle format, `n` toggle Nerd Font icon in icon mode, `s` toggle trigger split (auto/manual/unknown), `t` toggle tokens reclaimed, `h` hide when zero
 - **Cache widgets** (Cache Hit Rate, Cache Read, Cache Write): `t` toggle turn/session scope, `h` hide when empty
 - **Voice Status**: `f` cycle format, `n` toggle Nerd Font microphone icons
+- **Caveman Mode**: `s` toggle the token-savings suffix
 - **Current Working Dir**: `h` home abbreviation, `s` segment editor, `f` fish-style path, `g` optional leading glyph (off by default; pair with raw value to replace the `cwd:` label with the glyph)
 - **Skills**: `v` cycle view mode, `h` hide when empty, `l` edit list limit in list mode
 - **Input Speed / Output Speed / Total Speed**: `w` edit the rolling window in seconds

--- a/src/utils/__tests__/caveman.test.ts
+++ b/src/utils/__tests__/caveman.test.ts
@@ -1,0 +1,114 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import { getCavemanStatus } from '../caveman';
+
+const ORIGINAL_CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR;
+let testClaudeConfigDir = '';
+const PICK = String.fromCodePoint(0x26cf);
+const ESC = String.fromCharCode(0x1b);
+
+function writeActiveFlag(content: string): void {
+    fs.writeFileSync(path.join(testClaudeConfigDir, '.caveman-active'), content, 'utf-8');
+}
+
+function writeSavingsFile(content: string): void {
+    fs.writeFileSync(path.join(testClaudeConfigDir, '.caveman-statusline-suffix'), content, 'utf-8');
+}
+
+beforeEach(() => {
+    testClaudeConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-caveman-'));
+    process.env.CLAUDE_CONFIG_DIR = testClaudeConfigDir;
+});
+
+afterEach(() => {
+    if (testClaudeConfigDir) {
+        fs.rmSync(testClaudeConfigDir, { recursive: true, force: true });
+    }
+    if (ORIGINAL_CLAUDE_CONFIG_DIR === undefined) {
+        delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+        process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CLAUDE_CONFIG_DIR;
+    }
+});
+
+describe('getCavemanStatus', () => {
+    it('returns null when .caveman-active is absent', () => {
+        expect(getCavemanStatus()).toBeNull();
+    });
+
+    it('returns null when .caveman-active is a symlink', () => {
+        const realFile = path.join(testClaudeConfigDir, 'real-active');
+        fs.writeFileSync(realFile, 'ultra', 'utf-8');
+        fs.symlinkSync(realFile, path.join(testClaudeConfigDir, '.caveman-active'));
+
+        expect(getCavemanStatus()).toBeNull();
+    });
+
+    it('lowercases and strips a trailing newline for a whitelisted mode', () => {
+        writeActiveFlag('ULTRA\n');
+        expect(getCavemanStatus()).toEqual({ mode: 'ultra', savings: null });
+    });
+
+    it('returns null for non-whitelisted content', () => {
+        writeActiveFlag('hacked');
+        expect(getCavemanStatus()).toBeNull();
+    });
+
+    it('returns null for content containing ANSI-escape bytes', () => {
+        writeActiveFlag(`${ESC}[31multra${ESC}[0m`);
+        expect(getCavemanStatus()).toBeNull();
+    });
+
+    it('caps the read at 64 bytes and does not crash on an oversized file', () => {
+        writeActiveFlag(`ultra${'x'.repeat(200)}`);
+        expect(getCavemanStatus()).toBeNull();
+    });
+
+    describe('savings suffix', () => {
+        beforeEach(() => {
+            writeActiveFlag('ultra');
+        });
+
+        it('is null when the suffix file is absent', () => {
+            expect(getCavemanStatus()).toEqual({ mode: 'ultra', savings: null });
+        });
+
+        it('is null when the suffix file is a symlink', () => {
+            const realFile = path.join(testClaudeConfigDir, 'real-suffix');
+            fs.writeFileSync(realFile, `${PICK}  12.4k`, 'utf-8');
+            fs.symlinkSync(realFile, path.join(testClaudeConfigDir, '.caveman-statusline-suffix'));
+
+            expect(getCavemanStatus()).toEqual({ mode: 'ultra', savings: null });
+        });
+
+        it('strips control bytes from the suffix', () => {
+            writeSavingsFile(`${PICK}  12.4k${ESC}[0m`);
+            expect(getCavemanStatus()).toEqual({ mode: 'ultra', savings: `${PICK}  12.4k[0m` });
+        });
+
+        it('is null when the suffix is empty after stripping control bytes', () => {
+            writeSavingsFile(ESC);
+            expect(getCavemanStatus()).toEqual({ mode: 'ultra', savings: null });
+        });
+
+        it('returns the pre-rendered savings string on the happy path', () => {
+            writeSavingsFile(`${PICK}  12.4k`);
+            expect(getCavemanStatus()).toEqual({ mode: 'ultra', savings: `${PICK}  12.4k` });
+        });
+
+        it('caps the suffix read at 64 bytes on an oversized file', () => {
+            writeSavingsFile('a'.repeat(100));
+            const status = getCavemanStatus();
+            expect(status?.savings).toHaveLength(64);
+        });
+    });
+});

--- a/src/utils/caveman.ts
+++ b/src/utils/caveman.ts
@@ -1,0 +1,84 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { getClaudeConfigDir } from './claude-settings';
+
+const CAVEMAN_MODES = new Set([
+    'off', 'lite', 'full', 'ultra',
+    'wenyan-lite', 'wenyan', 'wenyan-full', 'wenyan-ultra',
+    'commit', 'review', 'compress'
+]);
+const MAX_READ_BYTES = 64;
+
+export interface CavemanStatus {
+    mode: string;           // whitelisted mode word, lowercase
+    savings: string | null; // pre-rendered savings string, control bytes stripped
+}
+
+/**
+ * Reads up to MAX_READ_BYTES from filePath, refusing symlinks (a local attacker
+ * could otherwise point the flag at a sensitive file and have its bytes,
+ * including ANSI escape sequences, rendered to the terminal every keystroke).
+ * O_NOFOLLOW makes the open itself fail on a symlink (ELOOP), closing the
+ * TOCTOU gap a separate lstat-then-open would leave. Any error, including a
+ * missing file, returns null.
+ */
+function readCappedFile(filePath: string): string | null {
+    let fd: number | undefined;
+    try {
+        const buffer = Buffer.alloc(MAX_READ_BYTES);
+        fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+        const bytesRead = fs.readSync(fd, buffer, 0, MAX_READ_BYTES, 0);
+        return buffer.toString('utf-8', 0, bytesRead);
+    } catch {
+        return null;
+    } finally {
+        if (fd !== undefined) {
+            fs.closeSync(fd);
+        }
+    }
+}
+
+/**
+ * Strips control bytes (below 0x20, plus DEL) by filtering on code point
+ * rather than a control-char regex — blocks terminal-escape injection and
+ * OSC hyperlink spoofing via file contents.
+ */
+function stripControlBytes(s: string): string {
+    return Array.from(s).filter((c) => {
+        const code = c.codePointAt(0) ?? 0;
+        return code >= 0x20 && code !== 0x7f;
+    }).join('');
+}
+
+function readSavings(configDir: string): string | null {
+    const raw = readCappedFile(path.join(configDir, '.caveman-statusline-suffix'));
+    if (raw === null) {
+        return null;
+    }
+
+    const stripped = stripControlBytes(raw);
+    return stripped.length > 0 ? stripped : null;
+}
+
+export function getCavemanStatus(): CavemanStatus | null {
+    const configDir = getClaudeConfigDir();
+
+    const raw = readCappedFile(path.join(configDir, '.caveman-active'));
+    if (raw === null) {
+        return null;
+    }
+
+    const mode = raw
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, '');
+
+    if (!CAVEMAN_MODES.has(mode)) {
+        return null;
+    }
+
+    return {
+        mode,
+        savings: readSavings(configDir)
+    };
+}

--- a/src/utils/widget-manifest.ts
+++ b/src/utils/widget-manifest.ts
@@ -95,6 +95,7 @@ export const WIDGET_MANIFEST: WidgetManifestEntry[] = [
     { type: 'vim-mode', create: () => new widgets.VimModeWidget() },
     { type: 'voice-status', create: () => new widgets.VoiceStatusWidget() },
     { type: 'remote-control-status', create: () => new widgets.RemoteControlStatusWidget() },
+    { type: 'caveman-mode', create: () => new widgets.CavemanModeWidget() },
     { type: 'worktree-mode', create: () => new widgets.GitWorktreeModeWidget() },
     { type: 'worktree-name', create: () => new widgets.GitWorktreeNameWidget() },
     { type: 'worktree-branch', create: () => new widgets.GitWorktreeBranchWidget() },

--- a/src/widgets/CavemanMode.ts
+++ b/src/widgets/CavemanMode.ts
@@ -1,0 +1,97 @@
+import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
+import type {
+    CustomKeybind,
+    Widget,
+    WidgetEditorDisplay,
+    WidgetItem
+} from '../types/Widget';
+import { getCavemanStatus } from '../utils/caveman';
+
+const TOGGLE_SAVINGS_ACTION = 'toggle-savings';
+const HIDE_SAVINGS_METADATA_KEY = 'hideSavings';
+
+function isSavingsHidden(item: WidgetItem): boolean {
+    return item.metadata?.[HIDE_SAVINGS_METADATA_KEY] === 'true';
+}
+
+function toggleSavings(item: WidgetItem): WidgetItem {
+    if (!isSavingsHidden(item)) {
+        return {
+            ...item,
+            metadata: {
+                ...(item.metadata ?? {}),
+                [HIDE_SAVINGS_METADATA_KEY]: 'true'
+            }
+        };
+    }
+
+    const { [HIDE_SAVINGS_METADATA_KEY]: removedHideSavings, ...restMetadata } = item.metadata ?? {};
+    void removedHideSavings;
+
+    return {
+        ...item,
+        metadata: Object.keys(restMetadata).length > 0 ? restMetadata : undefined
+    };
+}
+
+function formatBadge(mode: string, savings: string | null, showSavings: boolean): string {
+    const badge = mode === 'full' ? '[CAVEMAN]' : `[CAVEMAN:${mode.toUpperCase()}]`;
+    if (!showSavings || savings === null) {
+        return badge;
+    }
+    return `${badge} ${savings}`;
+}
+
+export class CavemanModeWidget implements Widget {
+    getDefaultColor(): string { return 'yellow'; }
+    getDescription(): string { return 'Shows the active caveman compression mode badge and token savings'; }
+    getDisplayName(): string { return 'Caveman Mode'; }
+    getCategory(): string { return 'Core'; }
+
+    getEditorDisplay(item: WidgetItem): WidgetEditorDisplay {
+        return {
+            displayText: this.getDisplayName(),
+            modifierText: isSavingsHidden(item) ? '(no savings)' : '(savings)'
+        };
+    }
+
+    handleEditorAction(action: string, item: WidgetItem): WidgetItem | null {
+        if (action === TOGGLE_SAVINGS_ACTION) {
+            return toggleSavings(item);
+        }
+
+        return null;
+    }
+
+    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+        const showSavings = !isSavingsHidden(item);
+
+        if (context.isPreview) {
+            if (item.rawValue) {
+                return 'full';
+            }
+            return formatBadge('full', '⛏  12.4k', showSavings);
+        }
+
+        const status = getCavemanStatus();
+        if (status === null) {
+            return null;
+        }
+
+        if (item.rawValue) {
+            return status.mode;
+        }
+
+        return formatBadge(status.mode, status.savings, showSavings);
+    }
+
+    getCustomKeybinds(): CustomKeybind[] {
+        return [
+            { key: 's', label: '(s)avings', action: TOGGLE_SAVINGS_ACTION }
+        ];
+    }
+
+    supportsRawValue(): boolean { return true; }
+    supportsColors(_item: WidgetItem): boolean { return true; }
+}

--- a/src/widgets/__tests__/CavemanMode.test.ts
+++ b/src/widgets/__tests__/CavemanMode.test.ts
@@ -1,0 +1,157 @@
+import {
+    afterEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import type {
+    RenderContext,
+    WidgetItem
+} from '../../types';
+import { DEFAULT_SETTINGS } from '../../types/Settings';
+import * as caveman from '../../utils/caveman';
+import { CavemanModeWidget } from '../CavemanMode';
+
+const ITEM: WidgetItem = { id: 'caveman-mode', type: 'caveman-mode' };
+const HIDDEN_SAVINGS_ITEM: WidgetItem = { ...ITEM, metadata: { hideSavings: 'true' } };
+
+function makeContext(overrides: Partial<RenderContext> = {}): RenderContext {
+    return { ...overrides };
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('CavemanModeWidget', () => {
+    describe('metadata', () => {
+        it('has correct display name', () => {
+            expect(new CavemanModeWidget().getDisplayName()).toBe('Caveman Mode');
+        });
+
+        it('has correct description', () => {
+            expect(new CavemanModeWidget().getDescription()).toBe('Shows the active caveman compression mode badge and token savings');
+        });
+
+        it('has correct category', () => {
+            expect(new CavemanModeWidget().getCategory()).toBe('Core');
+        });
+
+        it('has yellow default color', () => {
+            expect(new CavemanModeWidget().getDefaultColor()).toBe('yellow');
+        });
+
+        it('supports raw value', () => {
+            expect(new CavemanModeWidget().supportsRawValue()).toBe(true);
+        });
+
+        it('supports colors', () => {
+            expect(new CavemanModeWidget().supportsColors(ITEM)).toBe(true);
+        });
+    });
+
+    describe('editor configuration', () => {
+        it('exposes s keybind', () => {
+            expect(new CavemanModeWidget().getCustomKeybinds()).toEqual([
+                { key: 's', label: '(s)avings', action: 'toggle-savings' }
+            ]);
+        });
+
+        it('defaults to showing savings in the editor display', () => {
+            expect(new CavemanModeWidget().getEditorDisplay(ITEM)).toEqual({
+                displayText: 'Caveman Mode',
+                modifierText: '(savings)'
+            });
+        });
+
+        it('shows no savings in the editor display when hidden', () => {
+            expect(new CavemanModeWidget().getEditorDisplay(HIDDEN_SAVINGS_ITEM)).toEqual({
+                displayText: 'Caveman Mode',
+                modifierText: '(no savings)'
+            });
+        });
+
+        it('toggles hideSavings metadata on and off', () => {
+            const widget = new CavemanModeWidget();
+            const hidden = widget.handleEditorAction('toggle-savings', ITEM);
+            const shown = widget.handleEditorAction('toggle-savings', hidden ?? ITEM);
+
+            expect(hidden?.metadata?.hideSavings).toBe('true');
+            expect(shown?.metadata?.hideSavings).toBeUndefined();
+        });
+
+        it('returns null for unknown editor actions', () => {
+            expect(new CavemanModeWidget().handleEditorAction('unknown', ITEM)).toBeNull();
+        });
+    });
+
+    describe('render() - hide on absent status', () => {
+        it('returns null when getCavemanStatus returns null', () => {
+            vi.spyOn(caveman, 'getCavemanStatus').mockReturnValue(null);
+            expect(new CavemanModeWidget().render(ITEM, makeContext(), DEFAULT_SETTINGS)).toBeNull();
+        });
+    });
+
+    describe('render() - badge formatting', () => {
+        it('renders [CAVEMAN] for full mode', () => {
+            vi.spyOn(caveman, 'getCavemanStatus').mockReturnValue({ mode: 'full', savings: null });
+            expect(new CavemanModeWidget().render(ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('[CAVEMAN]');
+        });
+
+        it('renders [CAVEMAN:ULTRA] for ultra mode', () => {
+            vi.spyOn(caveman, 'getCavemanStatus').mockReturnValue({ mode: 'ultra', savings: null });
+            expect(new CavemanModeWidget().render(ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('[CAVEMAN:ULTRA]');
+        });
+    });
+
+    describe('render() - savings toggle', () => {
+        it('appends savings when shown (default) and present', () => {
+            vi.spyOn(caveman, 'getCavemanStatus').mockReturnValue({ mode: 'ultra', savings: '⛏  12.4k' });
+            expect(new CavemanModeWidget().render(ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('[CAVEMAN:ULTRA] ⛏  12.4k');
+        });
+
+        it('omits savings when null even if shown', () => {
+            vi.spyOn(caveman, 'getCavemanStatus').mockReturnValue({ mode: 'ultra', savings: null });
+            expect(new CavemanModeWidget().render(ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('[CAVEMAN:ULTRA]');
+        });
+
+        it('omits savings when hidden via metadata', () => {
+            vi.spyOn(caveman, 'getCavemanStatus').mockReturnValue({ mode: 'ultra', savings: '⛏  12.4k' });
+            expect(new CavemanModeWidget().render(HIDDEN_SAVINGS_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('[CAVEMAN:ULTRA]');
+        });
+    });
+
+    describe('render() - raw value', () => {
+        const RAW_ITEM: WidgetItem = { ...ITEM, rawValue: true };
+
+        it('returns the bare mode word', () => {
+            vi.spyOn(caveman, 'getCavemanStatus').mockReturnValue({ mode: 'ultra', savings: '⛏  12.4k' });
+            expect(new CavemanModeWidget().render(RAW_ITEM, makeContext(), DEFAULT_SETTINGS)).toBe('ultra');
+        });
+
+        it('returns null when status is null', () => {
+            vi.spyOn(caveman, 'getCavemanStatus').mockReturnValue(null);
+            expect(new CavemanModeWidget().render(RAW_ITEM, makeContext(), DEFAULT_SETTINGS)).toBeNull();
+        });
+
+        it('returns "full" in preview mode', () => {
+            expect(new CavemanModeWidget().render(RAW_ITEM, makeContext({ isPreview: true }), DEFAULT_SETTINGS)).toBe('full');
+        });
+    });
+
+    describe('render() - preview mode', () => {
+        it('renders the badge with savings by default and never calls the helper', () => {
+            const spy = vi.spyOn(caveman, 'getCavemanStatus');
+            expect(new CavemanModeWidget().render(ITEM, makeContext({ isPreview: true }), DEFAULT_SETTINGS)).toBe('[CAVEMAN] ⛏  12.4k');
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        it('renders the badge without savings when hidden via metadata', () => {
+            const spy = vi.spyOn(caveman, 'getCavemanStatus');
+            expect(new CavemanModeWidget().render(HIDDEN_SAVINGS_ITEM, makeContext({ isPreview: true }), DEFAULT_SETTINGS)).toBe('[CAVEMAN]');
+            expect(spy).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -81,3 +81,4 @@ export { GitWorktreeOriginalBranchWidget } from './GitWorktreeOriginalBranch';
 export { CompactionCounterWidget } from './CompactionCounter';
 export { VoiceStatusWidget } from './VoiceStatus';
 export { RemoteControlStatusWidget } from './RemoteControlStatus';
+export { CavemanModeWidget } from './CavemanMode';


### PR DESCRIPTION
## What

Adds a **Caveman Mode** widget (Core category) that surfaces the [caveman](https://github.com/JuliusBrussee/caveman) plugin's active compression mode as a status line badge — `[CAVEMAN]`, `[CAVEMAN:ULTRA]`, etc. — with an optional lifetime token-savings suffix (`⛏  12.4k`). The widget hides entirely when the plugin is inactive.

## Why

The caveman plugin ships its own statusline badge as a bash script wired into Claude Code's `settings.json` `statusLine` slot. That slot is single-occupancy, so anyone running ccstatusline can never see the badge — the plugin's installer detects the existing statusline and backs off. A native widget lets both coexist, enabled from the TUI picker like any other widget.

## How

- `src/utils/caveman.ts` — `getCavemanStatus()` reads the plugin's two state files under `$CLAUDE_CONFIG_DIR` (`.caveman-active` mode word, `.caveman-statusline-suffix` pre-rendered savings string). Ports the plugin script's own hardening, and tightens it: atomic `O_NOFOLLOW` open (the bash original has an lstat-then-read TOCTOU gap), 64-byte read cap, mode whitelist, control-byte strip on the suffix.
- `src/widgets/CavemanMode.ts` — mirrors the VoiceStatus pattern: metadata-backed `s` keybind toggles the savings suffix, raw value mode returns the bare mode word, preview support, no React editor needed.
- Registered via `WIDGET_MANIFEST` + barrel export; documented in `docs/USAGE.md` (widget list + keybinds).

## Testing

- 12 util tests against real temp files (symlink refusal on both state files, 64-byte cap proven positively via suffix length, whitelist rejection, ANSI-escape stripping)
- 22 widget tests with the reader mocked (badge formats, savings toggle round-trip, rawValue, preview never touches disk)
- `bun run lint` clean, full suite 1662 pass / 0 fail
- Manual E2E: piped payload renders `[CAVEMAN:ULTRA] ⛏  12.4k`, hides on absent flag, hides on symlinked flag