### PR TITLE
docs: add claude-carbon to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ If ccstatusline is useful to you, consider buying me a coffee:
 - [AIWatch](https://ai-watch.dev) - Live status monitor for 30+ AI APIs and apps; pairs with a Custom Command widget to surface provider outages in your status line.
 - [crispy-recall](https://github.com/TheSylvester/crispy-recall) - Searchable memory for your Claude Code and Codex sessions. Local, fast, no daemon.
 - [statuslin.es](https://statuslin.es) - Community gallery of Claude Code status lines with live, sandbox-rendered previews.
+- [claude-carbon](https://github.com/gwittebolle/claude-carbon) - Live CO2 estimate for your Claude Code sessions, next to the cost. Ships a `--segment` mode built to embed as a Custom Command widget.
 
 ## 🙏 Acknowledgments
 


### PR DESCRIPTION
Adds [claude-carbon](https://github.com/gwittebolle/claude-carbon) to the Related Projects list: a live CO2 estimate for Claude Code sessions, derived from published inference-energy measurements (methodology and sources documented in the repo).

It ships a `--segment` mode designed specifically for ccstatusline: a Custom Command widget pointing at `statusline.sh --segment` reads the status JSON from stdin and prints just the cost + CO2 pair (e.g. `$0.68 · 35g CO₂`), no network calls. So the two tools compose rather than compete.