### PR TITLE
Add statuslin.es to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ If ccstatusline is useful to you, consider buying me a coffee:
 - [codachi](https://github.com/vincent-k2026/codachi) - A tamagotchi-style statusline pet that grows with your context window.
 - [AIWatch](https://ai-watch.dev) - Live status monitor for 30+ AI APIs and apps; pairs with a Custom Command widget to surface provider outages in your status line.
 - [crispy-recall](https://github.com/TheSylvester/crispy-recall) - Searchable memory for your Claude Code and Codex sessions. Local, fast, no daemon.
+- [statuslin.es](https://statuslin.es) - Community gallery of Claude Code status lines with live, sandbox-rendered previews.
 
 ## 🙏 Acknowledgments
 


### PR DESCRIPTION
statuslin.es is a gallery of Claude Code status lines rendered in a sandbox so previews show real output (there's a Powerline section too). Since ccstatusline is how a lot of people build theirs, I figured its users might like somewhere to browse what others have made and share their own.