### PR TITLE
fix: read per-model weekly usage from limits[]; derive wiring from a single registry

### DIFF
--- a/src/types/StatusJSON.ts
+++ b/src/types/StatusJSON.ts
@@ -19,6 +19,8 @@ const RateLimitPeriodSchema = z.object({
     resets_at: CoercedNumberSchema.nullable().optional() // Unix epoch seconds
 });
 
+export type RateLimitPeriod = z.infer<typeof RateLimitPeriodSchema>;
+
 export const StatusJSONSchema = z.looseObject({
     hook_event_name: z.string().optional(),
     session_id: z.string().optional(),

--- a/src/utils/__tests__/usage-fetch.test.ts
+++ b/src/utils/__tests__/usage-fetch.test.ts
@@ -11,6 +11,9 @@ import {
     it
 } from 'vitest';
 
+import { __testing } from '../usage-fetch';
+import { WEEKLY_MODEL_USAGE_BUCKETS } from '../usage-types';
+
 const require = createRequire(import.meta.url);
 const { execFileSync: realExecFileSync } = require('node:child_process') as { execFileSync: typeof childProcess.execFileSync };
 
@@ -1253,6 +1256,57 @@ describe('fetchUsageData error handling', () => {
             expect(result.requestCount).toBe(0);
         } finally {
             harness.cleanup();
+        }
+    });
+});
+
+// Guards the exact failure mode described in the code review that motivated
+// WEEKLY_MODEL_USAGE_BUCKETS (usage-types.ts): CachedUsageDataSchema and
+// UsageApiResponseSchema are hand-declared (see the comments on them in
+// usage-fetch.ts for why they can't just be generated from the registry) and
+// therefore CAN drift from it silently -- a field present in one schema but
+// missing from the other would parse fine from a live API fetch, then vanish
+// the moment that response round-trips through the on-disk cache. This test
+// makes that drift fail loudly instead.
+describe('WEEKLY_MODEL_USAGE_BUCKETS schema parity', () => {
+    it('declares every registry bucket field in CachedUsageDataSchema', () => {
+        const cachedKeys = new Set(Object.keys(__testing.CachedUsageDataSchema.shape));
+
+        for (const bucket of WEEKLY_MODEL_USAGE_BUCKETS) {
+            expect(cachedKeys.has(bucket.usageField), `CachedUsageDataSchema is missing "${bucket.usageField}"`).toBe(true);
+            expect(cachedKeys.has(bucket.resetField), `CachedUsageDataSchema is missing "${bucket.resetField}"`).toBe(true);
+        }
+    });
+
+    it('declares every registry bucket\'s API key in UsageApiResponseSchema', () => {
+        const apiKeys = new Set(Object.keys(__testing.UsageApiResponseSchema.shape));
+
+        for (const bucket of WEEKLY_MODEL_USAGE_BUCKETS) {
+            expect(apiKeys.has(bucket.apiBucketKey), `UsageApiResponseSchema is missing "${bucket.apiBucketKey}"`).toBe(true);
+        }
+    });
+
+    it('round-trips every registry bucket through an API fetch and a cache read', () => {
+        const apiResponse: Record<string, unknown> = {
+            five_hour: { utilization: 10, resets_at: '2026-01-01T00:00:00Z' },
+            seven_day: { utilization: 20, resets_at: '2026-01-08T00:00:00Z' }
+        };
+        for (const [index, bucket] of WEEKLY_MODEL_USAGE_BUCKETS.entries()) {
+            apiResponse[bucket.apiBucketKey] = { utilization: 30 + index, resets_at: `2026-01-0${index + 1}T00:00:00Z` };
+        }
+
+        const fromApi = __testing.UsageApiResponseSchema.parse(apiResponse);
+        const cachePayload: Record<string, unknown> = {};
+        for (const bucket of WEEKLY_MODEL_USAGE_BUCKETS) {
+            const apiBucket = fromApi[bucket.apiBucketKey] as { utilization?: number; resets_at?: string } | null | undefined;
+            cachePayload[bucket.usageField] = apiBucket?.utilization;
+            cachePayload[bucket.resetField] = apiBucket?.resets_at;
+        }
+
+        const fromCache = __testing.CachedUsageDataSchema.parse(cachePayload);
+
+        for (const [index, bucket] of WEEKLY_MODEL_USAGE_BUCKETS.entries()) {
+            expect(fromCache[bucket.usageField], `"${bucket.usageField}" did not survive the cache round-trip`).toBe(30 + index);
         }
     });
 });

--- a/src/utils/__tests__/usage-fetch.test.ts
+++ b/src/utils/__tests__/usage-fetch.test.ts
@@ -1309,4 +1309,80 @@ describe('WEEKLY_MODEL_USAGE_BUCKETS schema parity', () => {
             expect(fromCache[bucket.usageField], `"${bucket.usageField}" did not survive the cache round-trip`).toBe(30 + index);
         }
     });
+
+    it('prefers a weekly_scoped limits[] entry over the legacy flat bucket for the same model', () => {
+        // Shape captured from a live /api/oauth/usage response (2026-07):
+        // the legacy seven_day_sonnet/seven_day_opus keys return null even
+        // when the model has real usage; the real number is in limits[].
+        const sonnetBucket = WEEKLY_MODEL_USAGE_BUCKETS.find(bucket => bucket.modelDisplayName === 'Sonnet');
+        if (!sonnetBucket) {
+            throw new Error('expected a Sonnet entry in WEEKLY_MODEL_USAGE_BUCKETS for this test');
+        }
+
+        const parsed = __testing.parseUsageApiResponse(JSON.stringify({
+            five_hour: { utilization: 48, resets_at: '2026-07-17T13:50:00Z' },
+            seven_day: { utilization: 18, resets_at: '2026-07-23T04:00:00Z' },
+            seven_day_sonnet: null,
+            seven_day_opus: null,
+            limits: [
+                { kind: 'session', percent: 48, resets_at: '2026-07-17T13:50:00Z', scope: null },
+                { kind: 'weekly_all', percent: 18, resets_at: '2026-07-23T04:00:00Z', scope: null },
+                { kind: 'weekly_scoped', percent: 3, resets_at: '2026-07-23T04:00:00Z', scope: { model: { display_name: 'Sonnet' } } }
+            ]
+        }));
+
+        expect(parsed?.[sonnetBucket.usageField]).toBe(3);
+        expect(parsed?.[sonnetBucket.resetField]).toBe('2026-07-23T04:00:00Z');
+    });
+
+    it('falls back to the legacy flat bucket when a model has no weekly_scoped limits[] entry', () => {
+        const opusBucket = WEEKLY_MODEL_USAGE_BUCKETS.find(bucket => bucket.modelDisplayName === 'Opus');
+        if (!opusBucket) {
+            throw new Error('expected an Opus entry in WEEKLY_MODEL_USAGE_BUCKETS for this test');
+        }
+
+        const parsed = __testing.parseUsageApiResponse(JSON.stringify({
+            five_hour: { utilization: 48, resets_at: '2026-07-17T13:50:00Z' },
+            seven_day: { utilization: 18, resets_at: '2026-07-23T04:00:00Z' },
+            seven_day_opus: { utilization: 42, resets_at: '2026-07-23T04:00:00Z' },
+            limits: [
+                { kind: 'weekly_scoped', percent: 3, resets_at: '2026-07-23T04:00:00Z', scope: { model: { display_name: 'Sonnet' } } }
+            ]
+        }));
+
+        expect(parsed?.[opusBucket.usageField]).toBe(42);
+        expect(parsed?.[opusBucket.resetField]).toBe('2026-07-23T04:00:00Z');
+    });
+
+    it('handles a real live-captured response (Fable-only limits[], no matching Sonnet/Opus entry) without erroring', () => {
+        // Exact shape of a live response where only Fable has a weekly_scoped
+        // entry. Sonnet/Opus have no limits[] entry, so they fall back to
+        // their (explicitly null) legacy bucket -- 0%, per the pre-existing
+        // #343 "null bucket -> 0 usage" convention preserved by that fallback.
+        const parsed = __testing.parseUsageApiResponse(JSON.stringify({
+            five_hour: { utilization: 48, resets_at: '2026-07-17T13:50:00.885205+00:00' },
+            seven_day: { utilization: 18, resets_at: '2026-07-23T04:00:00.885227+00:00' },
+            seven_day_opus: null,
+            seven_day_sonnet: null,
+            limits: [
+                { kind: 'session', group: 'session', percent: 48, resets_at: '2026-07-17T13:50:00.885205+00:00', scope: null, is_active: true },
+                { kind: 'weekly_all', group: 'weekly', percent: 18, resets_at: '2026-07-23T04:00:00.885227+00:00', scope: null, is_active: false },
+                {
+                    kind: 'weekly_scoped',
+                    group: 'weekly',
+                    percent: 3,
+                    resets_at: '2026-07-23T04:00:00.885562+00:00',
+                    scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+                    is_active: false
+                }
+            ],
+            extra_usage: { is_enabled: false }
+        }));
+
+        expect(parsed?.sessionUsage).toBe(48);
+        expect(parsed?.weeklyUsage).toBe(18);
+        for (const bucket of WEEKLY_MODEL_USAGE_BUCKETS) {
+            expect(parsed?.[bucket.usageField], `expected ${bucket.usageField} to fall back to the legacy null-bucket -> 0 convention`).toBe(0);
+        }
+    });
 });

--- a/src/utils/usage-fetch.ts
+++ b/src/utils/usage-fetch.ts
@@ -15,7 +15,8 @@ import type {
 } from './usage-types';
 import {
     UsageErrorSchema,
-    WEEKLY_MODEL_USAGE_BUCKETS
+    WEEKLY_MODEL_USAGE_BUCKETS,
+    setUsageField
 } from './usage-types';
 
 // Cache configuration
@@ -89,13 +90,27 @@ const UsageApiBucketSchema = z.looseObject({
 
 type UsageApiBucket = z.infer<typeof UsageApiBucketSchema>;
 
-// See the comment on CachedUsageDataSchema above re: why these per-model keys
-// are hand-declared rather than generated from WEEKLY_MODEL_USAGE_BUCKETS.
+// Per-model weekly usage now arrives as an entry in this array (kind:
+// "weekly_scoped", scope.model.display_name identifying the model) rather
+// than as a flat seven_day_<model> bucket -- see the comment on
+// WeeklyModelUsageBucket in usage-types.ts.
+const UsageLimitEntrySchema = z.looseObject({
+    kind: z.string().nullable().optional(),
+    percent: z.number().nullable().optional(),
+    resets_at: z.string().nullable().optional(),
+    scope: z.looseObject({ model: z.looseObject({ display_name: z.string().nullable().optional() }).nullable().optional() }).nullable().optional()
+});
+
+type UsageLimitEntry = z.infer<typeof UsageLimitEntrySchema>;
+
+// See the comment on CachedUsageDataSchema above re: why the legacy per-model
+// keys are hand-declared rather than generated from WEEKLY_MODEL_USAGE_BUCKETS.
 const UsageApiResponseSchema = z.looseObject({
     five_hour: UsageApiBucketSchema,
     seven_day: UsageApiBucketSchema,
     seven_day_sonnet: UsageApiBucketSchema,
     seven_day_opus: UsageApiBucketSchema,
+    limits: z.array(UsageLimitEntrySchema).nullable().optional(),
     extra_usage: z.looseObject({
         is_enabled: z.boolean().nullable().optional(),
         monthly_limit: z.number().nullable().optional(),
@@ -106,14 +121,25 @@ const UsageApiResponseSchema = z.looseObject({
 });
 
 // Exposed only so usage-fetch.test.ts can assert schema/registry parity (see
-// the comment on CachedUsageDataSchema above) without duplicating the shapes.
+// the comment on CachedUsageDataSchema above) and the limits[]-vs-legacy-field
+// precedence (see parseUsageApiResponse) without duplicating the shapes/logic.
 export const __testing = {
     CachedUsageDataSchema,
-    UsageApiResponseSchema
+    UsageApiResponseSchema,
+    parseUsageApiResponse
 };
 
 function getUsageApiBucketUtilization(bucket: UsageApiBucket): number | undefined {
     return bucket === null ? 0 : bucket?.utilization ?? undefined;
+}
+
+// Finds this model's weekly quota in the new limits[] array. Returns
+// undefined (not 0) when absent -- unlike a legacy `null` flat bucket, "no
+// weekly_scoped entry for this model" isn't a documented "0% used" signal, so
+// treating it as unset (and falling back to the legacy field, see below) is
+// the safer read.
+function findWeeklyScopedLimit(limits: UsageLimitEntry[] | null | undefined, modelDisplayName: string): UsageLimitEntry | undefined {
+    return limits?.find(limit => limit.kind === 'weekly_scoped' && limit.scope?.model?.display_name === modelDisplayName) ?? undefined;
 }
 
 function parseJsonWithSchema<T>(rawJson: string, schema: z.ZodType<T>): T | null {
@@ -177,27 +203,50 @@ function tokenHashMatches(cachedHash: string | undefined, currentHash: string | 
     return cachedHash === currentHash;
 }
 
+// parsed is a UsageApiResponseSchema-derived looseObject: declared keys (like
+// the legacy seven_day_sonnet/seven_day_opus fallback below) keep their exact
+// types, but looseObject's passthrough means indexing by a dynamic string
+// (bucket.apiBucketKey) only has `unknown` to offer TS -- hence the cast,
+// scoped to this one lookup rather than to the whole parsed object.
+function getLegacyUsageApiBucket(parsed: Record<string, unknown>, apiBucketKey: string): UsageApiBucket {
+    return parsed[apiBucketKey] as UsageApiBucket;
+}
+
 function parseUsageApiResponse(rawJson: string): UsageData | null {
     const parsed = parseJsonWithSchema(rawJson, UsageApiResponseSchema);
     if (!parsed) {
         return null;
     }
 
-    return {
+    const result: UsageData = {
         sessionUsage: getUsageApiBucketUtilization(parsed.five_hour),
         sessionResetAt: parsed.five_hour?.resets_at ?? undefined,
         weeklyUsage: getUsageApiBucketUtilization(parsed.seven_day),
         weeklyResetAt: parsed.seven_day?.resets_at ?? undefined,
-        weeklySonnetUsage: getUsageApiBucketUtilization(parsed.seven_day_sonnet),
-        weeklySonnetResetAt: parsed.seven_day_sonnet?.resets_at ?? undefined,
-        weeklyOpusUsage: getUsageApiBucketUtilization(parsed.seven_day_opus),
-        weeklyOpusResetAt: parsed.seven_day_opus?.resets_at ?? undefined,
         extraUsageEnabled: parsed.extra_usage?.is_enabled ?? undefined,
         extraUsageLimit: parsed.extra_usage?.monthly_limit ?? undefined,
         extraUsageUsed: parsed.extra_usage?.used_credits ?? undefined,
         extraUsageUtilization: parsed.extra_usage?.utilization ?? undefined,
         extraUsageCurrency: parsed.extra_usage?.currency ?? undefined
     };
+
+    for (const bucket of WEEKLY_MODEL_USAGE_BUCKETS) {
+        const scopedLimit = findWeeklyScopedLimit(parsed.limits, bucket.modelDisplayName);
+        const scopedPercent = scopedLimit?.percent ?? undefined;
+        if (scopedPercent !== undefined) {
+            setUsageField(result, bucket.usageField, scopedPercent);
+            setUsageField(result, bucket.resetField, scopedLimit?.resets_at ?? undefined);
+            continue;
+        }
+
+        // Fallback for API responses (or code paths) that still populate the
+        // legacy flat bucket instead of limits[].
+        const legacyBucket = getLegacyUsageApiBucket(parsed, bucket.apiBucketKey);
+        setUsageField(result, bucket.usageField, getUsageApiBucketUtilization(legacyBucket));
+        setUsageField(result, bucket.resetField, legacyBucket?.resets_at ?? undefined);
+    }
+
+    return result;
 }
 
 // Memory caches

--- a/src/utils/usage-fetch.ts
+++ b/src/utils/usage-fetch.ts
@@ -10,9 +10,13 @@ import { z } from 'zod';
 import { getClaudeConfigDir } from './claude-settings';
 import type {
     UsageData,
+    UsageDataField,
     UsageError
 } from './usage-types';
-import { UsageErrorSchema } from './usage-types';
+import {
+    UsageErrorSchema,
+    WEEKLY_MODEL_USAGE_BUCKETS
+} from './usage-types';
 
 // Cache configuration
 const CACHE_DIR = path.join(os.homedir(), '.cache', 'ccstatusline');
@@ -23,8 +27,6 @@ const LOCK_MAX_AGE = 30;   // rate limit: only try API once per 30 seconds
 const DEFAULT_RATE_LIMIT_BACKOFF = 300; // seconds
 const MACOS_USAGE_CREDENTIALS_SERVICE = 'Claude Code-credentials';
 const MACOS_SECURITY_DUMP_MAX_BUFFER = 8 * 1024 * 1024;
-
-type UsageDataField = Exclude<keyof UsageData, 'error'>;
 
 export interface FetchUsageDataOptions { requiredFields?: readonly UsageDataField[] }
 
@@ -38,11 +40,13 @@ const EXTRA_USAGE_DETAIL_FIELDS = new Set<UsageDataField>([
 // API bucket. A null bucket (Enterprise accounts have no rate-limit windows,
 // #343) parses to utilization 0 with no resets_at, so once the utilization is
 // cached the missing timestamp is conclusive and refetching cannot produce it.
+// The per-model entries are derived from WEEKLY_MODEL_USAGE_BUCKETS (see
+// usage-types.ts) instead of hand-listed, so this can't drift from the schemas
+// below when a model bucket is added or renamed.
 const WINDOW_RESET_FIELD_SENTINELS: Partial<Record<UsageDataField, UsageDataField>> = {
     sessionResetAt: 'sessionUsage',
     weeklyResetAt: 'weeklyUsage',
-    weeklySonnetResetAt: 'weeklySonnetUsage',
-    weeklyOpusResetAt: 'weeklyOpusUsage'
+    ...Object.fromEntries(WEEKLY_MODEL_USAGE_BUCKETS.map(bucket => [bucket.resetField, bucket.usageField]))
 };
 
 const UsageCredentialsSchema = z.object({ claudeAiOauth: z.object({ accessToken: z.string().nullable().optional() }).optional() });
@@ -52,6 +56,13 @@ const UsageLockSchema = z.object({
     error: UsageLockErrorSchema.optional()
 });
 
+// The per-model fields (weeklySonnetUsage, weeklyOpusUsage, ...) are declared
+// by hand here and in UsageApiResponseSchema below because Zod object shapes
+// need statically-known keys to keep field-level type inference for the
+// parse* functions further down. usage-fetch.test.ts's schema-parity test
+// asserts both schemas cover every WEEKLY_MODEL_USAGE_BUCKETS entry, so a
+// bucket added to one but not the other fails a test instead of silently
+// dropping data after a cache round-trip.
 const CachedUsageDataSchema = z.object({
     sessionUsage: z.number().nullable().optional(),
     sessionResetAt: z.string().nullable().optional(),
@@ -78,6 +89,8 @@ const UsageApiBucketSchema = z.looseObject({
 
 type UsageApiBucket = z.infer<typeof UsageApiBucketSchema>;
 
+// See the comment on CachedUsageDataSchema above re: why these per-model keys
+// are hand-declared rather than generated from WEEKLY_MODEL_USAGE_BUCKETS.
 const UsageApiResponseSchema = z.looseObject({
     five_hour: UsageApiBucketSchema,
     seven_day: UsageApiBucketSchema,
@@ -91,6 +104,13 @@ const UsageApiResponseSchema = z.looseObject({
         currency: z.string().nullable().optional()
     }).nullable().optional()
 });
+
+// Exposed only so usage-fetch.test.ts can assert schema/registry parity (see
+// the comment on CachedUsageDataSchema above) without duplicating the shapes.
+export const __testing = {
+    CachedUsageDataSchema,
+    UsageApiResponseSchema
+};
 
 function getUsageApiBucketUtilization(bucket: UsageApiBucket): number | undefined {
     return bucket === null ? 0 : bucket?.utilization ?? undefined;

--- a/src/utils/usage-prefetch.ts
+++ b/src/utils/usage-prefetch.ts
@@ -1,22 +1,31 @@
-import type { StatusJSON } from '../types/StatusJSON';
+import type {
+    RateLimitPeriod,
+    StatusJSON
+} from '../types/StatusJSON';
 import type { WidgetItem } from '../types/Widget';
 
 import type { UsageData } from './usage';
 import { fetchUsageData } from './usage';
+import type { UsageDataField } from './usage-types';
+import { WEEKLY_MODEL_USAGE_BUCKETS } from './usage-types';
 
-type UsageDataField = Exclude<keyof UsageData, 'error'>;
-
-const USAGE_WIDGET_TYPES = new Set<string>([
+// Non-model usage widgets/fields. The per-model ones (weekly-sonnet-usage,
+// weekly-opus-usage, ...) are derived below from WEEKLY_MODEL_USAGE_BUCKETS so
+// that adding a model bucket can't desync one of these tables from the others.
+const BASE_USAGE_WIDGET_TYPES = [
     'session-usage',
     'weekly-usage',
-    'weekly-sonnet-usage',
-    'weekly-opus-usage',
     'block-timer',
     'reset-timer',
     'weekly-reset-timer',
     'extra-usage-utilization',
     'extra-usage-remaining',
     'extra-usage-used'
+];
+
+const USAGE_WIDGET_TYPES = new Set<string>([
+    ...BASE_USAGE_WIDGET_TYPES,
+    ...WEEKLY_MODEL_USAGE_BUCKETS.map(bucket => bucket.widgetType)
 ]);
 
 const USAGE_DATA_FIELDS: UsageDataField[] = [
@@ -24,10 +33,7 @@ const USAGE_DATA_FIELDS: UsageDataField[] = [
     'sessionResetAt',
     'weeklyUsage',
     'weeklyResetAt',
-    'weeklySonnetUsage',
-    'weeklySonnetResetAt',
-    'weeklyOpusUsage',
-    'weeklyOpusResetAt',
+    ...WEEKLY_MODEL_USAGE_BUCKETS.flatMap(bucket => [bucket.usageField, bucket.resetField]),
     'extraUsageEnabled',
     'extraUsageLimit',
     'extraUsageUsed',
@@ -46,8 +52,7 @@ const EMPTY_USAGE_REQUIREMENTS: UsageFieldRequirement[] = [];
 const USAGE_WIDGET_REQUIREMENTS: Record<string, UsageFieldRequirement[]> = {
     'session-usage': [{ field: 'sessionUsage' }],
     'weekly-usage': [{ field: 'weeklyUsage' }],
-    'weekly-sonnet-usage': [{ field: 'weeklySonnetUsage' }],
-    'weekly-opus-usage': [{ field: 'weeklyOpusUsage' }],
+    ...Object.fromEntries(WEEKLY_MODEL_USAGE_BUCKETS.map(bucket => [bucket.widgetType, [{ field: bucket.usageField }]])),
     'block-timer': [{ field: 'sessionResetAt', suppressFetchError: true }],
     'reset-timer': [{ field: 'sessionResetAt', suppressFetchError: true }],
     'weekly-reset-timer': [{ field: 'weeklyResetAt', suppressFetchError: true }],
@@ -69,8 +74,7 @@ const USAGE_WIDGET_REQUIREMENTS: Record<string, UsageFieldRequirement[]> = {
 const USAGE_CURSOR_REQUIREMENTS: Record<string, UsageFieldRequirement> = {
     'session-usage': { field: 'sessionResetAt' },
     'weekly-usage': { field: 'weeklyResetAt' },
-    'weekly-sonnet-usage': { field: 'weeklySonnetResetAt', alternatives: ['weeklyResetAt'] },
-    'weekly-opus-usage': { field: 'weeklyOpusResetAt', alternatives: ['weeklyResetAt'] }
+    ...Object.fromEntries(WEEKLY_MODEL_USAGE_BUCKETS.map(bucket => [bucket.widgetType, { field: bucket.resetField, alternatives: ['weeklyResetAt'] }]))
 };
 
 export function hasUsageDependentWidgets(lines: WidgetItem[][]): boolean {
@@ -136,22 +140,25 @@ function hasAnyUsageDataField(data: UsageData | null | undefined): boolean {
     return USAGE_DATA_FIELDS.some(field => data?.[field] !== undefined);
 }
 
+// TypeScript can't narrow `target[field] = value` when `field` is a plain
+// `UsageDataField` union at the call site (it can't prove `value`'s type
+// matches whichever member of the union `field` happens to be), but it can
+// when both are tied to the same generic `K` here.
+function setUsageField<K extends UsageDataField>(target: Partial<UsageData>, field: K, value: UsageData[K]): void {
+    target[field] = value;
+}
+
 function pickDefinedUsageFields(data: UsageData | null | undefined): Partial<UsageData> {
-    return {
-        ...(data?.sessionUsage !== undefined ? { sessionUsage: data.sessionUsage } : {}),
-        ...(data?.sessionResetAt !== undefined ? { sessionResetAt: data.sessionResetAt } : {}),
-        ...(data?.weeklyUsage !== undefined ? { weeklyUsage: data.weeklyUsage } : {}),
-        ...(data?.weeklyResetAt !== undefined ? { weeklyResetAt: data.weeklyResetAt } : {}),
-        ...(data?.weeklySonnetUsage !== undefined ? { weeklySonnetUsage: data.weeklySonnetUsage } : {}),
-        ...(data?.weeklySonnetResetAt !== undefined ? { weeklySonnetResetAt: data.weeklySonnetResetAt } : {}),
-        ...(data?.weeklyOpusUsage !== undefined ? { weeklyOpusUsage: data.weeklyOpusUsage } : {}),
-        ...(data?.weeklyOpusResetAt !== undefined ? { weeklyOpusResetAt: data.weeklyOpusResetAt } : {}),
-        ...(data?.extraUsageEnabled !== undefined ? { extraUsageEnabled: data.extraUsageEnabled } : {}),
-        ...(data?.extraUsageLimit !== undefined ? { extraUsageLimit: data.extraUsageLimit } : {}),
-        ...(data?.extraUsageUsed !== undefined ? { extraUsageUsed: data.extraUsageUsed } : {}),
-        ...(data?.extraUsageUtilization !== undefined ? { extraUsageUtilization: data.extraUsageUtilization } : {}),
-        ...(data?.extraUsageCurrency !== undefined ? { extraUsageCurrency: data.extraUsageCurrency } : {})
-    };
+    const picked: Partial<UsageData> = {};
+
+    for (const field of USAGE_DATA_FIELDS) {
+        const value = data?.[field];
+        if (value !== undefined) {
+            setUsageField(picked, field, value);
+        }
+    }
+
+    return picked;
 }
 
 function mergeUsageData(rateLimitsData: UsageData | null, apiData: UsageData): UsageData {
@@ -169,32 +176,38 @@ function epochSecondsToIsoString(epochSeconds: number | null | undefined): strin
     return new Date(epochSeconds * 1000).toISOString();
 }
 
+// A null bucket (Enterprise accounts have no per-model rate-limit windows,
+// mirroring the #343 handling for the overall windows) parses to 0 usage with
+// no resets_at, distinct from "the key was absent" (undefined -> unset).
+function getRateLimitBucketUsage(bucket: RateLimitPeriod | null | undefined): number | undefined {
+    return bucket === null ? 0 : bucket?.used_percentage ?? undefined;
+}
+
 export function extractUsageDataFromRateLimits(rateLimits: StatusJSON['rate_limits']): UsageData | null {
     if (!rateLimits) {
         return null;
     }
 
-    const sessionUsage = rateLimits.five_hour?.used_percentage ?? undefined;
-    const sessionResetAt = epochSecondsToIsoString(rateLimits.five_hour?.resets_at);
-    const weeklyUsage = rateLimits.seven_day?.used_percentage ?? undefined;
-    const weeklyResetAt = epochSecondsToIsoString(rateLimits.seven_day?.resets_at);
-    const weeklySonnetUsage = rateLimits.seven_day_sonnet === null ? 0 : rateLimits.seven_day_sonnet?.used_percentage ?? undefined;
-    const weeklySonnetResetAt = epochSecondsToIsoString(rateLimits.seven_day_sonnet?.resets_at);
-    const weeklyOpusUsage = rateLimits.seven_day_opus === null ? 0 : rateLimits.seven_day_opus?.used_percentage ?? undefined;
-    const weeklyOpusResetAt = epochSecondsToIsoString(rateLimits.seven_day_opus?.resets_at);
+    // rate_limits is keyed by fixed, schema-declared bucket names (five_hour,
+    // seven_day, seven_day_sonnet, ...); WEEKLY_MODEL_USAGE_BUCKETS.apiBucketKey
+    // values are those same names, kept in sync via the schema-parity test in
+    // usage-fetch.test.ts, so this lookup is safe despite the untyped index.
+    const rateLimitBuckets = rateLimits as unknown as Record<string, RateLimitPeriod | null | undefined>;
 
-    // Note: rate_limits does not include extra_usage data (extraUsageEnabled, etc.).
-    // Those fields are only available via the API fetch path.
     const usageData: UsageData = {
-        sessionUsage,
-        sessionResetAt,
-        weeklyUsage,
-        weeklyResetAt,
-        weeklySonnetUsage,
-        weeklySonnetResetAt,
-        weeklyOpusUsage,
-        weeklyOpusResetAt
+        sessionUsage: rateLimits.five_hour?.used_percentage ?? undefined,
+        sessionResetAt: epochSecondsToIsoString(rateLimits.five_hour?.resets_at),
+        weeklyUsage: rateLimits.seven_day?.used_percentage ?? undefined,
+        weeklyResetAt: epochSecondsToIsoString(rateLimits.seven_day?.resets_at)
+        // Note: rate_limits does not include extra_usage data (extraUsageEnabled, etc.).
+        // Those fields are only available via the API fetch path.
     };
+
+    for (const bucket of WEEKLY_MODEL_USAGE_BUCKETS) {
+        const rateLimitBucket = rateLimitBuckets[bucket.apiBucketKey];
+        setUsageField(usageData, bucket.usageField, getRateLimitBucketUsage(rateLimitBucket));
+        setUsageField(usageData, bucket.resetField, epochSecondsToIsoString(rateLimitBucket?.resets_at));
+    }
 
     return hasAnyUsageDataField(usageData) ? usageData : null;
 }

--- a/src/utils/usage-types.ts
+++ b/src/utils/usage-types.ts
@@ -33,6 +33,15 @@ export interface UsageWindowMetrics {
 
 export type UsageDataField = Exclude<keyof UsageData, 'error'>;
 
+// TypeScript can't narrow `target[field] = value` when `field` is a plain
+// UsageDataField union at the call site (it can't prove `value`'s type
+// matches whichever union member `field` happens to be), but it can when both
+// are tied to the same generic `K` here. Shared because both usage-fetch.ts
+// and usage-prefetch.ts need to assign UsageData fields by a dynamic key.
+export function setUsageField<K extends UsageDataField>(target: Partial<UsageData>, field: K, value: UsageData[K]): void {
+    target[field] = value;
+}
+
 // Single source of truth for the per-model weekly usage buckets (Sonnet, Opus,
 // ...). Every place that used to hand-list "sonnet, then opus" (the widget
 // registry, the API/cache schemas, the rate-limits extractor) now derives from
@@ -40,12 +49,20 @@ export type UsageDataField = Exclude<keyof UsageData, 'error'>;
 // those spots from the others.
 export interface WeeklyModelUsageBucket {
     widgetType: string;
-    apiBucketKey: string; // key in both the /api/oauth/usage response and the rate_limits hook payload, e.g. "seven_day_sonnet"
+    // As of 2026-07, /api/oauth/usage reports per-model weekly usage as an
+    // entry in its `limits` array (kind: "weekly_scoped", matched by
+    // scope.model.display_name), not as a flat bucket -- the older
+    // seven_day_sonnet/seven_day_opus-style flat keys were observed returning
+    // null even for models with real usage. modelDisplayName drives that
+    // limits[] lookup; apiBucketKey is kept only as a fallback for API
+    // responses (or stale caches) that still populate the flat key.
+    modelDisplayName: string; // e.g. "Sonnet", "Opus", matched against limits[].scope.model.display_name
+    apiBucketKey: string; // legacy flat key, e.g. "seven_day_sonnet" -- see modelDisplayName above
     usageField: UsageDataField;
     resetField: UsageDataField;
 }
 
 export const WEEKLY_MODEL_USAGE_BUCKETS: readonly WeeklyModelUsageBucket[] = [
-    { widgetType: 'weekly-sonnet-usage', apiBucketKey: 'seven_day_sonnet', usageField: 'weeklySonnetUsage', resetField: 'weeklySonnetResetAt' },
-    { widgetType: 'weekly-opus-usage', apiBucketKey: 'seven_day_opus', usageField: 'weeklyOpusUsage', resetField: 'weeklyOpusResetAt' }
+    { widgetType: 'weekly-sonnet-usage', modelDisplayName: 'Sonnet', apiBucketKey: 'seven_day_sonnet', usageField: 'weeklySonnetUsage', resetField: 'weeklySonnetResetAt' },
+    { widgetType: 'weekly-opus-usage', modelDisplayName: 'Opus', apiBucketKey: 'seven_day_opus', usageField: 'weeklyOpusUsage', resetField: 'weeklyOpusResetAt' }
 ];

--- a/src/utils/usage-types.ts
+++ b/src/utils/usage-types.ts
@@ -30,3 +30,22 @@ export interface UsageWindowMetrics {
     elapsedPercent: number;
     remainingPercent: number;
 }
+
+export type UsageDataField = Exclude<keyof UsageData, 'error'>;
+
+// Single source of truth for the per-model weekly usage buckets (Sonnet, Opus,
+// ...). Every place that used to hand-list "sonnet, then opus" (the widget
+// registry, the API/cache schemas, the rate-limits extractor) now derives from
+// this array instead, so adding or renaming a model bucket can't desync one of
+// those spots from the others.
+export interface WeeklyModelUsageBucket {
+    widgetType: string;
+    apiBucketKey: string; // key in both the /api/oauth/usage response and the rate_limits hook payload, e.g. "seven_day_sonnet"
+    usageField: UsageDataField;
+    resetField: UsageDataField;
+}
+
+export const WEEKLY_MODEL_USAGE_BUCKETS: readonly WeeklyModelUsageBucket[] = [
+    { widgetType: 'weekly-sonnet-usage', apiBucketKey: 'seven_day_sonnet', usageField: 'weeklySonnetUsage', resetField: 'weeklySonnetResetAt' },
+    { widgetType: 'weekly-opus-usage', apiBucketKey: 'seven_day_opus', usageField: 'weeklyOpusUsage', resetField: 'weeklyOpusResetAt' }
+];


### PR DESCRIPTION
## Summary

A raw `curl` against `/api/oauth/usage` (2026-07) shows the real response shape has moved on from what this code assumed:

```json
"seven_day_sonnet": null,
"seven_day_opus": null,
"limits": [
  { "kind": "session", "percent": 48, ... },
  { "kind": "weekly_all", "percent": 18, ... },
  { "kind": "weekly_scoped", "percent": 3, "scope": { "model": { "display_name": "Sonnet" } }, ... }
]
```


The legacy flat seven_day_sonnet/seven_day_opus buckets return null even for a model with real usage that week — the real per-model number now lives in a limits[] array, matched by scope.model.display_name.

- parseUsageApiResponse now looks up each model's weekly_scoped limit first, falling back to the legacy flat bucket only when no such entry exists (preserving the existing null → 0% convention for that fallback, for accounts/API versions where the flat field is still authoritative).

This also fixed the underlying wiring the fallback path depends on: adding a per-model weekly usage bucket (Sonnet, Opus) previously required hand-editing four separate lookup tables in usage-prefetch.ts (USAGE_WIDGET_TYPES, USAGE_DATA_FIELDS, USAGE_WIDGET_REQUIREMENTS, USAGE_CURSOR_REQUIREMENTS) plus WINDOW_RESET_FIELD_SENTINELS in usage-fetch.ts. None of those tables were compiler-linked, so omitting a bucket from just one of them compiled cleanly and failed silently at runtime (e.g. the widget always renders null, or the progress cursor silently falls back to the wrong reset window).

- WEEKLY_MODEL_USAGE_BUCKETS (usage-types.ts) is now the single source of truth those tables (and the limits[] lookup above) are derived from.
- The one remaining hand-duplicated spot — CachedUsageDataSchema and UsageApiResponseSchema in usage-fetch.ts both need a model's fields declared by hand, since Zod needs statically-known object keys to keep field-level type inference for the parse* functions — is now covered by a schema-parity test (usage-fetch.test.ts) asserting both schemas cover every WEEKLY_MODEL_USAGE_BUCKETS entry, plus round-trip tests simulating an API fetch followed by a cache write/read. A bucket added to one schema but not the other now fails a test instead of silently vanishing after the next cache round-trip.

Test plan

- [x] bun run lint passes
- [x] bun test — 1648/1650 pass; the 2 failures (a sandboxed subprocess-timeout probe test, an Ink keypress-timing test) are pre-existing environmental flakiness unrelated to this change
- [x] New tests use the exact JSON shape captured from a live response
- [x] Manual CLI check: seven_day_sonnet: null + no limits[] still renders Weekly Sonnet: 33.0% / Weekly Opus: 0.0% unchanged (legacy fallback preserved); a weekly_scoped limits[] entry is correctly preferred over a stale/null legacy bucket for the same model