### PR TITLE
feat(tui): Tab to flip between a line's items and colors editors

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -64,6 +64,7 @@ import {
     installPowerlineFonts,
     type PowerlineFontStatus
 } from '../utils/powerline';
+import { arePerLineColorsThemeManaged } from '../utils/powerline-settings';
 import { getPackageVersion } from '../utils/terminal';
 import {
     checkForUpdates,
@@ -1204,6 +1205,7 @@ export const App: React.FC = () => {
                         }}
                         lineNumber={selectedLine + 1}
                         settings={settings}
+                        onSwitchToColors={arePerLineColorsThemeManaged(settings) ? undefined : () => { setScreen('colors'); }}
                     />
                 )}
                 {screen === 'colorLines' && (

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1192,6 +1192,12 @@ export const App: React.FC = () => {
                         initialSelection={menuSelections.lines}
                         title='Select Line to Edit Items'
                         allowEditing={true}
+                        onSwitchScreen={arePerLineColorsThemeManaged(settings)
+                            ? undefined
+                            : (index) => {
+                                setMenuSelections(prev => ({ ...prev, lines: index }));
+                                setScreen('colorLines');
+                            }}
                     />
                 )}
                 {screen === 'items' && (
@@ -1227,6 +1233,10 @@ export const App: React.FC = () => {
                         blockIfPowerlineActive={true}
                         settings={settings}
                         allowEditing={false}
+                        onSwitchScreen={(index) => {
+                            setMenuSelections(prev => ({ ...prev, lines: index }));
+                            setScreen('lines');
+                        }}
                     />
                 )}
                 {screen === 'colors' && (

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1244,6 +1244,7 @@ export const App: React.FC = () => {
                             // Go back to line selection for colors
                             setScreen('colorLines');
                         }}
+                        onSwitchToItems={() => { setScreen('items'); }}
                     />
                 )}
                 {screen === 'terminalConfig' && (

--- a/src/tui/components/ColorMenu.tsx
+++ b/src/tui/components/ColorMenu.tsx
@@ -35,9 +35,10 @@ export interface ColorMenuProps {
     settings: Settings;
     onUpdate: (widgets: WidgetItem[]) => void;
     onBack: () => void;
+    onSwitchToItems?: () => void;
 }
 
-export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settings, onUpdate, onBack }) => {
+export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settings, onUpdate, onBack, onSwitchToItems }) => {
     const [showSeparators, setShowSeparators] = useState(false);
     const [hexInputMode, setHexInputMode] = useState(false);
     const [hexInput, setHexInput] = useState('');
@@ -222,7 +223,9 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
         }
 
         // Normal keyboard handling when there are items
-        if (key.escape) {
+        if (key.tab) {
+            onSwitchToItems?.();
+        } else if (key.escape) {
             if (editingBackground) {
                 setEditingBackground(false);
             } else {
@@ -593,6 +596,7 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
                         {!editingBackground && settings.colorLevel >= 2 ? ' (g)radient,' : ''}
                         {' '}
                         (r)eset, (c)lear all, ESC to go back
+                        {onSwitchToItems ? ', Tab edit items' : ''}
                     </Text>
                     {!settings.powerline.enabled && !settings.defaultSeparator && (
                         <Text dimColor>

--- a/src/tui/components/ColorMenu.tsx
+++ b/src/tui/components/ColorMenu.tsx
@@ -595,8 +595,10 @@ export const ColorMenu: React.FC<ColorMenuProps> = ({ widgets, lineIndex, settin
                         {settings.colorLevel === 3 ? ' (h)ex,' : settings.colorLevel === 2 ? ' (a)nsi256,' : ''}
                         {!editingBackground && settings.colorLevel >= 2 ? ' (g)radient,' : ''}
                         {' '}
-                        (r)eset, (c)lear all, ESC to go back
-                        {onSwitchToItems ? ', Tab edit items' : ''}
+                        (r)eset, (c)lear all,
+                        {onSwitchToItems ? ' Tab edit items,' : ''}
+                        {' '}
+                        ESC to go back
                     </Text>
                     {!settings.powerline.enabled && !settings.defaultSeparator && (
                         <Text dimColor>

--- a/src/tui/components/ItemsEditor.tsx
+++ b/src/tui/components/ItemsEditor.tsx
@@ -40,6 +40,7 @@ export interface ItemsEditorProps {
     onBack: () => void;
     lineNumber: number;
     settings: Settings;
+    onSwitchToColors?: () => void;
 }
 
 function isMergedIntoPreviousWidget(widgets: WidgetItem[], index: number): boolean {
@@ -50,7 +51,7 @@ function isMergedIntoPreviousWidget(widgets: WidgetItem[], index: number): boole
     return Boolean(widgets[index - 1]?.merge);
 }
 
-export const ItemsEditor: React.FC<ItemsEditorProps> = ({ widgets, onUpdate, onBack, lineNumber, settings }) => {
+export const ItemsEditor: React.FC<ItemsEditorProps> = ({ widgets, onUpdate, onBack, lineNumber, settings, onSwitchToColors }) => {
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [moveMode, setMoveMode] = useState(false);
     const [customEditorWidget, setCustomEditorWidget] = useState<CustomEditorWidgetState | null>(null);
@@ -235,7 +236,8 @@ export const ItemsEditor: React.FC<ItemsEditorProps> = ({ widgets, onUpdate, onB
             openWidgetPicker,
             getCustomKeybindsForWidget,
             setCustomEditorWidget,
-            getUniqueBackgroundColor
+            getUniqueBackgroundColor,
+            onSwitchToColors
         });
     });
 
@@ -302,6 +304,9 @@ export const ItemsEditor: React.FC<ItemsEditorProps> = ({ widgets, onUpdate, onB
     }
     if (canExcludeAlign) {
         helpText += ', e(x)clude align';
+    }
+    if (onSwitchToColors) {
+        helpText += ', Tab edit colors';
     }
     helpText += ', ESC back';
 

--- a/src/tui/components/LineSelector.tsx
+++ b/src/tui/components/LineSelector.tsx
@@ -12,6 +12,7 @@ import React, {
 
 import type { Settings } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
+import { arePerLineColorsThemeManaged } from '../../utils/powerline-settings';
 
 import { ConfirmDialog } from './ConfirmDialog';
 import { List } from './List';
@@ -76,13 +77,8 @@ const LineSelector: React.FC<LineSelectorProps> = ({
     };
 
     // Check if powerline theme is managing colors
-    const powerlineEnabled = settings ? settings.powerline.enabled : false;
     const powerlineTheme = settings ? settings.powerline.theme : undefined;
-    const isThemeManaged
-        = blockIfPowerlineActive
-            && powerlineEnabled
-            && powerlineTheme
-            && powerlineTheme !== 'custom';
+    const isThemeManaged = blockIfPowerlineActive && !!settings && arePerLineColorsThemeManaged(settings);
 
     // Handle keyboard input
     useInput((input, key) => {
@@ -157,8 +153,8 @@ const LineSelector: React.FC<LineSelectorProps> = ({
                     <Text color='yellow'>
                         ⚠ Colors are currently managed by the Powerline theme:
                         {' '
-                            + powerlineTheme.charAt(0).toUpperCase()
-                            + powerlineTheme.slice(1)}
+                            + (powerlineTheme ?? '').charAt(0).toUpperCase()
+                            + (powerlineTheme ?? '').slice(1)}
                     </Text>
                 </Box>
                 <Box marginTop={1}>

--- a/src/tui/components/LineSelector.tsx
+++ b/src/tui/components/LineSelector.tsx
@@ -27,6 +27,7 @@ interface LineSelectorProps {
     blockIfPowerlineActive?: boolean;
     settings?: Settings;
     allowEditing?: boolean;
+    onSwitchScreen?: (currentIndex: number) => void;
 }
 
 const LineSelector: React.FC<LineSelectorProps> = ({
@@ -38,7 +39,8 @@ const LineSelector: React.FC<LineSelectorProps> = ({
     title,
     blockIfPowerlineActive = false,
     settings,
-    allowEditing = false
+    allowEditing = false,
+    onSwitchScreen
 }) => {
     const [selectedIndex, setSelectedIndex] = useState(initialSelection);
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -137,6 +139,11 @@ const LineSelector: React.FC<LineSelectorProps> = ({
                     setMoveMode(true);
                 }
                 return;
+        }
+
+        if (key.tab) {
+            onSwitchScreen?.(selectedIndex);
+            return;
         }
 
         if (key.escape) {
@@ -245,9 +252,9 @@ const LineSelector: React.FC<LineSelectorProps> = ({
                     <Text dimColor>
                         {allowEditing ? (
                             localLines.length > 1
-                                ? '(a) to append new line, (d) to delete line, (m) to move line, ESC to go back'
-                                : '(a) to append new line, ESC to go back'
-                        ) : 'ESC to go back'}
+                                ? `(a) to append new line, (d) to delete line, (m) to move line${onSwitchScreen ? ', Tab switch items/colors' : ''}, ESC to go back`
+                                : `(a) to append new line${onSwitchScreen ? ', Tab switch items/colors' : ''}, ESC to go back`
+                        ) : `${onSwitchScreen ? 'Tab switch items/colors, ' : ''}ESC to go back`}
                     </Text>
                 )}
 

--- a/src/tui/components/__tests__/ColorMenu.test.tsx
+++ b/src/tui/components/__tests__/ColorMenu.test.tsx
@@ -119,4 +119,43 @@ describe('ColorMenu', () => {
             stderr.destroy();
         }
     });
+
+    it('switches to the items editor on Tab', async () => {
+        const stdin = createMockStdin();
+        const stdout = createMockStdout();
+        const stderr = createMockStdout();
+        const onSwitchToItems = vi.fn();
+
+        const instance = render(
+            React.createElement(ColorMenu, {
+                widgets: [{ id: '1', type: 'cache-hit-rate' }],
+                settings: DEFAULT_SETTINGS,
+                onUpdate: vi.fn(),
+                onBack: vi.fn(),
+                onSwitchToItems
+            }),
+            {
+                stdin,
+                stdout,
+                stderr,
+                debug: true,
+                exitOnCtrlC: false,
+                patchConsole: false
+            }
+        );
+
+        try {
+            await flushInk();
+            stdin.write('\t');
+            await flushInk();
+
+            expect(onSwitchToItems).toHaveBeenCalledTimes(1);
+        } finally {
+            instance.unmount();
+            instance.cleanup();
+            stdin.destroy();
+            stdout.destroy();
+            stderr.destroy();
+        }
+    });
 });

--- a/src/tui/components/__tests__/ColorMenu.test.tsx
+++ b/src/tui/components/__tests__/ColorMenu.test.tsx
@@ -150,6 +150,48 @@ describe('ColorMenu', () => {
             await flushInk();
 
             expect(onSwitchToItems).toHaveBeenCalledTimes(1);
+            expect(stdout.getOutput()).toContain('Tab edit items, ESC to go back');
+        } finally {
+            instance.unmount();
+            instance.cleanup();
+            stdin.destroy();
+            stdout.destroy();
+            stderr.destroy();
+        }
+    });
+
+    it('does not switch to items when a sub-mode is active', async () => {
+        const stdin = createMockStdin();
+        const stdout = createMockStdout();
+        const stderr = createMockStdout();
+        const onSwitchToItems = vi.fn();
+
+        const instance = render(
+            React.createElement(ColorMenu, {
+                widgets: [{ id: '1', type: 'cache-hit-rate' }],
+                settings: DEFAULT_SETTINGS,
+                onUpdate: vi.fn(),
+                onBack: vi.fn(),
+                onSwitchToItems
+            }),
+            {
+                stdin,
+                stdout,
+                stderr,
+                debug: true,
+                exitOnCtrlC: false,
+                patchConsole: false
+            }
+        );
+
+        try {
+            await flushInk();
+            stdin.write('c');
+            await flushInk();
+            stdin.write('\t');
+            await flushInk();
+
+            expect(onSwitchToItems).not.toHaveBeenCalled();
         } finally {
             instance.unmount();
             instance.cleanup();

--- a/src/tui/components/__tests__/LineSelector.test.tsx
+++ b/src/tui/components/__tests__/LineSelector.test.tsx
@@ -1,0 +1,135 @@
+import { render } from 'ink';
+import { PassThrough } from 'node:stream';
+import React from 'react';
+import {
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import type { WidgetItem } from '../../../types/Widget';
+import { LineSelector } from '../LineSelector';
+
+class MockTtyStream extends PassThrough {
+    isTTY = true;
+    columns = 160;
+    rows = 40;
+
+    setRawMode() {
+        return this;
+    }
+
+    ref() {
+        return this;
+    }
+
+    unref() {
+        return this;
+    }
+}
+
+interface CapturedWriteStream extends NodeJS.WriteStream { getOutput: () => string }
+
+function createMockStdin(): NodeJS.ReadStream {
+    return new MockTtyStream() as unknown as NodeJS.ReadStream;
+}
+
+function createMockStdout(): CapturedWriteStream {
+    const stream = new MockTtyStream();
+    const chunks: string[] = [];
+
+    stream.on('data', (chunk: Buffer | string) => {
+        chunks.push(chunk.toString());
+    });
+
+    return Object.assign(stream as unknown as NodeJS.WriteStream, {
+        getOutput() {
+            return chunks.join('');
+        }
+    });
+}
+
+function flushInk() {
+    return new Promise((resolve) => {
+        setTimeout(resolve, 25);
+    });
+}
+
+describe('LineSelector', () => {
+    const lines: WidgetItem[][] = [
+        [{ id: '1', type: 'model' }],
+        [{ id: '2', type: 'git-branch' }]
+    ];
+
+    it('switches screen on Tab, carrying the highlighted row', async () => {
+        const stdin = createMockStdin();
+        const stdout = createMockStdout();
+        const stderr = createMockStdout();
+        const onSwitchScreen = vi.fn();
+
+        const instance = render(
+            React.createElement(LineSelector, {
+                lines,
+                onSelect: vi.fn(),
+                onBack: vi.fn(),
+                onLinesUpdate: vi.fn(),
+                onSwitchScreen,
+                allowEditing: true,
+                title: 'Select Line to Edit Items'
+            }),
+            { stdin, stdout, stderr, debug: true, exitOnCtrlC: false, patchConsole: false }
+        );
+
+        try {
+            await flushInk();
+            stdin.write('\t');
+            await flushInk();
+            expect(onSwitchScreen).toHaveBeenCalledWith(0);
+
+            stdin.write('\x1B[B'); // arrow down -> highlight row 1
+            await flushInk();
+            stdin.write('\t');
+            await flushInk();
+            expect(onSwitchScreen).toHaveBeenLastCalledWith(1);
+        } finally {
+            instance.unmount();
+            instance.cleanup();
+            stdin.destroy();
+            stdout.destroy();
+            stderr.destroy();
+        }
+    });
+
+    it('does not switch on Tab when no handler is provided', async () => {
+        const stdin = createMockStdin();
+        const stdout = createMockStdout();
+        const stderr = createMockStdout();
+        const onBack = vi.fn();
+
+        const instance = render(
+            React.createElement(LineSelector, {
+                lines,
+                onSelect: vi.fn(),
+                onBack,
+                onLinesUpdate: vi.fn(),
+                allowEditing: true,
+                title: 'Select Line to Edit Items'
+            }),
+            { stdin, stdout, stderr, debug: true, exitOnCtrlC: false, patchConsole: false }
+        );
+
+        try {
+            await flushInk();
+            stdin.write('\t');
+            await flushInk();
+            expect(onBack).not.toHaveBeenCalled();
+        } finally {
+            instance.unmount();
+            instance.cleanup();
+            stdin.destroy();
+            stdout.destroy();
+            stderr.destroy();
+        }
+    });
+});

--- a/src/tui/components/items-editor/__tests__/input-handlers.test.ts
+++ b/src/tui/components/items-editor/__tests__/input-handlers.test.ts
@@ -833,6 +833,9 @@ describe('items-editor input handlers', () => {
 
     it('does nothing on Tab when no colors switch is available', () => {
         const onBack = vi.fn();
+        const onUpdate = vi.fn();
+        const openWidgetPicker = vi.fn();
+        const setMoveMode = vi.fn();
 
         handleNormalInputMode({
             input: '',
@@ -841,16 +844,19 @@ describe('items-editor input handlers', () => {
             selectedIndex: 0,
             separatorChars: ['|'],
             onBack,
-            onUpdate: vi.fn(),
+            onUpdate,
             setSelectedIndex: vi.fn(),
-            setMoveMode: vi.fn(),
+            setMoveMode,
             setShowClearConfirm: vi.fn(),
-            openWidgetPicker: vi.fn(),
+            openWidgetPicker,
             getCustomKeybindsForWidget: (widgetImpl, widget) => widgetImpl.getCustomKeybinds ? widgetImpl.getCustomKeybinds(widget) : [],
             setCustomEditorWidget: vi.fn()
         });
 
         expect(onBack).not.toHaveBeenCalled();
+        expect(onUpdate).not.toHaveBeenCalled();
+        expect(openWidgetPicker).not.toHaveBeenCalled();
+        expect(setMoveMode).not.toHaveBeenCalled();
     });
 
     describe('k shortcut - clone widget', () => {

--- a/src/tui/components/items-editor/__tests__/input-handlers.test.ts
+++ b/src/tui/components/items-editor/__tests__/input-handlers.test.ts
@@ -808,6 +808,51 @@ describe('items-editor input handlers', () => {
         expect(customEditorState?.widget?.type).toBe('skills');
     });
 
+    it('switches to colors on Tab in normal mode', () => {
+        const onSwitchToColors = vi.fn();
+
+        handleNormalInputMode({
+            input: '',
+            key: { tab: true },
+            widgets: [{ id: '1', type: 'tokens-input' }],
+            selectedIndex: 0,
+            separatorChars: ['|'],
+            onBack: vi.fn(),
+            onUpdate: vi.fn(),
+            setSelectedIndex: vi.fn(),
+            setMoveMode: vi.fn(),
+            setShowClearConfirm: vi.fn(),
+            openWidgetPicker: vi.fn(),
+            getCustomKeybindsForWidget: (widgetImpl, widget) => widgetImpl.getCustomKeybinds ? widgetImpl.getCustomKeybinds(widget) : [],
+            setCustomEditorWidget: vi.fn(),
+            onSwitchToColors
+        });
+
+        expect(onSwitchToColors).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing on Tab when no colors switch is available', () => {
+        const onBack = vi.fn();
+
+        handleNormalInputMode({
+            input: '',
+            key: { tab: true },
+            widgets: [{ id: '1', type: 'tokens-input' }],
+            selectedIndex: 0,
+            separatorChars: ['|'],
+            onBack,
+            onUpdate: vi.fn(),
+            setSelectedIndex: vi.fn(),
+            setMoveMode: vi.fn(),
+            setShowClearConfirm: vi.fn(),
+            openWidgetPicker: vi.fn(),
+            getCustomKeybindsForWidget: (widgetImpl, widget) => widgetImpl.getCustomKeybinds ? widgetImpl.getCustomKeybinds(widget) : [],
+            setCustomEditorWidget: vi.fn()
+        });
+
+        expect(onBack).not.toHaveBeenCalled();
+    });
+
     describe('k shortcut - clone widget', () => {
         it('inserts clone after source and moves selection to clone', () => {
             const widgets: WidgetItem[] = [

--- a/src/tui/components/items-editor/input-handlers.ts
+++ b/src/tui/components/items-editor/input-handlers.ts
@@ -349,6 +349,7 @@ export interface HandleNormalInputModeArgs {
     getCustomKeybindsForWidget: (widgetImpl: Widget, widget: WidgetItem) => CustomKeybind[];
     setCustomEditorWidget: (state: CustomEditorWidgetState | null) => void;
     getUniqueBackgroundColor?: (insertIndex: number) => string | undefined;
+    onSwitchToColors?: () => void;
 }
 
 export function handleNormalInputMode({
@@ -366,7 +367,8 @@ export function handleNormalInputMode({
     openWidgetPicker,
     getCustomKeybindsForWidget,
     setCustomEditorWidget,
-    getUniqueBackgroundColor
+    getUniqueBackgroundColor,
+    onSwitchToColors
 }: HandleNormalInputModeArgs): void {
     if (key.upArrow && widgets.length > 0) {
         setSelectedIndex(selectedIndex - 1 < 0 ? widgets.length - 1 : selectedIndex - 1);
@@ -470,6 +472,8 @@ export function handleNormalInputMode({
             }
             onUpdate(newWidgets);
         }
+    } else if (key.tab) {
+        onSwitchToColors?.();
     } else if (key.escape) {
         onBack();
     } else if (widgets.length > 0) {

--- a/src/utils/__tests__/powerline-settings.test.ts
+++ b/src/utils/__tests__/powerline-settings.test.ts
@@ -6,7 +6,10 @@ import {
 
 import { DEFAULT_SETTINGS } from '../../types/Settings';
 import type { WidgetItem } from '../../types/Widget';
-import { buildEnabledPowerlineSettings } from '../powerline-settings';
+import {
+    arePerLineColorsThemeManaged,
+    buildEnabledPowerlineSettings
+} from '../powerline-settings';
 
 describe('powerline settings helpers', () => {
     it('enables powerline with default theme and default padding', () => {
@@ -69,5 +72,30 @@ describe('powerline settings helpers', () => {
 
         const updated = buildEnabledPowerlineSettings(settings, false);
         expect(updated.lines[0]?.map(item => item.type)).toEqual(['model', 'separator', 'context-length']);
+    });
+});
+
+function withPowerline(enabled: boolean, theme: string | undefined) {
+    return {
+        ...DEFAULT_SETTINGS,
+        powerline: { ...DEFAULT_SETTINGS.powerline, enabled, theme }
+    };
+}
+
+describe('arePerLineColorsThemeManaged', () => {
+    it('is true when powerline is enabled with a preset theme', () => {
+        expect(arePerLineColorsThemeManaged(withPowerline(true, 'nord'))).toBe(true);
+    });
+
+    it('is false for the custom theme', () => {
+        expect(arePerLineColorsThemeManaged(withPowerline(true, 'custom'))).toBe(false);
+    });
+
+    it('is false when the theme is undefined (the default)', () => {
+        expect(arePerLineColorsThemeManaged(withPowerline(true, undefined))).toBe(false);
+    });
+
+    it('is false when powerline is disabled', () => {
+        expect(arePerLineColorsThemeManaged(withPowerline(false, 'nord'))).toBe(false);
     });
 });

--- a/src/utils/powerline-settings.ts
+++ b/src/utils/powerline-settings.ts
@@ -30,3 +30,9 @@ export function buildEnabledPowerlineSettings(settings: Settings, removeManualSe
         lines
     };
 }
+
+export function arePerLineColorsThemeManaged(settings: Settings): boolean {
+    return settings.powerline.enabled
+        && !!settings.powerline.theme
+        && settings.powerline.theme !== 'custom';
+}


### PR DESCRIPTION
## What

In the configurator, press `Tab` to jump straight between a line's **items editor** and its **color editor** — no more escaping to the main menu and re-selecting the line. `Tab` toggles; `Esc` is unchanged.

## Why

Editing a line's widgets and editing its colors are separate screens reached from two different main-menu entries. Switching between them for the *same* line means escaping all the way out and re-navigating each time. This adds a direct toggle that stays on the current line.

## How

Both editors already render off `App`'s shared `selectedLine`, so the flip is just `setScreen('colors')` ⇄ `setScreen('items')` with `selectedLine` left untouched:

- `ItemsEditor` gains an optional `onSwitchToColors` callback, bound to `Tab` in its normal-mode input handler. `App` passes it — gated off when a powerline preset theme manages colors (a new `arePerLineColorsThemeManaged(settings)` helper that mirrors the existing "Select Line to Edit Colors" `isThemeManaged` gate).
- `ColorMenu` gains an optional `onSwitchToItems` callback, bound to `Tab` in its normal-mode key chain. Always available (the color editor is only reachable when colors aren't theme-managed).
- `Tab` fires **only** in each editor's normal mode — never inside the widget picker/search/move modes or the hex/ansi256/gradient color-entry sub-modes.
- `Tab` also flips the **line-selector** screens — "Select Line to Edit Items" ⇄ "Select Line to Edit Colors" (a new `onSwitchScreen` prop on `LineSelector`), carrying the highlighted row (both selectors already share the same cursor slot) and gated the same way under powerline preset themes. So the items/colors flow is Tab-flippable at both the picker and the editor level.
- Footer hints added to both editors and both selectors.

## Tests

- `arePerLineColorsThemeManaged` predicate unit tests (existing `powerline-settings` tests preserved).
- `input-handlers`: `Tab` switches to colors from normal mode.
- `ColorMenu`: `Tab` switches to items, driven via a real stdin keypress through the existing mock-TTY harness.
- `LineSelector`: `Tab` flips the selector screen and carries the highlighted row; no-op when no handler is wired.
- Full suite + `bun run lint` (`--max-warnings=0`) clean.
