### PR TITLE
fix(usage): read keychain credential by account, not service name alone

### DIFF
--- a/src/utils/__tests__/usage-token.test.ts
+++ b/src/utils/__tests__/usage-token.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import type { Mock } from 'vitest';
 import {
@@ -34,7 +35,7 @@ function encodeAsciiAsHex(value: string): string {
     return Buffer.from(value, 'utf8').toString('hex');
 }
 
-function makeKeychainBlock(service: string, modifiedAt?: { raw?: string; quoted?: string }): string {
+function makeKeychainBlock(service: string, modifiedAt?: { raw?: string; quoted?: string }, account?: string): string {
     const lines = [
         'keychain: "/Users/example/Library/Keychains/login.keychain-db"',
         'version: 512',
@@ -42,6 +43,10 @@ function makeKeychainBlock(service: string, modifiedAt?: { raw?: string; quoted?
         'attributes:',
         `    "svce"<blob>="${service}"`
     ];
+
+    if (account !== undefined) {
+        lines.push(`    "acct"<blob>="${account}"`);
+    }
 
     if (modifiedAt?.raw && modifiedAt.quoted) {
         lines.push(`    "mdat"<timedate>=0x${modifiedAt.raw}    "${modifiedAt.quoted}"`);
@@ -111,6 +116,7 @@ describe('getUsageToken', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
         vi.spyOn(claudeSettings, 'getClaudeConfigDir').mockReturnValue('/fake/claude');
+        vi.spyOn(os, 'userInfo').mockReturnValue({ username: 'testuser' } as unknown as os.UserInfo<string>);
         mockedExecFileSync.mockReset();
     });
 
@@ -135,6 +141,64 @@ describe('getUsageToken', () => {
         expect(getSecurityCallLog()).toEqual([
             'find-generic-password -s Claude Code-credentials -w',
             'find-generic-password -s Claude Code-credentials -w'
+        ]);
+    });
+
+    it('reads the OS-username account when the service-only lookup returns an item without an OAuth token', () => {
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+        mockCredentialsFile();
+        mockedExecFileSync.mockImplementation((command: string, args?: string[]) => {
+            if (command !== 'security' || !args) {
+                throw new Error(`Unexpected security args: ${args?.join(' ')}`);
+            }
+
+            const isCredentialsService = args[0] === 'find-generic-password' && args[2] === 'Claude Code-credentials';
+            if (isCredentialsService && args.includes('-a') && args[args.indexOf('-a') + 1] === 'testuser') {
+                return makeTokenPayload('account-token');
+            }
+
+            if (isCredentialsService) {
+                // Service-only match: an unrelated account's MCP-only item.
+                return JSON.stringify({ mcpOAuth: { some: 'value' } });
+            }
+
+            throw new Error(`Unexpected security args: ${args.join(' ')}`);
+        });
+
+        expect(getUsageToken()).toBe('account-token');
+        expect(getSecurityCallLog()).toEqual([
+            'find-generic-password -s Claude Code-credentials -w',
+            'find-generic-password -s Claude Code-credentials -a testuser -w'
+        ]);
+    });
+
+    it('skips the OS-username account read when the username cannot be resolved', () => {
+        // os.userInfo() throws when the uid has no passwd entry (some containers).
+        vi.spyOn(os, 'userInfo').mockImplementation(() => {
+            throw new Error('no passwd entry');
+        });
+        vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+        mockCredentialsFile(makeTokenPayload('file-token'));
+        mockedExecFileSync.mockImplementation((command: string, args?: string[]) => {
+            if (command !== 'security' || !args) {
+                throw new Error(`Unexpected security args: ${args?.join(' ')}`);
+            }
+
+            if (args[0] === 'find-generic-password' && args[2] === 'Claude Code-credentials') {
+                throw new Error('missing exact credential');
+            }
+
+            if (args[0] === 'dump-keychain') {
+                return '';
+            }
+
+            throw new Error(`Unexpected security args: ${args.join(' ')}`);
+        });
+
+        expect(getUsageToken()).toBe('file-token');
+        expect(getSecurityCallLog()).toEqual([
+            'find-generic-password -s Claude Code-credentials -w',
+            'dump-keychain'
         ]);
     });
 
@@ -170,9 +234,11 @@ describe('getUsageToken', () => {
         expect(getUsageToken()).toBe('hashed-token');
         expect(getSecurityCallLog()).toEqual([
             'find-generic-password -s Claude Code-credentials -w',
+            'find-generic-password -s Claude Code-credentials -a testuser -w',
             'dump-keychain',
             'find-generic-password -s Claude Code-credentials-new -w',
             'find-generic-password -s Claude Code-credentials -w',
+            'find-generic-password -s Claude Code-credentials -a testuser -w',
             'dump-keychain',
             'find-generic-password -s Claude Code-credentials-new -w'
         ]);
@@ -207,9 +273,11 @@ describe('getUsageToken', () => {
         expect(getUsageToken()).toBe('file-token');
         expect(getSecurityCallLog()).toEqual([
             'find-generic-password -s Claude Code-credentials -w',
+            'find-generic-password -s Claude Code-credentials -a testuser -w',
             'dump-keychain',
             'find-generic-password -s Claude Code-credentials-hashed -w',
             'find-generic-password -s Claude Code-credentials -w',
+            'find-generic-password -s Claude Code-credentials -a testuser -w',
             'dump-keychain',
             'find-generic-password -s Claude Code-credentials-hashed -w'
         ]);

--- a/src/utils/usage-fetch.ts
+++ b/src/utils/usage-fetch.ts
@@ -339,11 +339,14 @@ export function parseMacKeychainCredentialCandidates(rawDump: string, servicePre
         .map(candidate => candidate.service);
 }
 
-function readMacKeychainSecret(service: string): string | null {
+function readMacKeychainSecret(service: string, account?: string): string | null {
     try {
+        const args = account
+            ? ['find-generic-password', '-s', service, '-a', account, '-w']
+            : ['find-generic-password', '-s', service, '-w'];
         return execFileSync(
             'security',
-            ['find-generic-password', '-s', service, '-w'],
+            args,
             { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'], windowsHide: true }
         ).trim();
     } catch {
@@ -351,9 +354,26 @@ function readMacKeychainSecret(service: string): string | null {
     }
 }
 
-function readUsageTokenFromMacKeychainService(service: string): string | null {
-    const secret = readMacKeychainSecret(service);
+function readUsageTokenFromMacKeychainService(service: string, account?: string): string | null {
+    const secret = readMacKeychainSecret(service, account);
     return secret ? parseUsageAccessToken(secret) : null;
+}
+
+function getOsUsername(): string | null {
+    try {
+        return os.userInfo().username;
+    } catch {
+        return null;
+    }
+}
+
+// The login keychain can hold several items under one service, differing only by
+// account; a service-only lookup returns whichever matches first, which may be an
+// entry lacking `claudeAiOauth`. Claude Code reads/writes with an explicit account
+// (the OS username), so mirror that.
+function readUsageTokenFromMacKeychainUserAccount(service: string): string | null {
+    const osUsername = getOsUsername();
+    return osUsername ? readUsageTokenFromMacKeychainService(service, osUsername) : null;
 }
 
 function listMacKeychainCredentialCandidates(): string[] {
@@ -403,6 +423,7 @@ export function getUsageToken(): string | null {
     }
 
     return readUsageTokenFromMacKeychainService(MACOS_USAGE_CREDENTIALS_SERVICE)
+        ?? readUsageTokenFromMacKeychainUserAccount(MACOS_USAGE_CREDENTIALS_SERVICE)
         ?? readUsageTokenFromMacKeychainCandidates()
         ?? readUsageTokenFromCredentialsFile();
 }


### PR DESCRIPTION

## Problem

On macOS, all usage widgets can show `[No credentials]` even when a valid Claude Code OAuth token is in the keychain. The login keychain may hold more than one generic-password item under the service `Claude Code-credentials`, differing only by *account*:

| service | account | contents |
|---|---|---|
| `Claude Code-credentials` | `<os-username>` | `{ mcpOAuth, claudeAiOauth }` ← real token |
| `Claude Code-credentials` | `unknown` | `{ mcpOAuth }` only |

`security find-generic-password -s "Claude Code-credentials" -w` (no `-a`) returns whichever item `security` matches first — which can be the one lacking `claudeAiOauth` — so the token appears missing. The existing suffixed-service fallback can't recover it (it excludes the plain service name, and the `Claude Code-credentials-<hex>` services are all MCP tokens without `claudeAiOauth`).

Fixes #521.

## Fix

`getUsageToken()` now, when the service-only read yields no `claudeAiOauth`, does one additional read scoped to the OS username — `security find-generic-password -s "Claude Code-credentials" -a <os.userInfo().username> -w` — mirroring how Claude Code itself writes/reads the item (`-a <username> -s "Claude Code-credentials"`). It sits between the existing service-only read and the hashed-candidate + `.credentials.json` fallbacks.

Resolution order is unchanged for single-item keychains (the service-only read still wins first), so this is a no-op on machines that already work. `os.userInfo()` is wrapped so a machine where it throws (uid absent from passwd) simply skips the new read. The suffixed-candidate scan and the `.credentials.json` fallback are untouched.

## Scope / limitation

This resolves the observed case where the token lives under the **OS-username** account (which is what Claude Code writes). It intentionally does **not** try to guess a non-username account string (email/UUID/hash) — that would be speculative, and it can't regress those keychains (they already fall through to the existing fallbacks). If per-account resolution from config lands (cf. #219 / #266), the account could instead come from there; happy to align.

## Why not reverse-engineer the suffixed service names

The many `Claude Code-credentials-<hex>` entries are per-MCP-server OAuth tokens, not account credentials — matching against them is a dead end (the existing candidate scan already can't help). Scoping by account is exactly what Claude Code does, so it stays correct if the suffix scheme ever changes.

## Tests

- `reads the OS-username account when the service-only lookup returns an item without an OAuth token` — drives the exact bug: service-only read returns an MCP-only item, `-a <username>` read returns the real token; asserts the precise `security` call sequence.
- `skips the OS-username account read when the username cannot be resolved` — `os.userInfo()` throws → no `-a` lookup issued, chain proceeds to the fallbacks.
- Existing `getUsageToken` sequence tests updated for the new `-a <username>` call.
- On a branch merged with current `main`: `bun test` green (793 pass across 54 files, 0 fail) and `bun run lint` clean.

## Verification

Reproduced live on an affected machine: before, all usage widgets rendered `[No credentials]`; after, the token resolves via the OS-username account and the usage API returns real values.
