### PR TITLE
refactor(timers): route the timer bars through the shared progress helper

### DIFF
--- a/src/widgets/BlockResetTimer.ts
+++ b/src/widgets/BlockResetTimer.ts
@@ -20,6 +20,7 @@ import {
     LOCALE_EDITOR_ACTION,
     renderUsageLocaleEditor
 } from './shared/locale-editor';
+import { makeTimerProgressBar } from './shared/progress-bar';
 import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
 import {
     TIMEZONE_EDITOR_ACTION,
@@ -45,13 +46,6 @@ import {
     toggleUsageHourFormat,
     toggleUsageInverted
 } from './shared/usage-display';
-
-function makeTimerProgressBar(percent: number, width: number): string {
-    const clampedPercent = Math.max(0, Math.min(100, percent));
-    const filledWidth = Math.floor((clampedPercent / 100) * width);
-    const emptyWidth = width - filledWidth;
-    return '█'.repeat(filledWidth) + '░'.repeat(emptyWidth);
-}
 
 const BLOCK_RESET_PREVIEW_AT = '2026-03-12T08:30:00.000Z';
 const USAGE_TIMER_LOADING_MESSAGE = '[Loading]';

--- a/src/widgets/BlockTimer.ts
+++ b/src/widgets/BlockTimer.ts
@@ -11,6 +11,7 @@ import {
     resolveUsageWindowWithFallback
 } from '../utils/usage';
 
+import { makeTimerProgressBar } from './shared/progress-bar';
 import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
 import {
     cycleUsageDisplayMode,
@@ -26,13 +27,6 @@ import {
     toggleUsageCompact,
     toggleUsageInverted
 } from './shared/usage-display';
-
-function makeTimerProgressBar(percent: number, width: number): string {
-    const clampedPercent = Math.max(0, Math.min(100, percent));
-    const filledWidth = Math.floor((clampedPercent / 100) * width);
-    const emptyWidth = width - filledWidth;
-    return '█'.repeat(filledWidth) + '░'.repeat(emptyWidth);
-}
 
 export class BlockTimerWidget implements Widget {
     getDefaultColor(): string { return 'yellow'; }

--- a/src/widgets/WeeklyResetTimer.ts
+++ b/src/widgets/WeeklyResetTimer.ts
@@ -25,6 +25,7 @@ import {
     isMetadataFlagEnabled,
     toggleMetadataFlag
 } from './shared/metadata';
+import { makeTimerProgressBar } from './shared/progress-bar';
 import { formatRawOrLabeledValue } from './shared/raw-or-labeled';
 import {
     TIMEZONE_EDITOR_ACTION,
@@ -53,13 +54,6 @@ import {
     toggleUsageInverted,
     toggleUsageWeekday
 } from './shared/usage-display';
-
-function makeTimerProgressBar(percent: number, width: number): string {
-    const clampedPercent = Math.max(0, Math.min(100, percent));
-    const filledWidth = Math.floor((clampedPercent / 100) * width);
-    const emptyWidth = width - filledWidth;
-    return '█'.repeat(filledWidth) + '░'.repeat(emptyWidth);
-}
 
 const WEEKLY_PREVIEW_DURATION_MS = 36.5 * 60 * 60 * 1000;
 const WEEKLY_RESET_PREVIEW_AT = '2026-03-15T08:30:00.000Z';

--- a/src/widgets/__tests__/BlockResetTimer.test.ts
+++ b/src/widgets/__tests__/BlockResetTimer.test.ts
@@ -81,6 +81,26 @@ describe('BlockResetTimerWidget', () => {
         expect(render(widget, item, { usageData: {} })).toBe('Reset [███░░░░░░░░░░░░░] 20.0%');
     });
 
+    it('rounds the progress bar fill to the nearest cell', () => {
+        const widget = new BlockResetTimerWidget();
+        const item: WidgetItem = {
+            id: 'reset',
+            type: 'reset-timer',
+            metadata: { display: 'progress-short' }
+        };
+
+        mockResolveUsageWindowWithFallback.mockReturnValue({
+            sessionDurationMs: 18000000,
+            elapsedMs: 1800000,
+            remainingMs: 16200000,
+            elapsedPercent: 10,
+            remainingPercent: 90
+        });
+
+        // 10% of 16 cells is 1.6, past the half-cell mark, so the 2nd cell fills.
+        expect(render(widget, item, { usageData: {} })).toBe('Reset [██░░░░░░░░░░░░░░] 10.0%');
+    });
+
     it('returns usage error when no timer data is available', () => {
         const widget = new BlockResetTimerWidget();
 

--- a/src/widgets/__tests__/BlockTimer.test.ts
+++ b/src/widgets/__tests__/BlockTimer.test.ts
@@ -72,6 +72,26 @@ describe('BlockTimerWidget', () => {
         expect(render(widget, item, { usageData: {} })).toBe('Block [████░░░░░░░░░░░░] 25.0%');
     });
 
+    it('rounds the progress bar fill to the nearest cell', () => {
+        const widget = new BlockTimerWidget();
+        const item: WidgetItem = {
+            id: 'block',
+            type: 'block-timer',
+            metadata: { display: 'progress' }
+        };
+
+        mockResolveUsageWindowWithFallback.mockReturnValue({
+            sessionDurationMs: 18000000,
+            elapsedMs: 13302000,
+            remainingMs: 4698000,
+            elapsedPercent: 73.9,
+            remainingPercent: 26.1
+        });
+
+        // 73.9% of 32 cells is 23.648, past the half-cell mark, so the 24th cell fills.
+        expect(render(widget, item, { usageData: {} })).toBe(`Block [${'█'.repeat(24)}${'░'.repeat(8)}] 73.9%`);
+    });
+
     it('renders empty values when no usage or fallback data exists', () => {
         const widget = new BlockTimerWidget();
 

--- a/src/widgets/__tests__/WeeklyResetTimer.test.ts
+++ b/src/widgets/__tests__/WeeklyResetTimer.test.ts
@@ -112,6 +112,26 @@ describe('WeeklyResetTimerWidget', () => {
         expect(render(widget, item, { usageData: {} })).toBe('Weekly Reset [███░░░░░░░░░░░░░] 20.0%');
     });
 
+    it('rounds the progress bar fill to the nearest cell', () => {
+        const widget = new WeeklyResetTimerWidget();
+        const item: WidgetItem = {
+            id: 'weekly-reset',
+            type: 'weekly-reset-timer',
+            metadata: { display: 'progress-short' }
+        };
+
+        mockResolveWeeklyUsageWindow.mockReturnValue({
+            sessionDurationMs: 604800000,
+            elapsedMs: 211680000,
+            remainingMs: 393120000,
+            elapsedPercent: 35,
+            remainingPercent: 65
+        });
+
+        // 35% of 16 cells is 5.6, past the half-cell mark, so the 6th cell fills.
+        expect(render(widget, item, { usageData: {} })).toBe('Weekly Reset [██████░░░░░░░░░░] 35.0%');
+    });
+
     it('returns usage error when no weekly reset data is available', () => {
         const widget = new WeeklyResetTimerWidget();
 


### PR DESCRIPTION
`shared/progress-bar.ts` fills with `Math.round`. `BlockTimer.ts`,
`BlockResetTimer.ts` and `WeeklyResetTimer.ts` each carried a byte-identical
private `makeTimerProgressBar` that fills with `Math.floor`. Six other widgets
already use the shared helper, as do `makeSliderBar` and `makeUsageProgressBar`,
so floor was the only outlier in the repo.

The three copies are gone and all six call sites use the shared helper.

**This changes rendered output.** The bar shifts by one cell for roughly half of
all percentages, whenever the fill lands past the half-cell mark. BlockTimer's
own preview value is the clearest example: 73.9% of 32 cells is 23.648, so it
goes from 23 filled cells to 24. That widget already called the round-based
`makeSliderBar` for slider mode, so it was applying two rounding rules across its
own display modes.

Each of the three widgets gains a case pinning a value where floor and round
disagree (10% of 16, 73.9% of 32, 35% of 16). Putting `Math.floor` back in the
shared helper fails all three, so they are not retrofitted to current output.
Every pre-existing bar assertion is invariant under both rules, which is why none
of them needed touching.

The shared helper's cursor option stays inert here: all six timer call sites pass
no options, so `cursorPos` is `-1` and the loop reproduces the old
`'█'.repeat(filled) + '░'.repeat(width - filled)` exactly. Bar length is still
exactly `width`, so truncation, powerline width math and flex separators see no
change.

Tested: `bun run lint` clean; `bun test` 1870 pass, plus the one
`global-command-resolution` failure `main` already has on this host.
