### PR TITLE
docs: fix stale test and widget counts in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ All widgets must implement:
 - `getAllWidgetTypes()`: Returns all available widget types
 - `isKnownWidgetType()`: Validates if a type is registered
 
-**Available Widgets:**
+**Available Widgets** (highlights — the full, current list lives in `src/utils/widget-manifest.ts`):
 - Model, Version, OutputStyle, VoiceStatus - Claude Code metadata display
 - GitBranch, GitChanges, GitInsertions, GitDeletions, GitWorktree - Git repository status
 - TokensInput, TokensOutput, TokensCached, TokensTotal - Token usage metrics
@@ -141,7 +141,7 @@ Default to using Bun instead of Node.js:
 - **Dependencies**: All runtime dependencies are bundled using `--packages=external` for npm package
 - **Type checking and linting**: Run checks via `bun run lint` and use `bun run lint:fix` only when you intentionally want ESLint auto-fixes. Never use `npx eslint`, `eslint`, `tsx`, `bun tsc`, or any other variation directly
 - **Lint rules**: Never disable a lint rule via a comment, no matter how benign the lint warning or error may seem
-- **Testing**: Uses Vitest (via Bun) with 6 test files and ~40 test cases covering:
+- **Testing**: Uses Vitest (via Bun); tests live in `__tests__/` directories alongside the code they cover, including:
   - Model context detection and token calculation (src/utils/__tests__/model-context.test.ts)
   - Context percentage calculations (src/utils/__tests__/context-percentage.test.ts)
   - JSONL transcript parsing (src/utils/__tests__/jsonl.test.ts)


### PR DESCRIPTION
## What

Two lines in `AGENTS.md` had drifted out of date:

- **Testing** claimed "6 test files and ~40 test cases" — the repo currently has **127 test files and ~1,470 test cases**.
- **Available Widgets** reads as a complete list but names about 25 of the **85** widget types registered in `WIDGET_MANIFEST`.

## Why count-free instead of updated counts

Hardcoded counts in docs go stale on every feature PR (this drift is the proof). This change removes the numbers entirely and points at the source of truth instead:

- Testing: describes the test layout (`__tests__/` directories alongside the code) rather than counting files.
- Available Widgets: marks the list as highlights and points to `src/utils/widget-manifest.ts` for the full, current list.

Happy to switch to updated literal counts instead if you prefer — but they'll be wrong again soon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YuAUKeC6FjaSczoPWQkuP
