### PR TITLE
docs(readme): note what the install specifier costs per repaint

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,22 @@ Other supported command values are:
 - `bunx -y ccstatusline@latest`
 - `ccstatusline` (for self-managed/global installs)
 
+The status line command runs once per repaint, so what it costs to invoke is paid over and over. Under
+Bun that cost depends on the specifier: `bunx` re-resolves the `latest` dist-tag against the registry
+on every run, because a dist-tag is not cacheable. Measured on Windows with a warm cache, median of
+five runs of `--version`, which exits before rendering:
+
+| command | median |
+| --- | --- |
+| `bunx -y ccstatusline@latest` | 633 ms |
+| `bunx -y ccstatusline@2.2.27` | 202 ms |
+| `bunx -y ccstatusline` | 207 ms |
+
+Dropping `@latest` is worth about 430 ms per repaint there. npm does not behave this way: `npx -y
+ccstatusline@latest` and `npx -y ccstatusline@2.2.27` measured 1082 ms and 1135 ms, so pinning buys
+nothing under `npx`. A **Pinned global install**, which writes `"command": "ccstatusline"`, avoids the
+resolution entirely on both.
+
 For pinned installs, launch the TUI with `npx -y ccstatusline@latest` or `bunx -y ccstatusline@latest`, then choose **Pinned global install**. The TUI pins the active version by installing it globally and writing `"command": "ccstatusline"` to `settings.json`; afterward, you can run `ccstatusline` directly to open the TUI.
 
 </details>


### PR DESCRIPTION
The status line command runs once per repaint, so its invocation cost is paid continuously. The README
lists the command forms without saying what they cost, and the form the installer writes is the most
expensive one under Bun.

Windows, warm cache, median of five `--version` runs (exits before rendering):

| command | median |
|---|---|
| `bunx -y ccstatusline@latest` | 633 ms |
| `bunx -y ccstatusline@2.2.27` | 202 ms |
| `bunx -y ccstatusline` | 207 ms |
| `npx -y ccstatusline@latest` | 1082 ms |
| `npx -y ccstatusline@2.2.27` | 1135 ms |

`bunx` re-resolves the `latest` dist-tag every run, since a dist-tag is not cacheable; it rewrites its
temp `package.json` each time, and with `BUN_CONFIG_REGISTRY` on a closed port any version specifier
fails with `ConnectionRefused downloading package manifest` while the bare specifier runs offline.

Scoped to Bun deliberately: `npx` pinned measured marginally *slower*, so this is Bun's resolution
behavior, not the dist-tag. Docs only. Single Windows host, and the note says so.
