### PR TITLE
fix(usage): parse a model-scoped weekly limit at 0% with no resets_at as real zero usage

### DIFF
--- a/src/utils/__tests__/usage-fetch.test.ts
+++ b/src/utils/__tests__/usage-fetch.test.ts
@@ -268,7 +268,7 @@ describe('fetchUsageData error handling', () => {
             resets_at: '2030-01-07T00:00:00.000Z'
         }
     });
-    const placeholderFableResponseBody = JSON.stringify({
+    const unusedFableQuotaResponseBody = JSON.stringify({
         five_hour: {
             utilization: 42,
             resets_at: '2030-01-01T00:00:00.000Z'
@@ -759,11 +759,11 @@ describe('fetchUsageData error handling', () => {
         }
     });
 
-    it('treats a placeholder fable window as conclusive when core usage fields are present', () => {
+    it('parses an unused fable quota (0%, no resets_at) as real zero usage and serves it from cache', () => {
         const harness = createProbeHarness();
 
         try {
-            const home = harness.createTokenHome('placeholder-fable-conclusive');
+            const home = harness.createTokenHome('unused-fable-quota');
             const requiredFields = ['fableUsage'];
             const result = harness.runProbe({
                 claudeConfigDir: home.claudeConfig,
@@ -772,7 +772,51 @@ describe('fetchUsageData error handling', () => {
                 nowMs,
                 pathDir: home.bin,
                 requiredFields,
-                responseBody: placeholderFableResponseBody
+                responseBody: unusedFableQuotaResponseBody
+            });
+
+            expect(result.first).toEqual({
+                sessionUsage: 42,
+                sessionResetAt: '2030-01-01T00:00:00.000Z',
+                weeklyUsage: 17,
+                weeklyResetAt: '2030-01-07T00:00:00.000Z',
+                fableUsage: 0
+            });
+            expect(result.second).toEqual(result.first);
+            expect(result.requestCount).toBe(1);
+
+            const cacheMtimeMs = fs.statSync(path.join(home.home, '.cache', 'ccstatusline', 'usage.json')).mtimeMs;
+            const cachedResult = harness.runProbe({
+                claudeConfigDir: home.claudeConfig,
+                home: home.home,
+                mode: 'unexpected',
+                nowMs: cacheMtimeMs + 10000,
+                pathDir: home.bin,
+                requiredFields
+            });
+
+            expect(cachedResult.first).toEqual(result.first);
+            expect(cachedResult.second).toEqual(result.first);
+            expect(cachedResult.requestCount).toBe(0);
+        } finally {
+            harness.cleanup();
+        }
+    });
+
+    it('treats a missing fable window as conclusive when core usage fields are present', () => {
+        const harness = createProbeHarness();
+
+        try {
+            const home = harness.createTokenHome('missing-fable-conclusive');
+            const requiredFields = ['fableUsage'];
+            const result = harness.runProbe({
+                claudeConfigDir: home.claudeConfig,
+                home: home.home,
+                mode: 'success',
+                nowMs,
+                pathDir: home.bin,
+                requiredFields,
+                responseBody: successResponseBody
             });
 
             expect(result.first).toEqual({
@@ -1717,6 +1761,26 @@ describe('parseUsageApiResponse limits[] fallback (#503)', () => {
         expect(parseUsageApiResponse(placeholderLimitResponseBody)).toEqual({});
     });
 
+    it('treats a model-scoped weekly limit at 0% with no resets_at as real zero usage, not a placeholder', () => {
+        // Live payloads show a weekly_scoped entry sitting at percent 0 /
+        // resets_at null until the scoped model is first used in the current
+        // window (resets_at then fills in while percent stays 0), so unlike
+        // the unscoped case above this is a real 0% reading. The reset field
+        // stays unset until the window actually starts.
+        expect(parseUsageApiResponse(JSON.stringify({
+            limits: [
+                {
+                    kind: 'weekly_scoped',
+                    group: 'weekly',
+                    percent: 0,
+                    resets_at: null,
+                    scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+                    is_active: false
+                }
+            ]
+        }))).toEqual({ fableUsage: 0 });
+    });
+
     it('ignores unknown limits[] kinds but consumes fable weekly_scoped entries', () => {
         expect(parseUsageApiResponse(unknownKindsAndScopedResponseBody)).toEqual({
             sessionUsage: 10,
@@ -1758,19 +1822,6 @@ describe('parseUsageApiResponse limits[] fallback (#503)', () => {
             weeklySonnetUsage: 99,
             weeklySonnetResetAt: '2030-05-08T00:00:00.000Z'
         });
-    });
-
-    it('absent when fable placeholder (percent 0, no resets_at)', () => {
-        expect(parseUsageApiResponse(JSON.stringify({
-            limits: [
-                {
-                    kind: 'weekly_scoped',
-                    percent: 0,
-                    resets_at: null,
-                    scope: { model: { display_name: 'Fable' } }
-                }
-            ]
-        }))).toEqual({});
     });
 
     it('ignores weekly_scoped when no scope -> no crash', () => {

--- a/src/utils/usage-fetch.ts
+++ b/src/utils/usage-fetch.ts
@@ -148,7 +148,18 @@ function findUsageApiLimit(limits: UsageApiLimit[] | null | undefined, kind: str
 // Mirrors the null-bucket placeholder guard for #343 above: a limits[] entry
 // reporting 0% with no resets_at is not a real usage window, so the
 // limits[] fallback below must not resurrect it as a phantom 0% reading.
+//
+// weekly_scoped entries naming a concrete model are exempt: accounts with a
+// per-model quota report that entry as percent 0 / resets_at null until the
+// model is first used in the current window (resets_at fills in on first use,
+// percent stays 0), so for those the zero reading is real data - the same
+// state a null legacy per-model bucket already reports as 0 via
+// getUsageApiBucketUtilization. Accounts without the quota omit the entry
+// entirely, so this cannot resurrect a phantom window.
 function isPlaceholderUsageApiLimit(limit: UsageApiLimit): boolean {
+    if (limit.scope?.model?.display_name) {
+        return false;
+    }
     return (limit.percent ?? 0) === 0 && (limit.resets_at ?? null) === null;
 }
 


### PR DESCRIPTION
## Symptom

On an account with a Fable weekly quota that hadn't used Fable yet in the current window, the `fable-weekly-usage` widget rendered nothing — and whenever the usage API entered an error window it degraded to error text instead. That's how I noticed: my statusline showed `7d-F: [Rate limited]` for a full server-side 429 backoff window (Retry-After 3600) while the core session/weekly widgets kept rendering fine from the stdin `rate_limits` payload.

## Root cause

`/api/oauth/usage` reports a model-scoped weekly quota like this **before the scoped model has been used in the current window**:

```json
{
  "kind": "weekly_scoped", "group": "weekly", "percent": 0, "severity": "normal",
  "resets_at": null,
  "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
  "is_active": false
}
```

`isPlaceholderUsageApiLimit()` treats every `percent 0` + `resets_at null` entry as a placeholder, so this entry is discarded and `fableUsage` stays `undefined`. Two consequences:

- the widget renders blank even though the API explicitly reports the quota at 0%;
- the field never makes it into `usage.json`, so per-model widgets lean on the conclusive-absence heuristic, and on API error paths without a usable stale cache (e.g. the cached token hash no longer matches after a token refresh) they fall back to `getUsageErrorMessage()` text like `[Rate limited]` for the whole backoff window.

I verified against the live API that this state is real data rather than a placeholder — the moment the scoped model is first used in the window, `resets_at` fills in while `percent` stays `0` (same account, minutes apart):

```json
// before first Fable use this window
{ "kind": "weekly_scoped", "percent": 0, "resets_at": null, "scope": { "model": { "display_name": "Fable" } }, "is_active": false }

// right after first Fable use
{ "kind": "weekly_scoped", "percent": 0, "resets_at": "2026-07-31T11:59:59.663688+00:00", "scope": { "model": { "display_name": "Fable" } }, "is_active": false }
```

It is also the same semantic state that a `null` legacy per-model bucket already reports as `0` via `getUsageApiBucketUtilization()` (the #343 convention), so today the two encodings of "quota exists, unused" are treated inconsistently.

## Fix

Exempt entries whose scope names a concrete model from the placeholder guard: their `percent: 0` is surfaced as a real 0% reading, while the reset field stays unset until the window actually starts (the `WINDOW_RESET_FIELD_SENTINELS` mapping already handles that for requirement checks).

The guard is unchanged for unscoped `session` / `weekly_all` entries, so the #343 phantom-0% protection still applies where it was aimed. Accounts without a per-model quota omit the `weekly_scoped` entry entirely, so this cannot resurrect a phantom window — the conclusive-absence heuristic still covers that case, and keeps a dedicated test.

## Tests

- `parses an unused fable quota (0%, no resets_at) as real zero usage and serves it from cache` — probe-harness test updated from the previous placeholder-fable one; now also asserts the field round-trips through `usage.json`.
- `treats a missing fable window as conclusive when core usage fields are present` — new probe test preserving conclusive-absence coverage with a truly absent fable window.
- `treats a model-scoped weekly limit at 0% with no resets_at as real zero usage, not a placeholder` — parse-level test replacing `absent when fable placeholder (percent 0, no resets_at)`, which asserted the old behavior.
- `treats a limits[] entry with percent 0 and no resets_at as a placeholder (#343 rationale)` — unchanged and passing (unscoped guard intact).

`bun test` on the usage suites: 114 pass; 1 pre-existing environment-dependent failure on my Windows machine (`preserves root errors within a process...` times out at 5000 ms on an unmodified checkout too). `bun run lint` (tsc + eslint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
