### PR TITLE
perf(blocks): stop rescanning every transcript when no block is found

### DIFF
--- a/src/utils/__tests__/block-cache.test.ts
+++ b/src/utils/__tests__/block-cache.test.ts
@@ -289,3 +289,98 @@ describe('getCachedBlockMetrics integration', () => {
         expect(result).toBeNull();
     });
 });
+
+describe('getCachedBlockMetrics negative caching', () => {
+    let tempDir: string;
+    let originalClaudeConfigDir: string | undefined;
+
+    function readRawCache(): { startTime?: string; emptyUntil?: string; configDir?: string } {
+        return JSON.parse(fs.readFileSync(getBlockCachePath(), 'utf-8')) as { startTime?: string; emptyUntil?: string; configDir?: string };
+    }
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstatusline-empty-'));
+        vi.spyOn(os, 'homedir').mockReturnValue(tempDir);
+        originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+        // A config directory with no transcripts, so a scan finds no block.
+        process.env.CLAUDE_CONFIG_DIR = path.join(tempDir, '.claude-nonexistent');
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        if (originalClaudeConfigDir === undefined) {
+            delete process.env.CLAUDE_CONFIG_DIR;
+        } else {
+            process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+        }
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('records that a scan found no block', async () => {
+        const { getCachedBlockMetrics } = await import('../jsonl');
+
+        expect(getCachedBlockMetrics()).toBeNull();
+
+        const cached = readRawCache();
+        expect(typeof cached.emptyUntil).toBe('string');
+        expect(cached.configDir).toBe(path.resolve(process.env.CLAUDE_CONFIG_DIR ?? ''));
+
+        // The record bounds how late a new block can be reported, so it has to
+        // stand long enough to be worth having and short enough to go unnoticed.
+        const standsForMs = new Date(cached.emptyUntil ?? '').getTime() - Date.now();
+        expect(standsForMs).toBeGreaterThan(0);
+        expect(standsForMs).toBeLessThanOrEqual(5 * 60 * 1000);
+    });
+
+    it('does not scan again while the record stands', async () => {
+        const { getCachedBlockMetrics } = await import('../jsonl');
+
+        expect(getCachedBlockMetrics()).toBeNull();
+        const first = readRawCache().emptyUntil;
+
+        expect(getCachedBlockMetrics()).toBeNull();
+
+        // A second scan would have written a later instant.
+        expect(readRawCache().emptyUntil).toBe(first);
+    });
+
+    it('scans again once the record lapses', async () => {
+        const { getCachedBlockMetrics } = await import('../jsonl');
+        const cachePath = getBlockCachePath();
+        fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+        const lapsed = new Date(Date.now() - 1000).toISOString();
+        fs.writeFileSync(cachePath, JSON.stringify({
+            emptyUntil: lapsed,
+            configDir: path.resolve(process.env.CLAUDE_CONFIG_DIR ?? '')
+        }));
+
+        expect(getCachedBlockMetrics()).toBeNull();
+
+        expect(readRawCache().emptyUntil).not.toBe(lapsed);
+    });
+
+    it('ignores a record belonging to another config directory', async () => {
+        const { getCachedBlockMetrics } = await import('../jsonl');
+        const otherProfile = path.join(tempDir, '.claude-other');
+        const cachePath = getBlockCachePath();
+        fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+        const foreign = new Date(Date.now() + 60_000).toISOString();
+        fs.writeFileSync(cachePath, JSON.stringify({ emptyUntil: foreign, configDir: path.resolve(otherProfile) }));
+
+        expect(getCachedBlockMetrics()).toBeNull();
+
+        // The foreign record was not trusted, so a scan ran and replaced it.
+        expect(readRawCache().configDir).toBe(path.resolve(process.env.CLAUDE_CONFIG_DIR ?? ''));
+    });
+
+    it('prefers a live block over a stale no-block record', async () => {
+        const { getCachedBlockMetrics, writeBlockCache } = await import('../jsonl');
+        const startTime = new Date();
+        startTime.setHours(startTime.getHours() - 2);
+        writeBlockCache(startTime);
+
+        const result = getCachedBlockMetrics();
+
+        expect(result?.startTime.getTime()).toBe(startTime.getTime());
+    });
+});

--- a/src/utils/__tests__/global-command-resolution.test.ts
+++ b/src/utils/__tests__/global-command-resolution.test.ts
@@ -82,7 +82,7 @@ describe('global command resolution', () => {
         expect(execFileSyncSpy).toHaveBeenCalled();
         for (const call of execFileSyncSpy.mock.calls) {
             const options = call[2] as { stdio?: string[] };
-            expect(options.stdio).toEqual(['ignore', 'pipe', 'ignore']);
+            expect(options.stdio?.[2]).toBe('ignore');
         }
     });
 

--- a/src/utils/jsonl-cache.ts
+++ b/src/utils/jsonl-cache.ts
@@ -14,9 +14,23 @@ const mkdirSync = fs.mkdirSync;
 const existsSync = fs.existsSync;
 
 interface BlockCache {
-    startTime: string;
+    startTime?: string;
+    /** When set and still in the future, a scan already ran and found no block. */
+    emptyUntil?: string;
     configDir?: string;
 }
+
+/**
+ * How long a "no block found" answer stands before another scan is allowed.
+ *
+ * @remarks
+ * The scan walks every transcript under the config directory, so repeating it
+ * on each repaint is the dominant cost of a render whenever no block is
+ * active. The widgets built on this render whole minutes, so a minute of
+ * staleness costs nothing visible, and a new block can be reported at most one
+ * interval late.
+ */
+const EMPTY_RESULT_TTL_MS = 60 * 1000;
 
 function normalizeConfigDir(configDir: string): string {
     return path.resolve(configDir);
@@ -77,6 +91,68 @@ export function readBlockCache(expectedConfigDir?: string): Date | null {
 }
 
 /**
+ * Reads the instant until which a scan is known to find no block.
+ *
+ * @param expectedConfigDir - Config directory the entry must name to be trusted
+ * @returns That instant, or null when no usable entry is present
+ */
+function readEmptyBlockCache(expectedConfigDir?: string): Date | null {
+    try {
+        const normalizedExpectedConfigDir = expectedConfigDir !== undefined
+            ? normalizeConfigDir(expectedConfigDir)
+            : undefined;
+        const cachePath = getBlockCachePath(normalizedExpectedConfigDir);
+        if (!existsSync(cachePath)) {
+            return null;
+        }
+        const content = readFileSync(cachePath, 'utf-8');
+        const cache = JSON.parse(content) as BlockCache;
+        if (typeof cache.emptyUntil !== 'string') {
+            return null;
+        }
+        if (normalizedExpectedConfigDir !== undefined) {
+            if (typeof cache.configDir !== 'string') {
+                return null;
+            }
+            if (cache.configDir !== normalizedExpectedConfigDir) {
+                return null;
+            }
+        }
+        const date = new Date(cache.emptyUntil);
+        if (Number.isNaN(date.getTime())) {
+            return null;
+        }
+        return date;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Records that a scan found no block, suppressing further scans until an instant.
+ *
+ * @param emptyUntil - Instant at which scanning may resume
+ * @param configDir - Config directory the entry belongs to
+ */
+function writeEmptyBlockCache(emptyUntil: Date, configDir = getClaudeConfigDir()): void {
+    try {
+        const normalizedConfigDir = normalizeConfigDir(configDir);
+        const cachePath = getBlockCachePath(normalizedConfigDir);
+        const cacheDir = path.dirname(cachePath);
+        if (!existsSync(cacheDir)) {
+            mkdirSync(cacheDir, { recursive: true });
+        }
+        const cache: BlockCache = {
+            emptyUntil: emptyUntil.toISOString(),
+            configDir: normalizedConfigDir
+        };
+        writeFileSync(cachePath, JSON.stringify(cache), 'utf-8');
+    } catch {
+        // Silently fail - caching is best-effort
+    }
+}
+
+/**
  * Writes the block start time to the cache file
  * Creates the cache directory if it doesn't exist
  */
@@ -121,12 +197,19 @@ export function getCachedBlockMetrics(sessionDurationHours = 5): BlockMetrics | 
         // Cache expired - need to recalculate
     }
 
+    // A recent scan already found nothing; repeating it walks every transcript again
+    const emptyUntil = readEmptyBlockCache(activeConfigDir);
+    if (emptyUntil && now.getTime() < emptyUntil.getTime()) {
+        return null;
+    }
+
     // Cache miss or expired - run full calculation
     const metrics = getBlockMetrics();
 
-    // Write to cache if we found a valid block
     if (metrics) {
         writeBlockCache(metrics.startTime, activeConfigDir);
+    } else {
+        writeEmptyBlockCache(new Date(now.getTime() + EMPTY_RESULT_TTL_MS), activeConfigDir);
     }
 
     return metrics;


### PR DESCRIPTION
`getCachedBlockMetrics` writes the cache only when a scan produces metrics. `getBlockMetrics()` returns
null whenever the newest usage entry is older than the session duration, so nothing is written and the
next repaint repeats the whole scan: a glob over every `*.jsonl` under the config dir, a `statSync` on
each, then full reads of everything in the lookback window.

Corpus of 18,837 transcripts, 16.2 GiB, instant shifted so no block is active:

| | |
|---|---|
| time | 16,186 ms |
| read | 1,885 MiB |
| peak RSS | 6.4 GiB |
| result | null, nothing cached |

When a block *is* found: 19,371 ms, then 25 ms, then 0 ms. The positive path already had this; the null
path did not. Replaying 7 days of history at 15-minute intervals, 115 of 673 instants land in it.

This records the empty answer with a 60 s expiry. A new block is reported at most that late, and these
widgets render whole minutes. A positive block still wins; a record naming another config dir is still
ignored. Both helpers are module-private, so the public surface is unchanged.

Five tests. Suppression is asserted by the stored instant not moving, not by spying. Mutation-verified:
never writing the record, never reading it, ignoring expiry, ignoring config dir, letting it beat a live
block, expiry of zero, expiry of a year. All seven fail the suite.

Separate defect from #568, which fixes one transcript being read five times in a single render.
This one is about a scan result that is never cached, so it repeats every repaint. Either can land
alone; they share no file.
