### PR TITLE
feat(widgets): hide Git widgets when their Jujutsu analog is configured

### DIFF
--- a/src/widgets/GitBranch.ts
+++ b/src/widgets/GitBranch.ts
@@ -21,6 +21,7 @@ import {
 } from '../utils/hyperlink';
 
 import { makeModifierText } from './shared/editor-display';
+import { shouldHideGitWidgetForJj } from './shared/git-jj-precedence';
 import {
     getHideNoGitKeybinds,
     getHideNoGitModifierText,
@@ -102,7 +103,6 @@ export class GitBranchWidget implements Widget {
     }
 
     render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
-        void settings;
         const hideNoGit = isHideNoGitEnabled(item);
         const isLink = isLinkEnabled(item);
         const prefix = formatSymbolPrefix(item, DEFAULT_SYMBOL);
@@ -110,6 +110,10 @@ export class GitBranchWidget implements Widget {
         if (context.isPreview) {
             const text = item.rawValue ? 'main' : `${prefix}main`;
             return isLink ? renderOsc8Link('https://github.com/owner/repo/tree/main', text) : text;
+        }
+
+        if (shouldHideGitWidgetForJj('git-branch', context, settings)) {
+            return null;
         }
 
         if (!isInsideGitWorkTree(context)) {

--- a/src/widgets/GitChanges.ts
+++ b/src/widgets/GitChanges.ts
@@ -11,6 +11,7 @@ import {
     isInsideGitWorkTree
 } from '../utils/git';
 
+import { shouldHideGitWidgetForJj } from './shared/git-jj-precedence';
 import {
     getHideNoGitKeybinds,
     getHideNoGitModifierText,
@@ -34,11 +35,15 @@ export class GitChangesWidget implements Widget {
         return handleToggleNoGitAction(action, item);
     }
 
-    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
         const hideNoGit = isHideNoGitEnabled(item);
 
         if (context.isPreview) {
             return '(+42,-10)';
+        }
+
+        if (shouldHideGitWidgetForJj('git-changes', context, settings)) {
+            return null;
         }
 
         if (!isInsideGitWorkTree(context)) {

--- a/src/widgets/GitDeletions.ts
+++ b/src/widgets/GitDeletions.ts
@@ -11,6 +11,7 @@ import {
     isInsideGitWorkTree
 } from '../utils/git';
 
+import { shouldHideGitWidgetForJj } from './shared/git-jj-precedence';
 import {
     getHideNoGitKeybinds,
     getHideNoGitModifierText,
@@ -34,11 +35,15 @@ export class GitDeletionsWidget implements Widget {
         return handleToggleNoGitAction(action, item);
     }
 
-    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
         const hideNoGit = isHideNoGitEnabled(item);
 
         if (context.isPreview) {
             return '-10';
+        }
+
+        if (shouldHideGitWidgetForJj('git-deletions', context, settings)) {
+            return null;
         }
 
         if (!isInsideGitWorkTree(context)) {

--- a/src/widgets/GitInsertions.ts
+++ b/src/widgets/GitInsertions.ts
@@ -11,6 +11,7 @@ import {
     isInsideGitWorkTree
 } from '../utils/git';
 
+import { shouldHideGitWidgetForJj } from './shared/git-jj-precedence';
 import {
     getHideNoGitKeybinds,
     getHideNoGitModifierText,
@@ -34,11 +35,15 @@ export class GitInsertionsWidget implements Widget {
         return handleToggleNoGitAction(action, item);
     }
 
-    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
         const hideNoGit = isHideNoGitEnabled(item);
 
         if (context.isPreview) {
             return '+42';
+        }
+
+        if (shouldHideGitWidgetForJj('git-insertions', context, settings)) {
+            return null;
         }
 
         if (!isInsideGitWorkTree(context)) {

--- a/src/widgets/GitRootDir.ts
+++ b/src/widgets/GitRootDir.ts
@@ -19,6 +19,7 @@ import {
 } from '../utils/hyperlink';
 
 import { makeModifierText } from './shared/editor-display';
+import { shouldHideGitWidgetForJj } from './shared/git-jj-precedence';
 import {
     getHideNoGitKeybinds,
     getHideNoGitModifierText,
@@ -71,13 +72,17 @@ export class GitRootDirWidget implements Widget {
         return handleToggleNoGitAction(action, item);
     }
 
-    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
         const hideNoGit = isHideNoGitEnabled(item);
         const ideLinkMode = this.getIdeLinkMode(item);
 
         if (context.isPreview) {
             const name = 'my-repo';
             return ideLinkMode ? renderOsc8Link(buildIdeFileUrl('/Users/example/my-repo', ideLinkMode), name) : name;
+        }
+
+        if (shouldHideGitWidgetForJj('git-root-dir', context, settings)) {
+            return null;
         }
 
         if (!isInsideGitWorkTree(context)) {

--- a/src/widgets/GitSha.ts
+++ b/src/widgets/GitSha.ts
@@ -11,6 +11,7 @@ import {
     isInsideGitWorkTree
 } from '../utils/git';
 
+import { shouldHideGitWidgetForJj } from './shared/git-jj-precedence';
 import {
     getHideNoGitKeybinds,
     getHideNoGitModifierText,
@@ -35,11 +36,15 @@ export class GitShaWidget implements Widget {
         return handleToggleNoGitAction(action, item);
     }
 
-    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
         const hideNoGit = isHideNoGitEnabled(item);
 
         if (context.isPreview) {
             return 'a1b2c3d';
+        }
+
+        if (shouldHideGitWidgetForJj('git-sha', context, settings)) {
+            return null;
         }
 
         if (!isInsideGitWorkTree(context)) {

--- a/src/widgets/GitStatus.ts
+++ b/src/widgets/GitStatus.ts
@@ -13,6 +13,7 @@ import {
 } from '../utils/git';
 
 import { makeModifierText } from './shared/editor-display';
+import { shouldHideGitWidgetForJj } from './shared/git-jj-precedence';
 import {
     getHideNoGitKeybinds,
     getHideNoGitModifierText,
@@ -53,11 +54,15 @@ export class GitStatusWidget implements Widget {
         return handleToggleNoGitAction(action, item);
     }
 
-    render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
         const hideNoGit = isHideNoGitEnabled(item);
 
         if (context.isPreview) {
             return this.formatStatus(item, { staged: true, unstaged: true, untracked: false, conflicts: false });
+        }
+
+        if (shouldHideGitWidgetForJj('git-status', context, settings)) {
+            return null;
         }
 
         if (!isInsideGitWorkTree(context)) {

--- a/src/widgets/GitWorktree.ts
+++ b/src/widgets/GitWorktree.ts
@@ -1,4 +1,5 @@
 import type { RenderContext } from '../types/RenderContext';
+import type { Settings } from '../types/Settings';
 import type {
     CustomKeybind,
     Widget,
@@ -11,6 +12,7 @@ import {
     runGit
 } from '../utils/git';
 
+import { shouldHideGitWidgetForJj } from './shared/git-jj-precedence';
 import {
     getHideNoGitKeybinds,
     getHideNoGitModifierText,
@@ -41,12 +43,16 @@ export class GitWorktreeWidget implements Widget {
         return handleToggleNoGitAction(action, item);
     }
 
-    render(item: WidgetItem, context: RenderContext): string | null {
+    render(item: WidgetItem, context: RenderContext, settings: Settings): string | null {
         const hideNoGit = isHideNoGitEnabled(item);
         const prefix = formatSymbolPrefix(item, DEFAULT_SYMBOL);
 
         if (context.isPreview)
             return item.rawValue ? 'main' : `${prefix}main`;
+
+        if (shouldHideGitWidgetForJj('git-worktree', context, settings)) {
+            return null;
+        }
 
         if (!isInsideGitWorkTree(context)) {
             return hideNoGit ? null : `${prefix}no git`;

--- a/src/widgets/__tests__/GitJjPrecedence.test.ts
+++ b/src/widgets/__tests__/GitJjPrecedence.test.ts
@@ -21,6 +21,7 @@ import { GitDeletionsWidget } from '../GitDeletions';
 import { GitInsertionsWidget } from '../GitInsertions';
 import { GitRootDirWidget } from '../GitRootDir';
 import { GitShaWidget } from '../GitSha';
+import { GitStatusWidget } from '../GitStatus';
 import { GitWorktreeWidget } from '../GitWorktree';
 
 vi.mock('child_process', () => ({
@@ -57,6 +58,8 @@ function installExecMock(options: { insideJjRepo: boolean }): void {
                 return '/tmp/my-repo';
             if (args[0] === 'rev-parse' && args[1] === '--git-dir')
                 return '.git';
+            if (args[0] === 'status' && args[1] === '--porcelain')
+                return ' M file.txt\0';
             throw new Error(`unexpected git args: ${args.join(' ')}`);
         }
 
@@ -85,7 +88,8 @@ const cases: {
     { name: 'GitInsertionsWidget', gitType: 'git-insertions', jjType: 'jj-insertions', widget: new GitInsertionsWidget() },
     { name: 'GitDeletionsWidget', gitType: 'git-deletions', jjType: 'jj-deletions', widget: new GitDeletionsWidget() },
     { name: 'GitRootDirWidget', gitType: 'git-root-dir', jjType: 'jj-root-dir', widget: new GitRootDirWidget() },
-    { name: 'GitWorktreeWidget', gitType: 'git-worktree', jjType: 'jj-workspace', widget: new GitWorktreeWidget() }
+    { name: 'GitWorktreeWidget', gitType: 'git-worktree', jjType: 'jj-workspace', widget: new GitWorktreeWidget() },
+    { name: 'GitStatusWidget', gitType: 'git-status', jjType: 'jj-changes', widget: new GitStatusWidget() }
 ];
 
 describe('Git widgets defer to their Jj analog', () => {

--- a/src/widgets/__tests__/GitJjPrecedence.test.ts
+++ b/src/widgets/__tests__/GitJjPrecedence.test.ts
@@ -1,0 +1,131 @@
+import { execFileSync } from 'child_process';
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import type { RenderContext } from '../../types/RenderContext';
+import type { Settings } from '../../types/Settings';
+import { DEFAULT_SETTINGS } from '../../types/Settings';
+import type {
+    Widget,
+    WidgetItem
+} from '../../types/Widget';
+import { clearGitCache } from '../../utils/git';
+import { GitBranchWidget } from '../GitBranch';
+import { GitChangesWidget } from '../GitChanges';
+import { GitDeletionsWidget } from '../GitDeletions';
+import { GitInsertionsWidget } from '../GitInsertions';
+import { GitRootDirWidget } from '../GitRootDir';
+import { GitShaWidget } from '../GitSha';
+import { GitWorktreeWidget } from '../GitWorktree';
+
+vi.mock('child_process', () => ({
+    execSync: vi.fn(),
+    execFileSync: vi.fn(),
+    spawnSync: vi.fn()
+}));
+
+const mockExecFileSync = execFileSync as unknown as { mockImplementation: (impl: (cmd: string, args: string[]) => string) => void };
+
+// Responds to whichever git/jj probe each widget makes so a single mock can
+// drive all 7 widgets without per-widget call-order bookkeeping.
+function installExecMock(options: { insideJjRepo: boolean }): void {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'jj') {
+            if (args[0] === 'root') {
+                if (!options.insideJjRepo)
+                    throw new Error('not a jj repo');
+                return '/tmp/repo\n';
+            }
+            throw new Error(`unexpected jj args: ${args.join(' ')}`);
+        }
+
+        if (cmd === 'git') {
+            if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree')
+                return 'true\n';
+            if (args[0] === 'symbolic-ref' && args[1] === '--short')
+                return 'main';
+            if (args[0] === 'rev-parse' && args[1] === '--short')
+                return 'a1b2c3d';
+            if (args[0] === 'diff' && args[1] === '--stat')
+                return ' file.ts | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)';
+            if (args[0] === 'rev-parse' && args[1] === '--show-toplevel')
+                return '/tmp/my-repo';
+            if (args[0] === 'rev-parse' && args[1] === '--git-dir')
+                return '.git';
+            throw new Error(`unexpected git args: ${args.join(' ')}`);
+        }
+
+        throw new Error(`unexpected command: ${cmd}`);
+    });
+}
+
+function makeSettings(gitItem: WidgetItem, jjItem?: WidgetItem): Settings {
+    return {
+        ...DEFAULT_SETTINGS,
+        lines: [jjItem ? [gitItem, jjItem] : [gitItem]]
+    };
+}
+
+const context: RenderContext = {};
+
+const cases: {
+    gitType: string;
+    jjType: string;
+    name: string;
+    widget: Widget;
+}[] = [
+    { name: 'GitBranchWidget', gitType: 'git-branch', jjType: 'jj-bookmarks', widget: new GitBranchWidget() },
+    { name: 'GitShaWidget', gitType: 'git-sha', jjType: 'jj-revision', widget: new GitShaWidget() },
+    { name: 'GitChangesWidget', gitType: 'git-changes', jjType: 'jj-changes', widget: new GitChangesWidget() },
+    { name: 'GitInsertionsWidget', gitType: 'git-insertions', jjType: 'jj-insertions', widget: new GitInsertionsWidget() },
+    { name: 'GitDeletionsWidget', gitType: 'git-deletions', jjType: 'jj-deletions', widget: new GitDeletionsWidget() },
+    { name: 'GitRootDirWidget', gitType: 'git-root-dir', jjType: 'jj-root-dir', widget: new GitRootDirWidget() },
+    { name: 'GitWorktreeWidget', gitType: 'git-worktree', jjType: 'jj-workspace', widget: new GitWorktreeWidget() }
+];
+
+describe('Git widgets defer to their Jj analog', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        clearGitCache();
+    });
+
+    it.each(cases)('$name renders normally when no Jj analog is configured', ({ gitType, widget }) => {
+        installExecMock({ insideJjRepo: true });
+        const item: WidgetItem = { id: gitType, type: gitType };
+        const settings = makeSettings(item);
+
+        expect(widget.render(item, context, settings)).not.toBeNull();
+    });
+
+    it.each(cases)('$name renders normally when Jj analog is configured but not in a jj repo', ({ gitType, jjType, widget }) => {
+        installExecMock({ insideJjRepo: false });
+        const item: WidgetItem = { id: gitType, type: gitType };
+        const jjItem: WidgetItem = { id: jjType, type: jjType };
+        const settings = makeSettings(item, jjItem);
+
+        expect(widget.render(item, context, settings)).not.toBeNull();
+    });
+
+    it.each(cases)('$name hides once its Jj analog is configured in a jj repo', ({ gitType, jjType, widget }) => {
+        installExecMock({ insideJjRepo: true });
+        const item: WidgetItem = { id: gitType, type: gitType, metadata: { hideNoGit: 'false' } };
+        const jjItem: WidgetItem = { id: jjType, type: jjType };
+        const settings = makeSettings(item, jjItem);
+
+        expect(widget.render(item, context, settings)).toBeNull();
+    });
+
+    it.each(cases)('$name hides even when the Jj analog is on a different configured line', ({ gitType, jjType, widget }) => {
+        installExecMock({ insideJjRepo: true });
+        const item: WidgetItem = { id: gitType, type: gitType };
+        const jjItem: WidgetItem = { id: jjType, type: jjType };
+        const settings: Settings = { ...DEFAULT_SETTINGS, lines: [[item], [jjItem]] };
+
+        expect(widget.render(item, context, settings)).toBeNull();
+    });
+});

--- a/src/widgets/__tests__/GitWorktree.test.ts
+++ b/src/widgets/__tests__/GitWorktree.test.ts
@@ -11,6 +11,7 @@ import type {
     RenderContext,
     WidgetItem
 } from '../../types';
+import { DEFAULT_SETTINGS } from '../../types/Settings';
 import { expectGitExecOptions } from '../../utils/__tests__/git-test-helpers';
 import { clearGitCache } from '../../utils/git';
 import { GitWorktreeWidget } from '../GitWorktree';
@@ -46,7 +47,7 @@ function render(options: {
         metadata: options.hideNoGit ? { hideNoGit: 'true' } : undefined
     };
 
-    return widget.render(item, context);
+    return widget.render(item, context, DEFAULT_SETTINGS);
 }
 
 describe('GitWorktreeWidget', () => {

--- a/src/widgets/shared/git-jj-precedence.ts
+++ b/src/widgets/shared/git-jj-precedence.ts
@@ -2,6 +2,17 @@ import type { RenderContext } from '../../types/RenderContext';
 import type { Settings } from '../../types/Settings';
 import { isInsideJjRepo } from '../../utils/jj';
 
+// Only widgets with a direct 1:1 Jj counterpart are listed here — not every
+// Git widget has one (e.g. git-pr, git-conflicts, git-staged have no jj
+// equivalent). Where a Git widget could plausibly map to more than one Jj
+// widget, the pairing follows what each one actually displays rather than
+// grouping by feature area:
+//   - git-branch <-> jj-bookmarks: both show a named ref.
+//   - git-sha <-> jj-revision: both show a short commit/change identifier,
+//     not a name, so git-sha pairs with jj-revision rather than jj-bookmarks.
+//   - git-status <-> jj-changes: jj has no staged/unstaged distinction (the
+//     working copy is always fully tracked), so there's no 1:1 status
+//     widget; jj-changes is the closest signal for "there's local work here".
 const GIT_TO_JJ_ANALOGS: Record<string, string[]> = {
     'git-branch': ['jj-bookmarks'],
     'git-sha': ['jj-revision'],
@@ -9,7 +20,8 @@ const GIT_TO_JJ_ANALOGS: Record<string, string[]> = {
     'git-insertions': ['jj-insertions'],
     'git-deletions': ['jj-deletions'],
     'git-root-dir': ['jj-root-dir'],
-    'git-worktree': ['jj-workspace']
+    'git-worktree': ['jj-workspace'],
+    'git-status': ['jj-changes']
 };
 
 // A Git widget defers to its Jj counterpart once both are true: the repo is

--- a/src/widgets/shared/git-jj-precedence.ts
+++ b/src/widgets/shared/git-jj-precedence.ts
@@ -1,0 +1,33 @@
+import type { RenderContext } from '../../types/RenderContext';
+import type { Settings } from '../../types/Settings';
+import { isInsideJjRepo } from '../../utils/jj';
+
+const GIT_TO_JJ_ANALOGS: Record<string, string[]> = {
+    'git-branch': ['jj-bookmarks'],
+    'git-sha': ['jj-revision'],
+    'git-changes': ['jj-changes'],
+    'git-insertions': ['jj-insertions'],
+    'git-deletions': ['jj-deletions'],
+    'git-root-dir': ['jj-root-dir'],
+    'git-worktree': ['jj-workspace']
+};
+
+// A Git widget defers to its Jj counterpart once both are true: the repo is
+// actually a jj repo (colocated .git repos otherwise still look like plain
+// git repos to isInsideGitWorkTree), and the user has that Jj widget
+// configured somewhere in their status line, meaning they're relying on it.
+export function shouldHideGitWidgetForJj(
+    gitType: string,
+    context: RenderContext,
+    settings: Settings
+): boolean {
+    const jjTypes = GIT_TO_JJ_ANALOGS[gitType];
+    if (!jjTypes)
+        return false;
+
+    const jjAnalogConfigured = settings.lines.some(line => line.some(item => jjTypes.includes(item.type)));
+    if (!jjAnalogConfigured)
+        return false;
+
+    return isInsideJjRepo(context);
+}


### PR DESCRIPTION
#### Summary

Jujutsu repos are co-located with git repos, but not all of the Git widgets hide when we're in a jj repo. This adds logic to automatically hide a given Git widget when the associated jj widget is enabled and would be displayed given the jj logic. 

The mapping is as follows.


| Git widget | Jujutsu equivalent |
|---|---|
| git-branch | jj-bookmarks |
| git-sha | jj-revision |
| git-changes | jj-changes |
| git-insertions | jj-insertions |
| git-deletions | jj-deletions |
| git-root-dir | jj-root-dir |
| git-worktree | jj-workspace |
| git-status | jj-changes |

No analog (untouched): git-pr, git-conflicts, git-staged.


#### Testing

[Recording of claude going from a git repo to a jj repo](https://asciinema.org/a/1260653)

Config used in demo: 

<img width="2312" height="1544" alt="CleanShot 2026-07-11 at 17 34 07@2x" src="https://github.com/user-attachments/assets/0b487c8f-b761-4c39-9492-ed7415450748" />
