### PR TITLE
fix(renderer): preserve separators after hidden widgets

### DIFF
--- a/src/utils/__tests__/renderer-separator-collapse.test.ts
+++ b/src/utils/__tests__/renderer-separator-collapse.test.ts
@@ -10,6 +10,7 @@ import {
     type Settings
 } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { stripSgrCodes } from '../ansi';
 import { renderStatusLine } from '../renderer';
 
 interface PreRenderedWidget {
@@ -64,6 +65,28 @@ describe('renderer separator collapse around empty widgets', () => {
         expect((out.match(/\|/g) ?? []).length).toBe(1);
         expect(out).toContain('A');
         expect(out).toContain('C');
+    });
+
+    it('looks past an empty widget when no separator already owns the boundary', () => {
+        const widgets = [T('a'), T('b'), SEP, T('c')];
+        const out = stripSgrCodes(render(widgets, { 0: 'A', 1: '', 3: 'C' }));
+        expect(out).toBe('A | C');
+    });
+
+    it('replaces spacing before an empty widget with its following separator', () => {
+        const space: WidgetItem = { id: 'space', type: 'separator', character: ' ' };
+        const pipe: WidgetItem = { id: 'pipe', type: 'separator', character: '|' };
+        const widgets = [T('a'), space, T('b'), pipe, T('c')];
+        const out = stripSgrCodes(render(widgets, { 0: 'A', 2: '', 4: 'C' }));
+        expect(out).toBe('A | C');
+    });
+
+    it('keeps a visible separator as the boundary around an empty widget', () => {
+        const colon: WidgetItem = { id: 'colon', type: 'separator', character: ':' };
+        const pipe: WidgetItem = { id: 'pipe', type: 'separator', character: '|' };
+        const widgets = [T('a'), colon, T('b'), pipe, T('c')];
+        const out = stripSgrCodes(render(widgets, { 0: 'A', 2: '', 4: 'C' }));
+        expect(out).toBe('A:C');
     });
 
     it('collapses multiple consecutive empty widgets into a single separator', () => {

--- a/src/utils/__tests__/renderer-separator-collapse.test.ts
+++ b/src/utils/__tests__/renderer-separator-collapse.test.ts
@@ -170,4 +170,33 @@ describe('renderer separator collapse around empty widgets', () => {
         expect(stripped).toMatch(/A\s*C/);
         expect(stripped).not.toMatch(/A\s+\S+\s+C/);
     });
+
+    it('lets a merge:true widget own the boundary across an empty middle widget', () => {
+        const widgets: WidgetItem[] = [
+            { id: 'a', type: 'custom-text', merge: true },
+            { id: 'b', type: 'custom-text' },
+            SEP,
+            { id: 'c', type: 'custom-text' }
+        ];
+        const out = stripSgrCodes(render(widgets, { 0: 'A', 1: '', 3: 'C' }));
+
+        expect(out).not.toContain('|');
+        expect(out).toContain('A');
+        expect(out).toContain('C');
+    });
+
+    it('does not borrow visible content across a flex separator', () => {
+        const widgets: WidgetItem[] = [
+            T('left'),
+            { id: 'flex', type: 'flex-separator' },
+            T('hidden'),
+            SEP,
+            T('right')
+        ];
+        const out = stripSgrCodes(render(widgets, { 0: 'L', 2: '', 4: 'R' }));
+
+        expect(out).not.toContain('|');
+        expect(out).toContain('L');
+        expect(out).toContain('R');
+    });
 });

--- a/src/utils/__tests__/renderer-separator-collapse.test.ts
+++ b/src/utils/__tests__/renderer-separator-collapse.test.ts
@@ -138,6 +138,20 @@ describe('renderer separator collapse around empty widgets', () => {
         expect(out).toContain('C');
     });
 
+    it.each([
+        { label: 'true', merge: true },
+        { label: 'no-padding', merge: 'no-padding' }
+    ] as const)('keeps an explicit separator directly after a merge:$label widget', ({ merge }) => {
+        const widgets: WidgetItem[] = [
+            { id: 'a', type: 'custom-text', merge },
+            SEP,
+            { id: 'b', type: 'custom-text' }
+        ];
+        const out = stripSgrCodes(render(widgets, { 0: 'A', 2: 'B' }));
+
+        expect(out).toBe('A | B');
+    });
+
     it('lets a merge:no-padding widget glue to the next visible widget across an empty middle widget', () => {
         // Layout: [A(merge:no-padding), B(empty), SEP, C].
         //

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -734,6 +734,11 @@ function formatSeparator(sep: string): string {
     return sep;
 }
 
+function isSpacingSeparator(widget: WidgetItem | undefined, defaultSeparator: string | undefined): boolean {
+    return widget?.type === 'separator'
+        && (widget.character ?? defaultSeparator ?? '|').trim().length === 0;
+}
+
 export interface RenderResult {
     line: string;
     wasTruncated: boolean;
@@ -1003,24 +1008,39 @@ export function renderStatusLine(
 
         // Handle separators specially (they're not widgets)
         if (widget.type === 'separator') {
-            // Look backwards to the immediately-prior non-separator widget and
-            // emit this separator only if that widget actually rendered content.
-            // This collapses separators around hide-capable widgets that rendered
-            // empty (e.g., git-changes with no changes, conditional widgets with
-            // hide-when-zero semantics) and also suppresses a leading separator
-            // when no prior widget has rendered.
-            let hasContentBefore = false;
+            // Empty widgets do not break the relationship between a separator
+            // and the preceding visible content. A visible separator owns that
+            // boundary, while spacing-only separators can be replaced by a
+            // more meaningful separator that follows the empty widget.
+            let contentBeforeIndex: number | null = null;
+            let replacesSpacingSeparator = false;
             for (let j = i - 1; j >= 0; j--) {
                 const prevWidget = widgets[j];
                 if (!prevWidget)
                     continue;
-                if (prevWidget.type === 'separator' || prevWidget.type === 'flex-separator')
+                if (prevWidget.type === 'separator') {
+                    if (!isSpacingSeparator(prevWidget, settings.defaultSeparator))
+                        break;
+                    replacesSpacingSeparator = true;
                     continue;
-                hasContentBefore = Boolean(preRenderedWidgets[j]?.content);
-                break;
+                }
+                if (prevWidget.type === 'flex-separator')
+                    continue;
+                if (preRenderedWidgets[j]?.content) {
+                    // Preserve no-padding merges across widgets that render empty.
+                    if (prevWidget.merge !== 'no-padding')
+                        contentBeforeIndex = j;
+                    break;
+                }
             }
-            if (!hasContentBefore)
+            if (contentBeforeIndex === null)
                 continue;
+
+            if (replacesSpacingSeparator) {
+                while (isSpacingSeparator(elements[elements.length - 1]?.widget, settings.defaultSeparator)) {
+                    elements.pop();
+                }
+            }
 
             const sepChar = widget.character ?? (settings.defaultSeparator ?? '|');
             const formattedSep = formatSeparator(sepChar);
@@ -1031,10 +1051,10 @@ export function renderStatusLine(
             let separatorBold = widget.bold;
             let separatorDim = widget.dim;
 
-            if (settings.inheritSeparatorColors && i > 0 && !widget.color && !widget.backgroundColor) {
+            if (settings.inheritSeparatorColors && !widget.color && !widget.backgroundColor) {
                 // Only inherit if the separator doesn't have explicit colors set
-                const prevWidget = widgets[i - 1];
-                if (prevWidget && prevWidget.type !== 'separator' && prevWidget.type !== 'flex-separator') {
+                const prevWidget = widgets[contentBeforeIndex];
+                if (prevWidget) {
                     // Get the previous widget's colors
                     let widgetColor = prevWidget.color;
                     if (!widgetColor) {

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -1025,10 +1025,10 @@ export function renderStatusLine(
                     continue;
                 }
                 if (prevWidget.type === 'flex-separator')
-                    continue;
+                    break;
                 if (preRenderedWidgets[j]?.content) {
-                    // Preserve no-padding merges across widgets that render empty.
-                    if (prevWidget.merge !== 'no-padding')
+                    // Preserve merge ownership across widgets that render empty.
+                    if (!prevWidget.merge)
                         contentBeforeIndex = j;
                     break;
                 }

--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -1014,6 +1014,7 @@ export function renderStatusLine(
             // more meaningful separator that follows the empty widget.
             let contentBeforeIndex: number | null = null;
             let replacesSpacingSeparator = false;
+            let crossedEmptyWidget = false;
             for (let j = i - 1; j >= 0; j--) {
                 const prevWidget = widgets[j];
                 if (!prevWidget)
@@ -1028,10 +1029,11 @@ export function renderStatusLine(
                     break;
                 if (preRenderedWidgets[j]?.content) {
                     // Preserve merge ownership across widgets that render empty.
-                    if (!prevWidget.merge)
+                    if (!prevWidget.merge || !crossedEmptyWidget)
                         contentBeforeIndex = j;
                     break;
                 }
+                crossedEmptyWidget = true;
             }
             if (contentBeforeIndex === null)
                 continue;


### PR DESCRIPTION
## Summary

- Let manual separators look past widgets that rendered empty.
- Keep an existing visible separator as a hard boundary so the #344 orphan-separator fix remains intact.
- Replace whitespace-only spacing when a later separator belongs between the surrounding visible widgets.
- Inherit separator color from the actual preceding visible widget.

Fixes #518

Prepared with Codex assistance and reviewed against the existing separator regression suite.

## Tests

- `bun test` with 1,811 passing tests
- `bun run lint`
- `bun run build`
