### PR TITLE
fix(context): reset context length after a /compact boundary

### DIFF
--- a/src/utils/__tests__/jsonl-metrics.test.ts
+++ b/src/utils/__tests__/jsonl-metrics.test.ts
@@ -372,6 +372,134 @@ describe('jsonl transcript metrics', () => {
         });
     });
 
+    it('reports post-compaction context length from the boundary marker before the next turn', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-jsonl-metrics-'));
+        tempRoots.push(root);
+        const transcriptPath = path.join(root, 'compact-boundary.jsonl');
+
+        // A large pre-compaction turn, then Claude Code's compact_boundary marker.
+        // The pre-compaction entry describes a context that no longer exists, so
+        // context length must reflect the boundary's postTokens (18000), not the
+        // stale 235000 the last usage entry would otherwise produce.
+        const lines = [
+            makeUsageLine({
+                timestamp: '2026-01-01T10:00:00.000Z',
+                input: 5000,
+                output: 100,
+                cacheRead: 190000,
+                cacheCreate: 40000,
+                stopReason: 'end_turn'
+            }),
+            JSON.stringify({
+                type: 'system',
+                subtype: 'compact_boundary',
+                timestamp: '2026-01-01T10:05:00.000Z',
+                compactMetadata: { trigger: 'manual', preTokens: 235100, postTokens: 18000 }
+            })
+        ];
+
+        fs.writeFileSync(transcriptPath, lines.join('\n'));
+
+        const metrics = await getTokenMetrics(transcriptPath);
+
+        // Totals stay cumulative for the session; only contextLength resets.
+        expect(metrics).toEqual({
+            inputTokens: 5000,
+            outputTokens: 100,
+            cachedTokens: 230000,
+            cacheReadTokens: 190000,
+            cacheCreationTokens: 40000,
+            totalTokens: 235100,
+            contextLength: 18000
+        });
+    });
+
+    it('uses the first turn after a compaction boundary instead of its postTokens estimate', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-jsonl-metrics-'));
+        tempRoots.push(root);
+        const transcriptPath = path.join(root, 'compact-followup.jsonl');
+
+        const lines = [
+            makeUsageLine({
+                timestamp: '2026-01-01T10:00:00.000Z',
+                input: 5000,
+                output: 100,
+                cacheRead: 190000,
+                cacheCreate: 40000,
+                stopReason: 'end_turn'
+            }),
+            JSON.stringify({
+                type: 'system',
+                subtype: 'compact_boundary',
+                timestamp: '2026-01-01T10:05:00.000Z',
+                compactMetadata: { trigger: 'manual', preTokens: 235100, postTokens: 18000 }
+            }),
+            makeUsageLine({
+                timestamp: '2026-01-01T10:06:00.000Z',
+                input: 200,
+                output: 50,
+                cacheRead: 17000,
+                cacheCreate: 500,
+                stopReason: 'end_turn'
+            })
+        ];
+
+        fs.writeFileSync(transcriptPath, lines.join('\n'));
+
+        const metrics = await getTokenMetrics(transcriptPath);
+
+        // contextLength = post-compaction turn (200 + 17000 + 500), not 18000 or 235000.
+        expect(metrics).toEqual({
+            inputTokens: 5200,
+            outputTokens: 150,
+            cachedTokens: 247500,
+            cacheReadTokens: 207000,
+            cacheCreationTokens: 40500,
+            totalTokens: 252850,
+            contextLength: 17700
+        });
+    });
+
+    it('reports zero context length after a compaction marker that omits postTokens with no following turn', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-jsonl-metrics-'));
+        tempRoots.push(root);
+        const transcriptPath = path.join(root, 'compact-no-post-tokens.jsonl');
+
+        // Older transcript format: a compact_boundary without postTokens. The
+        // pre-compaction context is gone and we have no post-compaction size, so
+        // the stale 235000 must not leak through.
+        const lines = [
+            makeUsageLine({
+                timestamp: '2026-01-01T10:00:00.000Z',
+                input: 5000,
+                output: 100,
+                cacheRead: 190000,
+                cacheCreate: 40000,
+                stopReason: 'end_turn'
+            }),
+            JSON.stringify({
+                type: 'system',
+                subtype: 'compact_boundary',
+                timestamp: '2026-01-01T10:05:00.000Z',
+                compactMetadata: { trigger: 'manual', preTokens: 235100 }
+            })
+        ];
+
+        fs.writeFileSync(transcriptPath, lines.join('\n'));
+
+        const metrics = await getTokenMetrics(transcriptPath);
+
+        expect(metrics).toEqual({
+            inputTokens: 5000,
+            outputTokens: 100,
+            cachedTokens: 230000,
+            cacheReadTokens: 190000,
+            cacheCreationTokens: 40000,
+            totalTokens: 235100,
+            contextLength: 0
+        });
+    });
+
     it('returns zeroed token metrics when file is missing', async () => {
         const metrics = await getTokenMetrics('/tmp/ccstatusline-jsonl-metrics-missing.jsonl');
         expect(metrics).toEqual({

--- a/src/utils/compaction.ts
+++ b/src/utils/compaction.ts
@@ -14,12 +14,28 @@ export const ZERO_COMPACTION_STATS: CompactionData = Object.freeze({
     tokensReclaimed: 0
 });
 
-function isCompactBoundary(record: unknown): boolean {
+export function isCompactBoundary(record: unknown): boolean {
     if (typeof record !== 'object' || record === null) {
         return false;
     }
     const r = record as { type?: unknown; subtype?: unknown; isSidechain?: unknown };
     return r.type === 'system' && r.subtype === 'compact_boundary' && r.isSidechain !== true;
+}
+
+/**
+ * Returns the post-compaction context size (`compactMetadata.postTokens`) for a
+ * compact_boundary record, or null when the record is not a boundary or omits a
+ * finite postTokens value (older Claude Code transcripts).
+ */
+export function getCompactBoundaryPostTokens(record: unknown): number | null {
+    if (!isCompactBoundary(record)) {
+        return null;
+    }
+    const meta = (record as { compactMetadata?: unknown }).compactMetadata;
+    const post = (typeof meta === 'object' && meta !== null)
+        ? (meta as Record<string, unknown>).postTokens
+        : undefined;
+    return typeof post === 'number' && Number.isFinite(post) ? Math.max(0, post) : null;
 }
 
 /**

--- a/src/utils/jsonl-metrics.ts
+++ b/src/utils/jsonl-metrics.ts
@@ -8,6 +8,10 @@ import type {
 } from '../types';
 
 import {
+    getCompactBoundaryPostTokens,
+    isCompactBoundary
+} from './compaction';
+import {
     parseJsonlLine,
     readJsonlLines
 } from './jsonl-lines';
@@ -170,16 +174,30 @@ export async function getTokenMetrics(transcriptPath: string): Promise<TokenMetr
         // transcripts, count finalized entries plus the latest unfinished entry so
         // live updates do not overcount duplicate partial rows. If the transcript
         // format has no stop_reason field at all, fall back to counting all entries.
+        //
+        // Claude Code also writes a { type:'system', subtype:'compact_boundary' }
+        // record on every compaction. Usage entries before the most recent boundary
+        // describe a context that no longer exists, so they must not drive context
+        // length - otherwise it stays stuck at the pre-compaction size until the
+        // next turn repopulates Claude Code's live status data.
         let mostRecentMainChainEntry: TranscriptLine | null = null;
         let mostRecentTimestamp: Date | null = null;
+        let mostRecentPostCompactionEntry: TranscriptLine | null = null;
+        let mostRecentPostCompactionTimestamp: Date | null = null;
+        let lastCompactBoundaryLineIndex = -1;
+        let lastCompactBoundaryPostTokens: number | null = null;
 
-        const parsedEntries: TranscriptLine[] = [];
+        const parsedEntries: { data: TranscriptLine; lineIndex: number }[] = [];
         let hasStopReasonField = false;
 
-        for (const line of lines) {
+        for (const [lineIndex, line] of lines.entries()) {
             const data = parseJsonlLine(line) as TranscriptLine | null;
+            if (isCompactBoundary(data)) {
+                lastCompactBoundaryLineIndex = lineIndex;
+                lastCompactBoundaryPostTokens = getCompactBoundaryPostTokens(data);
+            }
             if (data?.message?.usage) {
-                parsedEntries.push(data);
+                parsedEntries.push({ data, lineIndex });
                 if (Object.hasOwn(data.message, 'stop_reason')) {
                     hasStopReasonField = true;
                 }
@@ -187,13 +205,13 @@ export async function getTokenMetrics(transcriptPath: string): Promise<TokenMetr
         }
 
         const entriesToCount = hasStopReasonField
-            ? parsedEntries.filter((data, index) => {
-                const stopReason = data.message?.stop_reason;
+            ? parsedEntries.filter((entry, index) => {
+                const stopReason = entry.data.message?.stop_reason;
                 return Boolean(stopReason) || (stopReason === null && index === parsedEntries.length - 1);
             })
             : parsedEntries;
 
-        for (const data of entriesToCount) {
+        for (const { data, lineIndex } of entriesToCount) {
             const usage = data.message?.usage;
             if (!usage) {
                 continue;
@@ -212,16 +230,32 @@ export async function getTokenMetrics(transcriptPath: string): Promise<TokenMetr
                     mostRecentTimestamp = entryTime;
                     mostRecentMainChainEntry = data;
                 }
+                if (lineIndex > lastCompactBoundaryLineIndex
+                    && (!mostRecentPostCompactionTimestamp || entryTime > mostRecentPostCompactionTimestamp)) {
+                    mostRecentPostCompactionTimestamp = entryTime;
+                    mostRecentPostCompactionEntry = data;
+                }
             }
         }
 
-        // Calculate context length from the most recent main chain message
-        if (mostRecentMainChainEntry?.message?.usage) {
-            const usage = mostRecentMainChainEntry.message.usage;
-            contextLength = (usage.input_tokens || 0)
+        // Context length is the live occupancy of the current context window.
+        // Without a compaction it is the most recent main-chain turn. After a
+        // compaction, prefer the first turn following the boundary, then the
+        // boundary's reported post-compaction size, and otherwise 0 - the stale
+        // pre-compaction turn must never leak through.
+        const contextLengthFromEntry = (entry: TranscriptLine | null): number | null => {
+            const usage = entry?.message?.usage;
+            if (!usage) {
+                return null;
+            }
+            return (usage.input_tokens || 0)
                 + (usage.cache_read_input_tokens ?? 0)
                 + (usage.cache_creation_input_tokens ?? 0);
-        }
+        };
+
+        contextLength = lastCompactBoundaryLineIndex >= 0
+            ? (contextLengthFromEntry(mostRecentPostCompactionEntry) ?? lastCompactBoundaryPostTokens ?? 0)
+            : (contextLengthFromEntry(mostRecentMainChainEntry) ?? 0);
 
         const cachedTokens = cacheReadTokens + cacheCreationTokens;
         const totalTokens = inputTokens + outputTokens + cachedTokens;


### PR DESCRIPTION
## Problem

Context-length / context-percentage widgets stay stuck at the **pre-compaction** token count after a `/compact`, until the next assistant turn — the bug reported in #92.

Right after `/compact`, Claude Code sets `context_window.current_usage` to `null`, so the context widgets fall back to transcript parsing. `getTokenMetrics()` then derives context length from the most recent usage entry — the now-defunct pre-compaction turn — so the displayed size never drops.

When #92 was closed, the reason given was that `/compact` "doesn't send anything back that gets logged to the jsonl." That's no longer true: Claude Code writes a `{ type: 'system', subtype: 'compact_boundary', compactMetadata: { preTokens, postTokens } }` record on every compaction — the same marker the Compaction Counter widget already parses.

## Fix

`getTokenMetrics()` is now compaction-aware. Usage entries before the most recent `compact_boundary` describe a context that no longer exists, so they no longer drive context length. Resolution order for `contextLength`:

1. the first main-chain turn **after** the boundary (once another message is sent), else
2. the boundary's `compactMetadata.postTokens`, else
3. `0` (older transcripts without `postTokens`) — never the stale pre-compaction number.

Session token **totals** (`inputTokens`, `outputTokens`, `cachedTokens`, `totalTokens`) stay cumulative — only `contextLength` resets. Behavior with no compaction is unchanged.

Boundary detection is reused from `compaction.ts` (`isCompactBoundary` is now exported, plus a small `getCompactBoundaryPostTokens` helper), so there's no duplicated parsing and no second pass over the transcript.

## Tests

Added 3 cases to `jsonl-metrics.test.ts`:
- post-compaction size taken from `postTokens` before the next turn,
- first post-boundary turn supersedes the `postTokens` estimate,
- marker without `postTokens` + no following turn → `0` (no stale leak).

`bun test` (full suite) and `bun run lint` (tsc + eslint, `--max-warnings=0`) pass.

## Before / after

Post-`/compact`, boundary `postTokens = 18000`, pre-compaction context ~235k:

| | status line |
|---|---|
| before | `... 235.0k (23.5%)` |
| after | `... 18.0k (1.8%)` |


