### PR TITLE
fix(usage): parse limits[] array from usage API for migrated accounts

### DIFF
--- a/src/utils/__tests__/usage-fetch.test.ts
+++ b/src/utils/__tests__/usage-fetch.test.ts
@@ -11,6 +11,8 @@ import {
     it
 } from 'vitest';
 
+import { parseUsageApiResponse } from '../usage-fetch';
+
 const require = createRequire(import.meta.url);
 const { execFileSync: realExecFileSync } = require('node:child_process') as { execFileSync: typeof childProcess.execFileSync };
 
@@ -1254,5 +1256,297 @@ describe('fetchUsageData error handling', () => {
         } finally {
             harness.cleanup();
         }
+    });
+});
+
+describe('parseUsageApiResponse limits[] fallback (#503)', () => {
+    const limitsOnlyResponseBody = JSON.stringify({
+        limits: [
+            {
+                kind: 'session',
+                group: 'session',
+                percent: 15,
+                is_active: false,
+                resets_at: '2030-02-01T00:00:00.000Z'
+            },
+            {
+                kind: 'weekly_all',
+                group: 'weekly',
+                percent: 36,
+                is_active: false,
+                resets_at: '2030-02-07T00:00:00.000Z'
+            }
+        ]
+    });
+    const flatAndLimitsResponseBody = JSON.stringify({
+        five_hour: {
+            utilization: 42,
+            resets_at: '2030-03-01T00:00:00.000Z'
+        },
+        seven_day: {
+            utilization: 17,
+            resets_at: '2030-03-07T00:00:00.000Z'
+        },
+        limits: [
+            {
+                kind: 'session',
+                percent: 99,
+                resets_at: '2030-09-01T00:00:00.000Z'
+            },
+            {
+                kind: 'weekly_all',
+                percent: 88,
+                resets_at: '2030-09-07T00:00:00.000Z'
+            }
+        ]
+    });
+    const partialFallbackResponseBody = JSON.stringify({
+        seven_day: {
+            utilization: null,
+            resets_at: '2030-04-07T00:00:00.000Z'
+        },
+        limits: [
+            {
+                kind: 'weekly_all',
+                percent: 71,
+                resets_at: '2099-01-01T00:00:00.000Z'
+            }
+        ]
+    });
+    const placeholderLimitResponseBody = JSON.stringify({
+        limits: [
+            {
+                kind: 'session',
+                percent: 0,
+                resets_at: null
+            }
+        ]
+    });
+    const unknownKindsAndScopedResponseBody = JSON.stringify({
+        five_hour: {
+            utilization: 10,
+            resets_at: '2030-05-01T00:00:00.000Z'
+        },
+        seven_day: {
+            utilization: 20,
+            resets_at: '2030-05-07T00:00:00.000Z'
+        },
+        limits: [
+            {
+                kind: 'session',
+                percent: 10,
+                resets_at: '2030-05-01T00:00:00.000Z'
+            },
+            {
+                kind: 'weekly_all',
+                percent: 20,
+                resets_at: '2030-05-07T00:00:00.000Z'
+            },
+            {
+                kind: 'weekly_scoped',
+                group: 'weekly',
+                percent: 71,
+                severity: 'normal',
+                scope: {
+                    model: {
+                        id: null,
+                        display_name: 'Fable'
+                    },
+                    surface: null
+                },
+                is_active: true,
+                resets_at: '2030-05-07T00:00:00.000Z'
+            },
+            {
+                kind: 'some_future_kind',
+                percent: 55,
+                resets_at: '2030-05-09T00:00:00.000Z'
+            }
+        ]
+    });
+    const noLimitsResponseBody = JSON.stringify({
+        five_hour: {
+            utilization: 42,
+            resets_at: '2030-01-01T00:00:00.000Z'
+        },
+        seven_day: {
+            utilization: 17,
+            resets_at: '2030-01-07T00:00:00.000Z'
+        }
+    });
+    const zeroPercentWithResetsResponseBody = JSON.stringify({
+        limits: [
+            {
+                kind: 'session',
+                percent: 0,
+                resets_at: '2030-06-01T00:00:00.000Z'
+            }
+        ]
+    });
+    const nullPercentWithResetsResponseBody = JSON.stringify({
+        limits: [
+            {
+                kind: 'session',
+                percent: null,
+                resets_at: '2030-06-01T00:00:00.000Z'
+            }
+        ]
+    });
+    const weeklyOnlyLimitsResponseBody = JSON.stringify({
+        limits: [
+            {
+                kind: 'weekly_all',
+                percent: 44,
+                resets_at: '2030-06-07T00:00:00.000Z'
+            }
+        ]
+    });
+    const nullKindEntryResponseBody = JSON.stringify({
+        limits: [
+            {
+                kind: null,
+                percent: 50,
+                resets_at: '2030-06-01T00:00:00.000Z'
+            },
+            {
+                kind: 'session',
+                percent: 12,
+                resets_at: '2030-06-02T00:00:00.000Z'
+            }
+        ]
+    });
+    const duplicateSessionKindResponseBody = JSON.stringify({
+        limits: [
+            {
+                kind: 'session',
+                percent: 12,
+                resets_at: '2030-06-01T00:00:00.000Z'
+            },
+            {
+                kind: 'session',
+                percent: 99,
+                resets_at: '2099-01-01T00:00:00.000Z'
+            }
+        ]
+    });
+    // Whole-bucket null (five_hour/seven_day explicitly null, not merely
+    // absent) is indistinguishable between an Enterprise account with no
+    // rate-limit window (#343, correctly pinned to 0%) and a migrated
+    // account whose flat buckets were hollowed out to null alongside a live
+    // limits[] (#503). getUsageApiBucketUtilization(null) intentionally
+    // returns 0 (the #343 rule) even though resets_at still falls back to
+    // limits[] here - this is a known, accepted limitation: the parser
+    // cannot tell the two cases apart from the payload alone, so the
+    // percent stays pinned to 0 while the reset timer still advances.
+    const nullBucketsWithLiveLimitsResponseBody = JSON.stringify({
+        five_hour: null,
+        seven_day: null,
+        limits: [
+            {
+                kind: 'session',
+                percent: 63,
+                resets_at: '2030-07-01T00:00:00.000Z'
+            },
+            {
+                kind: 'weekly_all',
+                percent: 81,
+                resets_at: '2030-07-07T00:00:00.000Z'
+            }
+        ]
+    });
+
+    it('derives session and weekly percentages and resets_at from limits[] when flat buckets are absent', () => {
+        expect(parseUsageApiResponse(limitsOnlyResponseBody)).toEqual({
+            sessionUsage: 15,
+            sessionResetAt: '2030-02-01T00:00:00.000Z',
+            weeklyUsage: 36,
+            weeklyResetAt: '2030-02-07T00:00:00.000Z'
+        });
+    });
+
+    it('prefers flat bucket values over limits[] when both are present', () => {
+        expect(parseUsageApiResponse(flatAndLimitsResponseBody)).toEqual({
+            sessionUsage: 42,
+            sessionResetAt: '2030-03-01T00:00:00.000Z',
+            weeklyUsage: 17,
+            weeklyResetAt: '2030-03-07T00:00:00.000Z'
+        });
+    });
+
+    it('falls back to limits[] percent independently of a present flat resets_at', () => {
+        expect(parseUsageApiResponse(partialFallbackResponseBody)).toEqual({
+            weeklyUsage: 71,
+            weeklyResetAt: '2030-04-07T00:00:00.000Z'
+        });
+    });
+
+    it('treats a limits[] entry with percent 0 and no resets_at as a placeholder (#343 rationale)', () => {
+        expect(parseUsageApiResponse(placeholderLimitResponseBody)).toEqual({});
+    });
+
+    it('ignores unknown limits[] kinds and weekly_scoped entries without error', () => {
+        expect(parseUsageApiResponse(unknownKindsAndScopedResponseBody)).toEqual({
+            sessionUsage: 10,
+            sessionResetAt: '2030-05-01T00:00:00.000Z',
+            weeklyUsage: 20,
+            weeklyResetAt: '2030-05-07T00:00:00.000Z'
+        });
+    });
+
+    it('behaves identically to before when limits[] is absent', () => {
+        expect(parseUsageApiResponse(noLimitsResponseBody)).toEqual({
+            sessionUsage: 42,
+            sessionResetAt: '2030-01-01T00:00:00.000Z',
+            weeklyUsage: 17,
+            weeklyResetAt: '2030-01-07T00:00:00.000Z'
+        });
+    });
+
+    it('surfaces a limits[] entry reporting percent 0 with a resets_at as a real 0%, not a placeholder', () => {
+        expect(parseUsageApiResponse(zeroPercentWithResetsResponseBody)).toEqual({
+            sessionUsage: 0,
+            sessionResetAt: '2030-06-01T00:00:00.000Z'
+        });
+    });
+
+    it('treats a limits[] entry with percent null and a present resets_at as usage-undefined but keeps the reset time', () => {
+        expect(parseUsageApiResponse(nullPercentWithResetsResponseBody)).toEqual({ sessionResetAt: '2030-06-01T00:00:00.000Z' });
+    });
+
+    it('does not reject the whole response when a limits[] entry has kind: null (F7)', () => {
+        expect(parseUsageApiResponse(nullKindEntryResponseBody)).toEqual({
+            sessionUsage: 12,
+            sessionResetAt: '2030-06-02T00:00:00.000Z'
+        });
+    });
+
+    it('derives only weekly fields when limits[] contains just a weekly_all entry (no session entry)', () => {
+        expect(parseUsageApiResponse(weeklyOnlyLimitsResponseBody)).toEqual({
+            weeklyUsage: 44,
+            weeklyResetAt: '2030-06-07T00:00:00.000Z'
+        });
+    });
+
+    it('takes the first match when limits[] has duplicate kind: session entries (documents current find() behavior)', () => {
+        expect(parseUsageApiResponse(duplicateSessionKindResponseBody)).toEqual({
+            sessionUsage: 12,
+            sessionResetAt: '2030-06-01T00:00:00.000Z'
+        });
+    });
+
+    // Known limitation (#343 vs #503 ambiguity) - see the comment on
+    // nullBucketsWithLiveLimitsResponseBody above. This locks the current,
+    // deliberately-accepted behavior in place: whole-bucket null keeps the
+    // #343 zero-pin on percent even when a live limits[] could otherwise
+    // supply a real percentage, while resets_at still falls back to
+    // limits[] independently, which can recreate the "frozen percent, live
+    // timer" symptom from #503 for this specific payload shape.
+    it('keeps percent pinned to 0 for whole-bucket null buckets even with live limits[] data, while resets_at still falls back (known #343/#503 overlap)', () => {
+        expect(parseUsageApiResponse(nullBucketsWithLiveLimitsResponseBody)).toEqual({
+            sessionUsage: 0,
+            sessionResetAt: '2030-07-01T00:00:00.000Z',
+            weeklyUsage: 0,
+            weeklyResetAt: '2030-07-07T00:00:00.000Z'
+        });
     });
 });

--- a/src/utils/usage-fetch.ts
+++ b/src/utils/usage-fetch.ts
@@ -78,11 +78,24 @@ const UsageApiBucketSchema = z.looseObject({
 
 type UsageApiBucket = z.infer<typeof UsageApiBucketSchema>;
 
+// Newer accounts migrated off the flat five_hour/seven_day buckets report the
+// same windows inside a limits[] array instead (#503). Only the fields this
+// module reads are declared; loose-object passes everything else (scope,
+// is_active, group, etc.) through without failing validation.
+const UsageApiLimitSchema = z.looseObject({
+    kind: z.string().nullable().optional(),
+    percent: z.number().nullable().optional(),
+    resets_at: z.string().nullable().optional()
+});
+
+type UsageApiLimit = z.infer<typeof UsageApiLimitSchema>;
+
 const UsageApiResponseSchema = z.looseObject({
     five_hour: UsageApiBucketSchema,
     seven_day: UsageApiBucketSchema,
     seven_day_sonnet: UsageApiBucketSchema,
     seven_day_opus: UsageApiBucketSchema,
+    limits: z.array(UsageApiLimitSchema).nullable().optional(),
     extra_usage: z.looseObject({
         is_enabled: z.boolean().nullable().optional(),
         monthly_limit: z.number().nullable().optional(),
@@ -94,6 +107,25 @@ const UsageApiResponseSchema = z.looseObject({
 
 function getUsageApiBucketUtilization(bucket: UsageApiBucket): number | undefined {
     return bucket === null ? 0 : bucket?.utilization ?? undefined;
+}
+
+function findUsageApiLimit(limits: UsageApiLimit[] | null | undefined, kind: string): UsageApiLimit | undefined {
+    return limits?.find(limit => limit.kind === kind);
+}
+
+// Mirrors the null-bucket placeholder guard for #343 above: a limits[] entry
+// reporting 0% with no resets_at is not a real usage window, so the
+// limits[] fallback below must not resurrect it as a phantom 0% reading.
+function isPlaceholderUsageApiLimit(limit: UsageApiLimit): boolean {
+    return (limit.percent ?? 0) === 0 && (limit.resets_at ?? null) === null;
+}
+
+function getUsageApiLimitPercent(limit: UsageApiLimit | undefined): number | undefined {
+    return limit && !isPlaceholderUsageApiLimit(limit) ? limit.percent ?? undefined : undefined;
+}
+
+function getUsageApiLimitResetAt(limit: UsageApiLimit | undefined): string | undefined {
+    return limit && !isPlaceholderUsageApiLimit(limit) ? limit.resets_at ?? undefined : undefined;
 }
 
 function parseJsonWithSchema<T>(rawJson: string, schema: z.ZodType<T>): T | null {
@@ -157,17 +189,24 @@ function tokenHashMatches(cachedHash: string | undefined, currentHash: string | 
     return cachedHash === currentHash;
 }
 
-function parseUsageApiResponse(rawJson: string): UsageData | null {
+export function parseUsageApiResponse(rawJson: string): UsageData | null {
     const parsed = parseJsonWithSchema(rawJson, UsageApiResponseSchema);
     if (!parsed) {
         return null;
     }
 
+    // Flat five_hour/seven_day buckets are the primary source. On accounts
+    // migrated to the limits[] shape those buckets may be missing/null, so
+    // each field falls back to the matching limits[] entry independently -
+    // the percentage and resets_at can each come from a different source (#503).
+    const sessionLimit = findUsageApiLimit(parsed.limits, 'session');
+    const weeklyLimit = findUsageApiLimit(parsed.limits, 'weekly_all');
+
     return {
-        sessionUsage: getUsageApiBucketUtilization(parsed.five_hour),
-        sessionResetAt: parsed.five_hour?.resets_at ?? undefined,
-        weeklyUsage: getUsageApiBucketUtilization(parsed.seven_day),
-        weeklyResetAt: parsed.seven_day?.resets_at ?? undefined,
+        sessionUsage: getUsageApiBucketUtilization(parsed.five_hour) ?? getUsageApiLimitPercent(sessionLimit),
+        sessionResetAt: parsed.five_hour?.resets_at ?? getUsageApiLimitResetAt(sessionLimit),
+        weeklyUsage: getUsageApiBucketUtilization(parsed.seven_day) ?? getUsageApiLimitPercent(weeklyLimit),
+        weeklyResetAt: parsed.seven_day?.resets_at ?? getUsageApiLimitResetAt(weeklyLimit),
         weeklySonnetUsage: getUsageApiBucketUtilization(parsed.seven_day_sonnet),
         weeklySonnetResetAt: parsed.seven_day_sonnet?.resets_at ?? undefined,
         weeklyOpusUsage: getUsageApiBucketUtilization(parsed.seven_day_opus),


### PR DESCRIPTION
# fix(usage): parse `limits[]` array from usage API for migrated accounts

Refs #503 (partial — see "Scope honesty")

## Problem

#503 reports weekly/session usage **percentages** freezing in the statusline while the reset **timers** keep working, after Claude added Fable-only weekly limits and reshaped its usage reporting. This PR repairs the API-path parsing for one identified variant behind that symptom — accounts migrated to the `limits[]` response shape — but it is **not** a verified fix for the original reporter's exact setup; see "Scope honesty" below.

The usage API (`GET /api/oauth/usage`) has been migrated to a newer shape that reports the same windows inside a `limits[]` array:

```json
"limits": [
  { "kind": "session",       "group": "session", "percent": 15, "scope": null, "resets_at": "..." },
  { "kind": "weekly_all",    "group": "weekly",  "percent": 36, "scope": null, "resets_at": "..." },
  { "kind": "weekly_scoped", "group": "weekly",  "percent": 71,
    "scope": { "model": { "id": null, "display_name": "Fable" } }, "is_active": true, "resets_at": "..." }
]
```

On migrated accounts the flat `five_hour`/`seven_day` buckets can be missing or hollowed out in that response, and `parseUsageApiResponse` only read the flat buckets — so percentages came back `undefined`/stale while `resets_at` (often still supplied via the statusline stdin `rate_limits`) kept the timers accurate.

The `limits[]` shape is corroborated by multiple independent tools that already parse it (claude-meter's documented observed payload, elgato-streamdeck-claude-code-usage, claude-statusline (Go), teamclaude, Simple-Claude-Widget). Notably there is **no** flat `seven_day_fable` field — model-scoped limits exist only inside `limits[]`.

## Fix

`parseUsageApiResponse` keeps the flat buckets as the **primary** source and falls back **per-field** to the matching `limits[]` entry (`kind: "session"` → session, `kind: "weekly_all"` → weekly) when the flat value is missing — the percentage and `resets_at` fall back independently, since one can be present flat while the other only exists in `limits[]`.

- A `limits[]` entry reporting `percent: 0` with no `resets_at` is treated as an absent placeholder — mirroring the existing #343 null-bucket guard — so the fallback cannot resurrect a phantom `0%` reading.
- `weekly_scoped` entries (per-model limits such as Fable) and unknown `kind`s are ignored by this fix (no behavior change; they're a candidate for a future widget).
- The existing `five_hour: null` → `0` rule (#343, Enterprise accounts with no rate-limit windows) is deliberately preserved: the fallback fires only when the flat-derived value is `undefined`, never to override that rule.

## Scope honesty — which #503 variants this reaches

- **Fixed:** accounts whose API response is missing the flat buckets entirely but carries `limits[]` (the migrated shape) — percentages now derive correctly.
- **Not addressed (disclosed):** if an affected account's flat buckets are *present but stale* alongside a live `limits[]`, flat-primary precedence would still prefer the stale value. We saw no evidence of that variant in any observed payload (flat and `limits[]` agreed where both were present), so this PR takes the conservative precedence; happy to flip to `limits[]`-first if maintainers have payload evidence the other way.
- **Not addressed (disclosed):** when a flat bucket is explicitly `null` (not merely absent) alongside a live `limits[]`, the existing #343 Enterprise no-window rule still pins that bucket's percent to `0` even though `resets_at` falls back to `limits[]` independently — which can recreate the exact "frozen percent, live timer" symptom from #503 for this payload shape. The parser cannot distinguish a legitimate Enterprise no-window `null` from a migrated account's hollowed-out `null`, so this is kept deliberately (accepted trade-off) and locked with a regression test rather than guessed at.
- We cannot confirm the original #503 reporter's payload took either the migrated-`limits[]` path this PR fixes or the stdin `rate_limits` path — this PR is a partial fix for one identified variant, not a verified resolution of the reporter's exact setup.
- The statusline **stdin** `rate_limits` path (`usage-prefetch.ts`) is untouched — on accounts where stdin already satisfies the active widgets, behavior is unchanged (verified live: stdin `five_hour`/`seven_day` matched `/usage` exactly on a current CC 2.1.215 account). `mergeUsageData` prefers stdin values when present, so this path can short-circuit the API-path fix entirely on some configurations.

## Tests

- 12 new tests in `src/utils/__tests__/usage-fetch.test.ts` covering: limits-only payload (all four fields derived), flat-wins precedence (differing values prove it), per-field partial fallback, the placeholder guard, unknown-kind + `weekly_scoped` entries ignored, absent `limits` (identical to prior behavior), a real `percent: 0` with `resets_at` surfacing as true 0% (not a placeholder), `percent: null` with `resets_at` present, weekly-only `limits[]` (no session entry), duplicate `kind: 'session'` entries (documents first-match `find()` behavior), a `kind: null` entry not rejecting the whole response (schema hardening), and the known whole-bucket-null-with-live-limits[] limitation locked as a regression test.
- Full suite: `bun test` → 1781 pass, 0 fail. `bun run lint` clean.
- Revert-proof: reverting only the fallback logic (keeping the tests) fails the fallback-dependent tests; restoring passes the full file.
