### PR TITLE
fix(git): time out cached commands

### DIFF
--- a/src/utils/__tests__/git-test-helpers.ts
+++ b/src/utils/__tests__/git-test-helpers.ts
@@ -4,6 +4,7 @@ export function expectGitExecOptions(options: unknown, cwd?: string): void {
     expect(options).toEqual(expect.objectContaining({
         encoding: 'utf8',
         stdio: ['pipe', 'pipe', 'ignore'],
+        timeout: 5_000,
         windowsHide: true,
         ...(cwd ? { cwd } : {})
     }));

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -38,6 +38,7 @@ interface PersistentGitCache {
 
 const DEFAULT_GIT_CACHE_TTL_SECONDS = 5;
 const GIT_CACHE_SCHEMA_VERSION = 1 as const;
+const GIT_COMMAND_TIMEOUT_MS = 5_000;
 
 // In-process cache keeps cwd in the key; the persistent cache stores cwd once
 // at the file level and keys entries by command.
@@ -331,6 +332,7 @@ export function runGitArgs(args: string[], context: RenderContext, cacheCommand?
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'ignore'],
             env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
+            timeout: GIT_COMMAND_TIMEOUT_MS,
             windowsHide: true,
             ...(cwd ? { cwd } : {})
         }).trimEnd();


### PR DESCRIPTION
## What changed

Git widgets use the cached command runner in `src/utils/git.ts`. On a cache miss, that runner called Git without a timeout, so a blocked Git process could also block the status line indefinitely.

This applies the existing five-second command boundary used by the other Git runner. A timeout still follows the current failure path: the widget gets no Git value and the result is cached normally.

## Validation

- `bun test src/utils/__tests__/git.test.ts` (53 passed)
- `bun test` (1,868 passed)
- `bun run lint`
- `bun run build`

The regression assertion verifies that every cached Git command receives the five-second timeout. The compatibility risk is limited to Git commands that take longer than five seconds; those now return no widget value instead of blocking the process.

Fixes #557
