### PR TITLE
feat(renderer): add left/right option for Default Padding

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -87,9 +87,11 @@ Configure global formatting preferences that apply to all widgets:
 
 ### Default Padding & Separators
 
-- **Default Padding** - Add consistent padding to the left and right of each widget
+- **Default Padding** - Add consistent padding around each widget
+- **Padding Side** - Choose whether default padding applies to **Both** sides (default), **Left only**, or **Right only**
 - **Default Separator** - Automatically insert a separator between all widgets
   - Press **(p)** to edit padding
+  - Press **(d)** to cycle padding side
   - Press **(s)** to edit separator
 - Manual separators collapse around widgets that render empty, so hide-when-empty widgets do not leave dangling dividers.
 

--- a/src/tui/components/GlobalOverridesMenu.tsx
+++ b/src/tui/components/GlobalOverridesMenu.tsx
@@ -6,7 +6,10 @@ import {
 import React, { useState } from 'react';
 
 import { getColorLevelString } from '../../types/ColorLevel';
-import type { Settings } from '../../types/Settings';
+import {
+    DefaultPaddingSideSchema,
+    type Settings
+} from '../../types/Settings';
 import {
     COLOR_MAP,
     applyColors,
@@ -231,6 +234,16 @@ export const GlobalOverridesMenu: React.FC<GlobalOverridesMenuProps> = ({ settin
                     overrideForegroundColor: undefined
                 };
                 onUpdate(updatedSettings);
+            } else if (input === 'd' || input === 'D') {
+                // Cycle through padding sides: both -> left -> right -> both
+                const paddingSides = DefaultPaddingSideSchema.options;
+                const currentIndex = paddingSides.indexOf(settings.defaultPaddingSide);
+                const nextSide = paddingSides[(currentIndex + 1) % paddingSides.length] ?? 'both';
+                const updatedSettings = {
+                    ...settings,
+                    defaultPaddingSide: nextSide
+                };
+                onUpdate(updatedSettings);
             }
         }
     });
@@ -298,7 +311,7 @@ export const GlobalOverridesMenu: React.FC<GlobalOverridesMenuProps> = ({ settin
             {editingPadding ? (
                 <Box flexDirection='column'>
                     <Box>
-                        <Text>Enter default padding (applied to left and right of each widget): </Text>
+                        <Text>Enter default padding (applied per the Padding Side setting): </Text>
                         <Text color='cyan'>{paddingInput ? `"${paddingInput}"` : '(empty)'}</Text>
                     </Box>
                     <Text dimColor>Press Enter to save, ESC to cancel</Text>
@@ -363,6 +376,12 @@ export const GlobalOverridesMenu: React.FC<GlobalOverridesMenuProps> = ({ settin
                         <Text>  Default Padding: </Text>
                         <Text color='cyan'>{settings.defaultPadding ? `"${settings.defaultPadding}"` : '(none)'}</Text>
                         <Text dimColor> - Press (p) to edit</Text>
+                    </Box>
+
+                    <Box>
+                        <Text>     Padding Side: </Text>
+                        <Text color='cyan'>{settings.defaultPaddingSide === 'left' ? 'Left only' : settings.defaultPaddingSide === 'right' ? 'Right only' : 'Both'}</Text>
+                        <Text dimColor> - Press (d) to cycle</Text>
                     </Box>
 
                     <Box>
@@ -441,6 +460,9 @@ export const GlobalOverridesMenu: React.FC<GlobalOverridesMenuProps> = ({ settin
                     <Box marginTop={1} flexDirection='column'>
                         <Text dimColor wrap='wrap'>
                             Note: These settings are applied during rendering and don't add widgets to your widget list.
+                        </Text>
+                        <Text dimColor wrap='wrap'>
+                            • Padding Side: Choose whether default padding applies to both sides, left only, or right only
                         </Text>
                         <Text dimColor wrap='wrap'>
                             • Inherit colors: Separators will use colors from the preceding widget

--- a/src/tui/components/__tests__/GlobalOverridesMenu.test.ts
+++ b/src/tui/components/__tests__/GlobalOverridesMenu.test.ts
@@ -180,6 +180,84 @@ describe('GlobalOverridesMenu', () => {
         }
     });
 
+    it('displays padding side as "Both" by default', async () => {
+        const stdin = createMockStdin();
+        const stdout = createMockStdout();
+        const stderr = createMockStdout();
+        const onUpdate = vi.fn();
+        const onBack = vi.fn();
+
+        const instance = render(
+            React.createElement(GlobalOverridesMenu, {
+                settings: DEFAULT_SETTINGS,
+                onUpdate,
+                onBack
+            }),
+            {
+                stdin,
+                stdout,
+                stderr,
+                debug: true,
+                exitOnCtrlC: false,
+                patchConsole: false
+            }
+        );
+
+        try {
+            await flushInk();
+            expect(stdout.getOutput()).toContain('Padding Side:');
+            expect(stdout.getOutput()).toContain('Both');
+        } finally {
+            instance.unmount();
+            instance.cleanup();
+            stdin.destroy();
+            stdout.destroy();
+            stderr.destroy();
+        }
+    });
+
+    it.each([
+        { starting: 'both' as const, expected: 'left' as const },
+        { starting: 'left' as const, expected: 'right' as const },
+        { starting: 'right' as const, expected: 'both' as const }
+    ])('cycles padding side from "$starting" to "$expected" when (d) is pressed', async ({ starting, expected }) => {
+        const stdin = createMockStdin();
+        const stdout = createMockStdout();
+        const stderr = createMockStdout();
+        const onUpdate = vi.fn();
+        const onBack = vi.fn();
+
+        const instance = render(
+            React.createElement(GlobalOverridesMenu, {
+                settings: { ...DEFAULT_SETTINGS, defaultPaddingSide: starting },
+                onUpdate,
+                onBack
+            }),
+            {
+                stdin,
+                stdout,
+                stderr,
+                debug: true,
+                exitOnCtrlC: false,
+                patchConsole: false
+            }
+        );
+
+        try {
+            await flushInk();
+            stdin.write('d');
+            await flushInk();
+
+            expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ defaultPaddingSide: expected }));
+        } finally {
+            instance.unmount();
+            instance.cleanup();
+            stdin.destroy();
+            stdout.destroy();
+            stderr.destroy();
+        }
+    });
+
     it('shows foreground override gradient and clear controls on the same line', async () => {
         const stdin = createMockStdin();
         const stdout = createMockStdout();

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -8,6 +8,10 @@ import { WidgetItemSchema } from './Widget';
 // Current version - bump this when making breaking changes to the schema
 export const CURRENT_VERSION = 3;
 
+// Which side(s) of a widget the default padding is applied to
+export const DefaultPaddingSideSchema = z.enum(['both', 'left', 'right']);
+export type DefaultPaddingSide = z.infer<typeof DefaultPaddingSideSchema>;
+
 export const InstallationMetadataSchema = z.discriminatedUnion('method', [
     z.object({
         method: z.literal('auto-update'),
@@ -64,6 +68,7 @@ export const SettingsSchema = z.object({
     colorLevel: ColorLevelSchema.default(2),
     defaultSeparator: z.string().optional(),
     defaultPadding: z.string().optional(),
+    defaultPaddingSide: DefaultPaddingSideSchema.default('both'),
     inheritSeparatorColors: z.boolean().default(false),
     overrideBackgroundColor: z.string().optional(),
     overrideForegroundColor: z.string().optional(),

--- a/src/utils/__tests__/renderer-padding-side.test.ts
+++ b/src/utils/__tests__/renderer-padding-side.test.ts
@@ -10,6 +10,7 @@ import {
     type Settings
 } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { stripSgrCodes } from '../ansi';
 import {
     calculateMaxWidthsFromPreRendered,
     renderStatusLine,
@@ -37,13 +38,26 @@ function text(content: string, extra: Partial<WidgetItem> = {}): WidgetItem {
     return { id: content, type: 'custom-text', customText: content, ...extra };
 }
 
+function powerlineSettings(overrides: Partial<Settings> = {}): Settings {
+    return createSettings({
+        ...overrides,
+        powerline: { ...DEFAULT_SETTINGS.powerline, enabled: true, separators: ['|'] }
+    });
+}
+
+// Assertions below only care about visible content and spacing, never
+// styling, so every render() call returns SGR-stripped output. This matches
+// the repo convention (see stripSgrCodes usage in renderer-flex-width.test.ts
+// and the separator-collapse tests) and keeps assertions stable regardless of
+// chalk's ambient color-support detection (e.g. under FORCE_COLOR/NO_COLOR),
+// which is independent of the `colorLevel` set on Settings.
 function render(widgets: WidgetItem[], contentByIndex: Record<number, string>, settings: Settings): string {
     const context: RenderContext = { isPreview: false, terminalWidth: 200 };
     const preRenderedWidgets = widgets.map((widget, i) => {
         const content = contentByIndex[i] ?? '';
         return { content, plainLength: content.length, widget };
     });
-    return renderStatusLine(widgets, settings, context, preRenderedWidgets, []);
+    return stripSgrCodes(renderStatusLine(widgets, settings, context, preRenderedWidgets, []));
 }
 
 describe('defaultPaddingSide', () => {
@@ -72,13 +86,6 @@ describe('defaultPaddingSide', () => {
     });
 
     describe('powerline rendering', () => {
-        function powerlineSettings(overrides: Partial<Settings> = {}): Settings {
-            return createSettings({
-                ...overrides,
-                powerline: { ...DEFAULT_SETTINGS.powerline, enabled: true, separators: ['|'] }
-            });
-        }
-
         it('applies padding to both sides by default', () => {
             const out = render([text('a')], { 0: 'A' }, powerlineSettings());
             expect(out).toContain('.A.');
@@ -98,6 +105,51 @@ describe('defaultPaddingSide', () => {
             const out = render(widgets, { 0: 'A', 1: 'B' }, settings);
             expect(out).toContain('A.');
             expect(out).not.toContain('.A');
+        });
+    });
+
+    describe('merge: "no-padding" takes precedence over the padding-side setting', () => {
+        it.each([
+            {
+                side: 'left' as const,
+                // Side 'left' means B's own leading pad would already be '.', so
+                // the no-padding merge must be what suppresses it (glue "AB").
+                withoutMerge: '.A.B',
+                withMerge: '.AB'
+            },
+            {
+                side: 'right' as const,
+                // Side 'right' means A's own trailing pad would already be '.', so
+                // the no-padding merge must be what suppresses it (glue "AB").
+                withoutMerge: 'A.B.',
+                withMerge: 'AB.'
+            }
+        ])('standard mode, side "$side": no double-pad and correct glue across a no-padding merge boundary', ({ side, withoutMerge, withMerge }) => {
+            const settings = createSettings({ defaultPaddingSide: side });
+
+            const baseline = render([text('a'), text('b')], { 0: 'A', 1: 'B' }, settings);
+            expect(baseline).toBe(withoutMerge);
+
+            const merged = render([text('a', { merge: 'no-padding' }), text('b')], { 0: 'A', 1: 'B' }, settings);
+            expect(merged).toBe(withMerge);
+        });
+
+        it.each([
+            { side: 'left' as const },
+            { side: 'right' as const }
+        ])('powerline mode, side "$side": no double-pad, no separator, and correct glue across a no-padding merge boundary', ({ side }) => {
+            const settings = powerlineSettings({ defaultPaddingSide: side });
+
+            const baseline = render([text('a'), text('b')], { 0: 'A', 1: 'B' }, settings);
+            // Without the merge, A and B are separate segments joined by the
+            // powerline separator.
+            expect(baseline).toContain('|');
+
+            const merged = render([text('a', { merge: 'no-padding' }), text('b')], { 0: 'A', 1: 'B' }, settings);
+            // With the no-padding merge, A and B glue directly together: no
+            // separator, and no padding character sits between them.
+            expect(merged).not.toContain('|');
+            expect(merged).toContain('AB');
         });
     });
 

--- a/src/utils/__tests__/renderer-padding-side.test.ts
+++ b/src/utils/__tests__/renderer-padding-side.test.ts
@@ -1,0 +1,126 @@
+import {
+    describe,
+    expect,
+    it
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import {
+    DEFAULT_SETTINGS,
+    type Settings
+} from '../../types/Settings';
+import type { WidgetItem } from '../../types/Widget';
+import {
+    calculateMaxWidthsFromPreRendered,
+    renderStatusLine,
+    type PreRenderedWidget
+} from '../renderer';
+
+function createSettings(overrides: Partial<Settings> = {}): Settings {
+    return {
+        ...DEFAULT_SETTINGS,
+        colorLevel: 0,
+        defaultPadding: '.',
+        ...overrides,
+        powerline: {
+            ...DEFAULT_SETTINGS.powerline,
+            ...(overrides.powerline ?? {})
+        }
+    };
+}
+
+function pre(content: string, extra: Partial<WidgetItem> = {}): PreRenderedWidget {
+    return { content, plainLength: content.length, widget: { id: content, type: 'custom-text', ...extra } };
+}
+
+function text(content: string, extra: Partial<WidgetItem> = {}): WidgetItem {
+    return { id: content, type: 'custom-text', customText: content, ...extra };
+}
+
+function render(widgets: WidgetItem[], contentByIndex: Record<number, string>, settings: Settings): string {
+    const context: RenderContext = { isPreview: false, terminalWidth: 200 };
+    const preRenderedWidgets = widgets.map((widget, i) => {
+        const content = contentByIndex[i] ?? '';
+        return { content, plainLength: content.length, widget };
+    });
+    return renderStatusLine(widgets, settings, context, preRenderedWidgets, []);
+}
+
+describe('defaultPaddingSide', () => {
+    it('defaults to "both", preserving existing behavior', () => {
+        expect(DEFAULT_SETTINGS.defaultPaddingSide).toBe('both');
+    });
+
+    describe('standard (non-powerline) rendering', () => {
+        it('applies padding to both sides by default', () => {
+            const settings = createSettings();
+            const out = render([text('a')], { 0: 'A' }, settings);
+            expect(out).toBe('.A.');
+        });
+
+        it('applies padding to the left only when side is "left"', () => {
+            const settings = createSettings({ defaultPaddingSide: 'left' });
+            const out = render([text('a')], { 0: 'A' }, settings);
+            expect(out).toBe('.A');
+        });
+
+        it('applies padding to the right only when side is "right"', () => {
+            const settings = createSettings({ defaultPaddingSide: 'right' });
+            const out = render([text('a')], { 0: 'A' }, settings);
+            expect(out).toBe('A.');
+        });
+    });
+
+    describe('powerline rendering', () => {
+        function powerlineSettings(overrides: Partial<Settings> = {}): Settings {
+            return createSettings({
+                ...overrides,
+                powerline: { ...DEFAULT_SETTINGS.powerline, enabled: true, separators: ['|'] }
+            });
+        }
+
+        it('applies padding to both sides by default', () => {
+            const out = render([text('a')], { 0: 'A' }, powerlineSettings());
+            expect(out).toContain('.A.');
+        });
+
+        it('applies padding to the left only when side is "left"', () => {
+            const settings = powerlineSettings({ defaultPaddingSide: 'left' });
+            const widgets = [text('a'), text('b')];
+            const out = render(widgets, { 0: 'A', 1: 'B' }, settings);
+            expect(out).toContain('.A');
+            expect(out).not.toContain('A.');
+        });
+
+        it('applies padding to the right only when side is "right"', () => {
+            const settings = powerlineSettings({ defaultPaddingSide: 'right' });
+            const widgets = [text('a'), text('b')];
+            const out = render(widgets, { 0: 'A', 1: 'B' }, settings);
+            expect(out).toContain('A.');
+            expect(out).not.toContain('.A');
+        });
+    });
+
+    describe('calculateMaxWidthsFromPreRendered width accounting', () => {
+        it('counts padding on both sides by default', () => {
+            const lines = [[pre('AB')]];
+            const settings = createSettings({ defaultPadding: '..' });
+            // 'AB' (2) + 2 leading + 2 trailing = 6
+            expect(calculateMaxWidthsFromPreRendered(lines, settings)).toEqual([6]);
+        });
+
+        it('counts padding only once when side is "left"', () => {
+            const lines = [[pre('AB')]];
+            const settings = createSettings({ defaultPadding: '..', defaultPaddingSide: 'left' });
+            // 'AB' (2) + 2 leading + 0 trailing = 4
+            expect(calculateMaxWidthsFromPreRendered(lines, settings)).toEqual([4]);
+        });
+
+        it('counts padding only once when side is "right"', () => {
+            const lines = [[pre('AB')]];
+            const settings = createSettings({ defaultPadding: '..', defaultPaddingSide: 'right' });
+            // 'AB' (2) + 0 leading + 2 trailing = 4
+            expect(calculateMaxWidthsFromPreRendered(lines, settings)).toEqual([4]);
+        });
+    });
+});

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -8,7 +8,10 @@ import {
     getColorLevelString,
     type ColorLevel
 } from '../types/ColorLevel';
-import type { Settings } from '../types/Settings';
+import type {
+    DefaultPaddingSide,
+    Settings
+} from '../types/Settings';
 
 import {
     applyLineGradient,
@@ -52,6 +55,16 @@ function maybeApplyForegroundGradient(
 ): string {
     const stops = parseGradientSpec(settings.overrideForegroundColor);
     return stops ? applyLineGradient(line, stops, colorLevel) : line;
+}
+
+// Split the default padding string into the leading/trailing pieces that
+// actually get applied, based on which side(s) padding is configured for.
+function resolvePaddingSides(padding: string, side: DefaultPaddingSide | undefined): { leading: string; trailing: string } {
+    if (side === 'left')
+        return { leading: padding, trailing: '' };
+    if (side === 'right')
+        return { leading: '', trailing: padding };
+    return { leading: padding, trailing: padding };
 }
 
 function resolveEffectiveTerminalWidth(
@@ -249,6 +262,7 @@ function renderPowerlineStatusLine(
         if (widgetText) {
             // Apply default padding from settings
             const padding = settings.defaultPadding ?? '';
+            const { leading: sideLeadingPadding, trailing: sideTrailingPadding } = resolvePaddingSides(padding, settings.defaultPaddingSide);
 
             // If override FG color is set and this is a custom command with preserveColors,
             // we need to strip the ANSI codes from the widget text
@@ -270,8 +284,8 @@ function renderPowerlineStatusLine(
                 && canMergeWithNextRenderedWidget(previousRenderedIndex ?? undefined);
             const omitTrailingPadding = widget.merge === 'no-padding' && mergesWithNext;
 
-            const leadingPadding = omitLeadingPadding ? '' : padding;
-            const trailingPadding = omitTrailingPadding ? '' : padding;
+            const leadingPadding = omitLeadingPadding ? '' : sideLeadingPadding;
+            const trailingPadding = omitTrailingPadding ? '' : sideTrailingPadding;
             const paddedText = `${leadingPadding}${widgetText}${trailingPadding}`;
 
             // Determine colors
@@ -826,7 +840,8 @@ export function calculateMaxWidthsFromPreRendered(
 ): number[] {
     const maxWidths: number[] = [];
     const defaultPadding = settings.defaultPadding ?? '';
-    const paddingLength = defaultPadding.length;
+    const { leading: sideLeadingPadding, trailing: sideTrailingPadding } = resolvePaddingSides(defaultPadding, settings.defaultPaddingSide);
+    const paddingPairLength = sideLeadingPadding.length + sideTrailingPadding.length;
 
     for (const preRenderedLine of preRenderedLines) {
         const isSeparatorBoundary = (entry: PreRenderedWidget | undefined): boolean => (
@@ -867,7 +882,7 @@ export function calculateMaxWidthsFromPreRendered(
 
             // Calculate the total width for this alignment position
             // If this widget is merged with the next, accumulate their widths
-            let totalWidth = widget.plainLength + (paddingLength * 2);
+            let totalWidth = widget.plainLength + paddingPairLength;
 
             // Check if this widget merges with the next one(s)
             let j = i;
@@ -880,7 +895,7 @@ export function calculateMaxWidthsFromPreRendered(
                     if (renderedWidgets[j - 1]?.widget.merge === 'no-padding') {
                         totalWidth += nextWidget.plainLength;
                     } else {
-                        totalWidth += nextWidget.plainLength + (paddingLength * 2);
+                        totalWidth += nextWidget.plainLength + paddingPairLength;
                     }
                 }
             }
@@ -1098,6 +1113,7 @@ export function renderStatusLine(
     // Apply default padding and separators
     const finalElements: string[] = [];
     const padding = settings.defaultPadding ?? '';
+    const { leading: sideLeadingPadding, trailing: sideTrailingPadding } = resolvePaddingSides(padding, settings.defaultPaddingSide);
     const defaultSep = settings.defaultSeparator ? formatSeparator(settings.defaultSeparator) : '';
 
     elements.forEach((elem, index) => {
@@ -1153,16 +1169,15 @@ export function renderStatusLine(
 
             if (padding && (elem.widget?.backgroundColor || hasColorOverride)) {
                 // Apply colors to padding - applyColorsWithOverride will handle the overrides
-                const leadingPadding = omitLeadingPadding ? '' : applyColorsWithOverride(padding, undefined, elem.widget?.backgroundColor);
-                const trailingPadding = omitTrailingPadding ? '' : applyColorsWithOverride(padding, undefined, elem.widget?.backgroundColor);
+                const leadingPadding = omitLeadingPadding || !sideLeadingPadding ? '' : applyColorsWithOverride(sideLeadingPadding, undefined, elem.widget?.backgroundColor);
+                const trailingPadding = omitTrailingPadding || !sideTrailingPadding ? '' : applyColorsWithOverride(sideTrailingPadding, undefined, elem.widget?.backgroundColor);
                 const paddedContent = leadingPadding + elem.content + trailingPadding;
                 finalElements.push(paddedContent);
             } else if (padding) {
                 // Wrap padding in ANSI reset codes to prevent trimming
                 // This ensures leading spaces aren't trimmed by terminals
-                const protectedPadding = chalk.reset(padding);
-                const leadingPadding = omitLeadingPadding ? '' : protectedPadding;
-                const trailingPadding = omitTrailingPadding ? '' : protectedPadding;
+                const leadingPadding = omitLeadingPadding || !sideLeadingPadding ? '' : chalk.reset(sideLeadingPadding);
+                const trailingPadding = omitTrailingPadding || !sideTrailingPadding ? '' : chalk.reset(sideTrailingPadding);
                 finalElements.push(leadingPadding + elem.content + trailingPadding);
             } else {
                 // No padding

--- a/src/widgets/__tests__/CurrentWorkingDir.test.ts
+++ b/src/widgets/__tests__/CurrentWorkingDir.test.ts
@@ -39,6 +39,7 @@ describe('CurrentWorkingDirWidget', () => {
         compactThreshold: 60,
         colorLevel: 2,
         defaultPadding: ' ',
+        defaultPaddingSide: 'both',
         inheritSeparatorColors: false,
         globalBold: false,
         gitCacheTtlSeconds: 5,

--- a/src/widgets/__tests__/CustomCommand.test.ts
+++ b/src/widgets/__tests__/CustomCommand.test.ts
@@ -25,6 +25,7 @@ describe('CustomCommandWidget', () => {
         compactThreshold: 60,
         colorLevel: 2,
         defaultPadding: ' ',
+        defaultPaddingSide: 'both',
         inheritSeparatorColors: false,
         globalBold: false,
         gitCacheTtlSeconds: 5,


### PR DESCRIPTION
Closes #482, requested by @riptscripts.

### Summary

The **Default Padding** setting always applied to both the left and
right of each widget. This adds a `defaultPaddingSide` setting
(`both` / `left` / `right`) so padding can be narrowed to one side.

- **Both** (left + right) — current behavior, still the **default**
- **Left only**
- **Right only**

Existing configs are unaffected — `defaultPaddingSide` defaults to
`'both'`, so nothing changes unless you opt in.

### Where it's applied

- Standard (non-Powerline) rendering — `renderStatusLine` in
  `src/utils/renderer.ts`
- Powerline rendering — `renderPowerlineStatusLine` in the same file
- Alignment width accounting — `calculateMaxWidthsFromPreRendered`
  now counts only the side(s) actually applied, so Powerline
  auto-align columns stay correct when padding is one-sided

`merge: 'no-padding'` interactions are preserved: a side that's
already suppressed by a no-padding merge stays suppressed regardless
of the padding-side setting. Covered by regression tests in both
renderers (see Testing below).

### UI

Exposed in the Global Overrides menu (`src/tui/components/GlobalOverridesMenu.tsx`),
next to Default Padding:

```
  Default Padding: " "  - Press (p) to edit
     Padding Side: Both  - Press (d) to cycle
```

Press **(d)** to cycle Both → Left only → Right only → Both. Available
in both standard and Powerline modes, matching how Default Padding
itself is already exposed in both modes.

### Docs

Updated `docs/USAGE.md` (Default Padding & Separators section) to
describe the new option and keybinding.

### Testing

```
bun run lint              # bun tsc --noEmit && eslint . --max-warnings=0 — clean
bun test                  # full suite green once known-flaky Ink timing tests settle
```

Added `src/utils/__tests__/renderer-padding-side.test.ts` covering:
- default (`both`) behavior is unchanged
- `left`/`right` in standard rendering
- `left`/`right` in Powerline rendering
- `calculateMaxWidthsFromPreRendered` width accounting for each side
- `merge: 'no-padding'` takes precedence over the padding-side setting
  (no double-pad, correct glue) in both standard and Powerline mode,
  for both `left` and `right`

All assertions strip SGR codes before comparing (`stripSgrCodes` from
`src/utils/ansi.ts`), per repo convention (see `renderer-flex-width.test.ts`; the
separator-collapse tests strip SGR inline the same way) — `chalk.reset()` reacts to ambient
color-support (`FORCE_COLOR`/`NO_COLOR`), independent of the `colorLevel`
set on `Settings`, so an unstripped exact-string assertion would be
environment-dependent. Verified the new file passing under both
`FORCE_COLOR=1` and `NO_COLOR=1`.

Added a `GlobalOverridesMenu.test.ts` case for the new `(d)` keybinding
(cycles `both → left → right → both`), mirroring the existing `(m)`
minimalist-mode toggle test pattern.

Also updated two pre-existing widget tests
(`CurrentWorkingDir.test.ts`, `CustomCommand.test.ts`) that construct
a full `Settings` object literal rather than spreading
`DEFAULT_SETTINGS` — they needed the new required field added, same
as any other defaulted `Settings` field.

Full-suite runs are noisy independent of this change: a handful of
Ink stdin-timing tests (e.g. `PowerlineThemeSelector`, `InstallMenu`,
occasionally a `GlobalOverridesMenu` gradient-selector case,
`fetchUsageData`'s error-handling timer case) flake under full-suite
parallel load but pass individually. Confirmed by running the full
suite twice on a clean, unmodified `main` checkout (via `git stash`) —
different tests flaked each time, none of them touching padding or
`Settings`. Every test file this PR touches passes consistently in
isolation.

### Notes

No `CURRENT_VERSION`/migration bump needed — `defaultPaddingSide` is
a new field with a Zod `.default('both')`, the same pattern used for
`gitCacheTtlSeconds`, `minimalistMode`, and `excludeFromAutoAlign`
(none of which bumped the version either).

---
🤖 Drafted with [Claude Code](https://claude.com/claude-code); reviewed and submitted by a human.