### PR TITLE
Add llms.txt for LLM/agent-readable project summary

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,23 @@
+# ccstatusline
+
+> A highly customizable status line formatter for Claude Code CLI. Renders a configurable terminal status line (model info, git branch/state, token/context usage, cost, timers, and other widgets) via an interactive TUI, with support for themes and Powerline-style separators.
+
+## Getting Started
+
+- [Quick Start](https://github.com/sirmalloc/ccstatusline#-quick-start): Run with `npx -y ccstatusline@latest` or `bunx -y ccstatusline@latest` — no installation required. Launches an interactive TUI to configure and install the status line into Claude Code's `settings.json`.
+- [Windows Support](https://github.com/sirmalloc/ccstatusline/blob/main/docs/WINDOWS.md): PowerShell setup, fonts, and WSL/Windows Terminal notes.
+- [Usage](https://github.com/sirmalloc/ccstatusline/blob/main/docs/USAGE.md): Full widget reference and configuration behavior.
+
+## Configuration
+
+- [Claude Code settings.json format](https://github.com/sirmalloc/ccstatusline#-quick-start): ccstatusline writes a `statusLine` command object (`type`, `command`, `padding`, `refreshInterval`) to Claude Code's settings, supporting `npx`, `bunx`, or a pinned global `ccstatusline` command; settings are stored at `~/.config/ccstatusline/settings.json` (overridable via `CLAUDE_CONFIG_DIR`).
+
+## Development
+
+- [Development guide](https://github.com/sirmalloc/ccstatusline/blob/main/docs/DEVELOPMENT.md): build and contribution workflow for the TypeScript/Bun-based codebase.
+- [Contributing](https://github.com/sirmalloc/ccstatusline#-contributing): guidelines for submitting changes.
+
+## Optional
+
+- [Related Projects](https://github.com/sirmalloc/ccstatusline#-related-projects): other tools in the Claude Code ecosystem.
+- [License](https://github.com/sirmalloc/ccstatusline/blob/main/LICENSE): MIT.


### PR DESCRIPTION
This repo doesn't have an [`llms.txt`](https://llmstxt.org) file yet — a small, curated markdown index (title, one-line summary, and grouped links to the docs that matter) that AI coding agents can read to understand a project quickly, instead of having to crawl and guess through the full README/docs tree.

Given ccstatusline's audience is largely Claude Code / agent users configuring their own tooling, this felt like a natural fit — an agent asked to help someone customize their statusline could load this file directly instead of parsing the full (quite long) README changelog.

Content is derived entirely from your existing docs (README Quick Start/Contributing sections, `docs/WINDOWS.md`, `docs/USAGE.md`, `docs/DEVELOPMENT.md`) — no new claims, just pointers. Validated against the [llms.txt spec](https://llmstxt.org) with [llms-txt-lint](https://github.com/abyworkings-coder/llms-txt-lint) (disclosure: a small validator tool I maintain — happy to drop that line from the PR if you'd rather not have it).

Totally understand if this isn't something you want to maintain — no worries either way, feel free to close.