### PR TITLE
feat(widgets): give the remaining git and jj widgets symbol slots

### DIFF
--- a/src/widgets/GitChanges.ts
+++ b/src/widgets/GitChanges.ts
@@ -1,9 +1,11 @@
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
 import type {
+    CustomKeybind,
     HideableState,
     Widget,
     WidgetEditorDisplay,
+    WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
 import {
@@ -15,6 +17,15 @@ import {
     NO_GIT_HIDEABLE_STATE,
     isHidden
 } from './shared/hideable';
+import {
+    getSlotSymbol,
+    getSymbolKeybind,
+    renderSymbolSlotsEditor,
+    type SymbolSlot
+} from './shared/symbol-override';
+
+const INSERTIONS_SLOT: SymbolSlot = { id: 'symbolInsertions', label: 'Insertions', defaultSymbol: '+' };
+const DELETIONS_SLOT: SymbolSlot = { id: 'symbolDeletions', label: 'Deletions', defaultSymbol: '-' };
 
 const ZERO_HIDEABLE_STATE: HideableState = { key: 'zero', label: 'when there are no changes' };
 
@@ -35,7 +46,7 @@ export class GitChangesWidget implements Widget {
         const hideNoGit = isHidden(item, NO_GIT_HIDEABLE_STATE.key);
 
         if (context.isPreview) {
-            return '(+42,-10)';
+            return `(${getSlotSymbol(item, INSERTIONS_SLOT)}42,${getSlotSymbol(item, DELETIONS_SLOT)}10)`;
         }
 
         if (!isInsideGitWorkTree(context)) {
@@ -47,7 +58,15 @@ export class GitChangesWidget implements Widget {
             return null;
         }
 
-        return `(+${changes.insertions},-${changes.deletions})`;
+        return `(${getSlotSymbol(item, INSERTIONS_SLOT)}${changes.insertions},${getSlotSymbol(item, DELETIONS_SLOT)}${changes.deletions})`;
+    }
+
+    getCustomKeybinds(): CustomKeybind[] {
+        return [getSymbolKeybind()];
+    }
+
+    renderEditor(props: WidgetEditorProps) {
+        return renderSymbolSlotsEditor(props, [INSERTIONS_SLOT, DELETIONS_SLOT]);
     }
 
     supportsRawValue(): boolean { return false; }

--- a/src/widgets/GitCleanStatus.ts
+++ b/src/widgets/GitCleanStatus.ts
@@ -1,9 +1,11 @@
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
 import type {
+    CustomKeybind,
     HideableState,
     Widget,
     WidgetEditorDisplay,
+    WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
 import {
@@ -15,6 +17,15 @@ import {
     NO_GIT_HIDEABLE_STATE,
     isHidden
 } from './shared/hideable';
+import {
+    getSlotSymbol,
+    getSymbolKeybind,
+    renderSymbolSlotsEditor,
+    type SymbolSlot
+} from './shared/symbol-override';
+
+const CLEAN_SLOT: SymbolSlot = { id: 'symbolClean', label: 'Clean', defaultSymbol: '✓' };
+const DIRTY_SLOT: SymbolSlot = { id: 'symbolDirty', label: 'Dirty', defaultSymbol: '✗' };
 
 export class GitCleanStatusWidget implements Widget {
     getDefaultColor(): string { return 'green'; }
@@ -33,7 +44,7 @@ export class GitCleanStatusWidget implements Widget {
         const hideNoGit = isHidden(item, NO_GIT_HIDEABLE_STATE.key);
 
         if (context.isPreview) {
-            return item.rawValue ? 'clean' : '✓';
+            return item.rawValue ? 'clean' : getSlotSymbol(item, CLEAN_SLOT);
         }
 
         if (!isInsideGitWorkTree(context)) {
@@ -45,12 +56,20 @@ export class GitCleanStatusWidget implements Widget {
             return clean ? 'clean' : 'dirty';
         }
 
-        return clean ? '✓' : '✗';
+        return clean ? getSlotSymbol(item, CLEAN_SLOT) : getSlotSymbol(item, DIRTY_SLOT);
     }
 
     private isClean(context: RenderContext): boolean {
         const status = getGitStatus(context);
         return !status.staged && !status.unstaged && !status.untracked && !status.conflicts;
+    }
+
+    getCustomKeybinds(): CustomKeybind[] {
+        return [getSymbolKeybind()];
+    }
+
+    renderEditor(props: WidgetEditorProps) {
+        return renderSymbolSlotsEditor(props, [CLEAN_SLOT, DIRTY_SLOT]);
     }
 
     supportsRawValue(): boolean { return true; }

--- a/src/widgets/GitDeletions.ts
+++ b/src/widgets/GitDeletions.ts
@@ -1,9 +1,11 @@
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
 import type {
+    CustomKeybind,
     HideableState,
     Widget,
     WidgetEditorDisplay,
+    WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
 import {
@@ -15,8 +17,15 @@ import {
     NO_GIT_HIDEABLE_STATE,
     isHidden
 } from './shared/hideable';
+import {
+    getSlotSymbol,
+    getSymbolKeybind,
+    renderSymbolSlotsEditor,
+    type SymbolSlot
+} from './shared/symbol-override';
 
 const ZERO_HIDEABLE_STATE: HideableState = { key: 'zero', label: 'when the deletion count is zero' };
+const DELETIONS_SLOT: SymbolSlot = { id: 'symbolDeletions', label: 'Deletions', defaultSymbol: '-' };
 
 export class GitDeletionsWidget implements Widget {
     getDefaultColor(): string { return 'red'; }
@@ -35,7 +44,7 @@ export class GitDeletionsWidget implements Widget {
         const hideNoGit = isHidden(item, NO_GIT_HIDEABLE_STATE.key);
 
         if (context.isPreview) {
-            return '-10';
+            return `${getSlotSymbol(item, DELETIONS_SLOT)}10`;
         }
 
         if (!isInsideGitWorkTree(context)) {
@@ -47,7 +56,15 @@ export class GitDeletionsWidget implements Widget {
             return null;
         }
 
-        return `-${changes.deletions}`;
+        return `${getSlotSymbol(item, DELETIONS_SLOT)}${changes.deletions}`;
+    }
+
+    getCustomKeybinds(): CustomKeybind[] {
+        return [getSymbolKeybind()];
+    }
+
+    renderEditor(props: WidgetEditorProps) {
+        return renderSymbolSlotsEditor(props, [DELETIONS_SLOT]);
     }
 
     supportsRawValue(): boolean { return false; }

--- a/src/widgets/GitInsertions.ts
+++ b/src/widgets/GitInsertions.ts
@@ -1,9 +1,11 @@
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
 import type {
+    CustomKeybind,
     HideableState,
     Widget,
     WidgetEditorDisplay,
+    WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
 import {
@@ -15,8 +17,15 @@ import {
     NO_GIT_HIDEABLE_STATE,
     isHidden
 } from './shared/hideable';
+import {
+    getSlotSymbol,
+    getSymbolKeybind,
+    renderSymbolSlotsEditor,
+    type SymbolSlot
+} from './shared/symbol-override';
 
 const ZERO_HIDEABLE_STATE: HideableState = { key: 'zero', label: 'when the insertion count is zero' };
+const INSERTIONS_SLOT: SymbolSlot = { id: 'symbolInsertions', label: 'Insertions', defaultSymbol: '+' };
 
 export class GitInsertionsWidget implements Widget {
     getDefaultColor(): string { return 'green'; }
@@ -35,7 +44,7 @@ export class GitInsertionsWidget implements Widget {
         const hideNoGit = isHidden(item, NO_GIT_HIDEABLE_STATE.key);
 
         if (context.isPreview) {
-            return '+42';
+            return `${getSlotSymbol(item, INSERTIONS_SLOT)}42`;
         }
 
         if (!isInsideGitWorkTree(context)) {
@@ -47,7 +56,15 @@ export class GitInsertionsWidget implements Widget {
             return null;
         }
 
-        return `+${changes.insertions}`;
+        return `${getSlotSymbol(item, INSERTIONS_SLOT)}${changes.insertions}`;
+    }
+
+    getCustomKeybinds(): CustomKeybind[] {
+        return [getSymbolKeybind()];
+    }
+
+    renderEditor(props: WidgetEditorProps) {
+        return renderSymbolSlotsEditor(props, [INSERTIONS_SLOT]);
     }
 
     supportsRawValue(): boolean { return false; }

--- a/src/widgets/JjChanges.ts
+++ b/src/widgets/JjChanges.ts
@@ -1,9 +1,11 @@
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
 import type {
+    CustomKeybind,
     HideableState,
     Widget,
     WidgetEditorDisplay,
+    WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
 import {
@@ -15,6 +17,15 @@ import {
     NO_JJ_HIDEABLE_STATE,
     isHidden
 } from './shared/hideable';
+import {
+    getSlotSymbol,
+    getSymbolKeybind,
+    renderSymbolSlotsEditor,
+    type SymbolSlot
+} from './shared/symbol-override';
+
+const INSERTIONS_SLOT: SymbolSlot = { id: 'symbolInsertions', label: 'Insertions', defaultSymbol: '+' };
+const DELETIONS_SLOT: SymbolSlot = { id: 'symbolDeletions', label: 'Deletions', defaultSymbol: '-' };
 
 export class JjChangesWidget implements Widget {
     getDefaultColor(): string { return 'yellow'; }
@@ -33,7 +44,7 @@ export class JjChangesWidget implements Widget {
         const hideNoJj = isHidden(item, NO_JJ_HIDEABLE_STATE.key);
 
         if (context.isPreview) {
-            return '(+42,-10)';
+            return `(${getSlotSymbol(item, INSERTIONS_SLOT)}42,${getSlotSymbol(item, DELETIONS_SLOT)}10)`;
         }
 
         if (!isInsideJjRepo(context)) {
@@ -42,7 +53,7 @@ export class JjChangesWidget implements Widget {
 
         const changes = this.getJjChanges(context);
         if (changes) {
-            return `(+${changes.insertions},-${changes.deletions})`;
+            return `(${getSlotSymbol(item, INSERTIONS_SLOT)}${changes.insertions},${getSlotSymbol(item, DELETIONS_SLOT)}${changes.deletions})`;
         }
 
         return hideNoJj ? null : '(no jj)';
@@ -66,6 +77,14 @@ export class JjChangesWidget implements Widget {
         }
 
         return { insertions: totalInsertions, deletions: totalDeletions };
+    }
+
+    getCustomKeybinds(): CustomKeybind[] {
+        return [getSymbolKeybind()];
+    }
+
+    renderEditor(props: WidgetEditorProps) {
+        return renderSymbolSlotsEditor(props, [INSERTIONS_SLOT, DELETIONS_SLOT]);
     }
 
     supportsRawValue(): boolean { return false; }

--- a/src/widgets/JjDeletions.ts
+++ b/src/widgets/JjDeletions.ts
@@ -1,9 +1,11 @@
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
 import type {
+    CustomKeybind,
     HideableState,
     Widget,
     WidgetEditorDisplay,
+    WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
 import {
@@ -15,6 +17,14 @@ import {
     NO_JJ_HIDEABLE_STATE,
     isHidden
 } from './shared/hideable';
+import {
+    getSlotSymbol,
+    getSymbolKeybind,
+    renderSymbolSlotsEditor,
+    type SymbolSlot
+} from './shared/symbol-override';
+
+const DELETIONS_SLOT: SymbolSlot = { id: 'symbolDeletions', label: 'Deletions', defaultSymbol: '-' };
 
 export class JjDeletionsWidget implements Widget {
     getDefaultColor(): string { return 'red'; }
@@ -33,7 +43,7 @@ export class JjDeletionsWidget implements Widget {
         const hideNoJj = isHidden(item, NO_JJ_HIDEABLE_STATE.key);
 
         if (context.isPreview) {
-            return '-10';
+            return `${getSlotSymbol(item, DELETIONS_SLOT)}10`;
         }
 
         if (!isInsideJjRepo(context)) {
@@ -41,7 +51,15 @@ export class JjDeletionsWidget implements Widget {
         }
 
         const changes = getJjChangeCounts(context);
-        return `-${changes.deletions}`;
+        return `${getSlotSymbol(item, DELETIONS_SLOT)}${changes.deletions}`;
+    }
+
+    getCustomKeybinds(): CustomKeybind[] {
+        return [getSymbolKeybind()];
+    }
+
+    renderEditor(props: WidgetEditorProps) {
+        return renderSymbolSlotsEditor(props, [DELETIONS_SLOT]);
     }
 
     supportsRawValue(): boolean { return false; }

--- a/src/widgets/JjInsertions.ts
+++ b/src/widgets/JjInsertions.ts
@@ -1,9 +1,11 @@
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
 import type {
+    CustomKeybind,
     HideableState,
     Widget,
     WidgetEditorDisplay,
+    WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
 import {
@@ -15,6 +17,14 @@ import {
     NO_JJ_HIDEABLE_STATE,
     isHidden
 } from './shared/hideable';
+import {
+    getSlotSymbol,
+    getSymbolKeybind,
+    renderSymbolSlotsEditor,
+    type SymbolSlot
+} from './shared/symbol-override';
+
+const INSERTIONS_SLOT: SymbolSlot = { id: 'symbolInsertions', label: 'Insertions', defaultSymbol: '+' };
 
 export class JjInsertionsWidget implements Widget {
     getDefaultColor(): string { return 'green'; }
@@ -33,7 +43,7 @@ export class JjInsertionsWidget implements Widget {
         const hideNoJj = isHidden(item, NO_JJ_HIDEABLE_STATE.key);
 
         if (context.isPreview) {
-            return '+42';
+            return `${getSlotSymbol(item, INSERTIONS_SLOT)}42`;
         }
 
         if (!isInsideJjRepo(context)) {
@@ -41,7 +51,15 @@ export class JjInsertionsWidget implements Widget {
         }
 
         const changes = getJjChangeCounts(context);
-        return `+${changes.insertions}`;
+        return `${getSlotSymbol(item, INSERTIONS_SLOT)}${changes.insertions}`;
+    }
+
+    getCustomKeybinds(): CustomKeybind[] {
+        return [getSymbolKeybind()];
+    }
+
+    renderEditor(props: WidgetEditorProps) {
+        return renderSymbolSlotsEditor(props, [INSERTIONS_SLOT]);
     }
 
     supportsRawValue(): boolean { return false; }

--- a/src/widgets/JjRevision.ts
+++ b/src/widgets/JjRevision.ts
@@ -1,9 +1,11 @@
 import type { RenderContext } from '../types/RenderContext';
 import type { Settings } from '../types/Settings';
 import type {
+    CustomKeybind,
     HideableState,
     Widget,
     WidgetEditorDisplay,
+    WidgetEditorProps,
     WidgetItem
 } from '../types/Widget';
 import {
@@ -15,6 +17,13 @@ import {
     NO_JJ_HIDEABLE_STATE,
     isHidden
 } from './shared/hideable';
+import {
+    formatSymbolPrefix,
+    getSymbolKeybind,
+    renderSymbolOverrideEditor
+} from './shared/symbol-override';
+
+const DEFAULT_SYMBOL = '';
 
 export class JjRevisionWidget implements Widget {
     getDefaultColor(): string { return 'green'; }
@@ -31,21 +40,22 @@ export class JjRevisionWidget implements Widget {
 
     render(item: WidgetItem, context: RenderContext, _settings: Settings): string | null {
         const hideNoJj = isHidden(item, NO_JJ_HIDEABLE_STATE.key);
+        const prefix = formatSymbolPrefix(item, DEFAULT_SYMBOL);
 
         if (context.isPreview) {
-            return item.rawValue ? 'kkmpptxz' : ' kkmpptxz';
+            return item.rawValue ? 'kkmpptxz' : `${prefix}kkmpptxz`;
         }
 
         if (!isInsideJjRepo(context)) {
-            return hideNoJj ? null : ' no jj';
+            return hideNoJj ? null : `${prefix}no jj`;
         }
 
         const changeId = this.getJjRevision(context);
         if (changeId) {
-            return item.rawValue ? changeId : ` ${changeId}`;
+            return item.rawValue ? changeId : `${prefix}${changeId}`;
         }
 
-        return hideNoJj ? null : ' no jj';
+        return hideNoJj ? null : `${prefix}no jj`;
     }
 
     private getJjRevision(context: RenderContext): string | null {
@@ -57,6 +67,14 @@ export class JjRevisionWidget implements Widget {
             '-T',
             'change_id.shortest()'
         ], context);
+    }
+
+    getCustomKeybinds(): CustomKeybind[] {
+        return [getSymbolKeybind()];
+    }
+
+    renderEditor(props: WidgetEditorProps) {
+        return renderSymbolOverrideEditor(props, DEFAULT_SYMBOL);
     }
 
     supportsRawValue(): boolean { return true; }

--- a/src/widgets/__tests__/SymbolOverride.test.ts
+++ b/src/widgets/__tests__/SymbolOverride.test.ts
@@ -11,7 +11,11 @@ import type {
 } from '../../types/Widget';
 import { GitAheadBehindWidget } from '../GitAheadBehind';
 import { GitBranchWidget } from '../GitBranch';
+import { GitChangesWidget } from '../GitChanges';
+import { GitCleanStatusWidget } from '../GitCleanStatus';
 import { GitConflictsWidget } from '../GitConflicts';
+import { GitDeletionsWidget } from '../GitDeletions';
+import { GitInsertionsWidget } from '../GitInsertions';
 import { GitStagedWidget } from '../GitStaged';
 import { GitStatusWidget } from '../GitStatus';
 import { GitUnstagedWidget } from '../GitUnstaged';
@@ -19,6 +23,10 @@ import { GitUntrackedWidget } from '../GitUntracked';
 import { GitWorktreeWidget } from '../GitWorktree';
 import { GitWorktreeModeWidget } from '../GitWorktreeMode';
 import { JjBookmarksWidget } from '../JjBookmarks';
+import { JjChangesWidget } from '../JjChanges';
+import { JjDeletionsWidget } from '../JjDeletions';
+import { JjInsertionsWidget } from '../JjInsertions';
+import { JjRevisionWidget } from '../JjRevision';
 import { JjWorkspaceWidget } from '../JjWorkspace';
 import {
     formatSymbolPrefix,
@@ -45,6 +53,7 @@ const cases: SymbolCase[] = [
     { name: 'GitStagedWidget', itemType: 'git-staged', widget: new GitStagedWidget(), defaultPreview: '+', overriddenPreview: '★', suppressedPreview: '' },
     { name: 'GitUnstagedWidget', itemType: 'git-unstaged', widget: new GitUnstagedWidget(), defaultPreview: '*', overriddenPreview: '★', suppressedPreview: '' },
     { name: 'GitUntrackedWidget', itemType: 'git-untracked', widget: new GitUntrackedWidget(), defaultPreview: '?', overriddenPreview: '★', suppressedPreview: '' },
+    { name: 'JjRevisionWidget', itemType: 'jj-revision', widget: new JjRevisionWidget(), defaultPreview: ' kkmpptxz', overriddenPreview: '★ kkmpptxz', suppressedPreview: 'kkmpptxz' },
     { name: 'GitWorktreeModeWidget', itemType: 'worktree-mode', widget: new GitWorktreeModeWidget(), defaultPreview: '⎇', overriddenPreview: '★', suppressedPreview: null }
 ];
 
@@ -144,5 +153,46 @@ describe('symbol override helpers', () => {
 
         const suppressed = setSlotSymbol(makeItem('git-branch'), characterSlot, '');
         expect(suppressed.character).toBe('');
+    });
+});
+
+interface SlotCase {
+    name: string;
+    itemType: string;
+    widget: Widget;
+    defaultPreview: string;
+    overrides: Record<string, string>;
+    overriddenPreview: string;
+    clearedPreview: string;
+}
+
+const slotCases: SlotCase[] = [
+    { name: 'GitInsertionsWidget', itemType: 'git-insertions', widget: new GitInsertionsWidget(), defaultPreview: '+42', overrides: { symbolInsertions: '▲' }, overriddenPreview: '▲42', clearedPreview: '42' },
+    { name: 'GitDeletionsWidget', itemType: 'git-deletions', widget: new GitDeletionsWidget(), defaultPreview: '-10', overrides: { symbolDeletions: '▼' }, overriddenPreview: '▼10', clearedPreview: '10' },
+    { name: 'JjInsertionsWidget', itemType: 'jj-insertions', widget: new JjInsertionsWidget(), defaultPreview: '+42', overrides: { symbolInsertions: '▲' }, overriddenPreview: '▲42', clearedPreview: '42' },
+    { name: 'JjDeletionsWidget', itemType: 'jj-deletions', widget: new JjDeletionsWidget(), defaultPreview: '-10', overrides: { symbolDeletions: '▼' }, overriddenPreview: '▼10', clearedPreview: '10' },
+    { name: 'GitChangesWidget', itemType: 'git-changes', widget: new GitChangesWidget(), defaultPreview: '(+42,-10)', overrides: { symbolInsertions: '▲', symbolDeletions: '▼' }, overriddenPreview: '(▲42,▼10)', clearedPreview: '(42,10)' },
+    { name: 'JjChangesWidget', itemType: 'jj-changes', widget: new JjChangesWidget(), defaultPreview: '(+42,-10)', overrides: { symbolInsertions: '▲', symbolDeletions: '▼' }, overriddenPreview: '(▲42,▼10)', clearedPreview: '(42,10)' },
+    { name: 'GitCleanStatusWidget', itemType: 'git-clean-status', widget: new GitCleanStatusWidget(), defaultPreview: '✓', overrides: { symbolClean: '★' }, overriddenPreview: '★', clearedPreview: '' }
+];
+
+describe('named-slot symbol overrides', () => {
+    it.each(slotCases)('$name renders its default symbols', ({ widget, itemType, defaultPreview }) => {
+        expect(widget.render(makeItem(itemType), { isPreview: true }, DEFAULT_SETTINGS)).toBe(defaultPreview);
+    });
+
+    it.each(slotCases)('$name renders slot overrides', ({ widget, itemType, overrides, overriddenPreview }) => {
+        expect(widget.render({ id: itemType, type: itemType, metadata: overrides }, { isPreview: true }, DEFAULT_SETTINGS)).toBe(overriddenPreview);
+    });
+
+    it.each(slotCases)('$name drops the symbol on an empty override', ({ widget, itemType, overrides, clearedPreview }) => {
+        const cleared = Object.fromEntries(Object.keys(overrides).map(key => [key, '']));
+        expect(widget.render({ id: itemType, type: itemType, metadata: cleared }, { isPreview: true }, DEFAULT_SETTINGS)).toBe(clearedPreview);
+    });
+
+    it.each(slotCases)('$name exposes the shared glyph keybind and editor', ({ widget }) => {
+        const keys = (widget.getCustomKeybinds?.() ?? []).map(keybind => keybind.key);
+        expect(keys).toContain('g');
+        expect(typeof widget.renderEditor).toBe('function');
     });
 });


### PR DESCRIPTION
Five widgets expose custom glyphs through `SymbolSlot`. Eight hardcode theirs,
so a line can restyle Git Status but not Git Changes beside it. This closes that
gap.

| Widget | Slots added | Default |
| ------ | ----------- | ------- |
| Git Insertions, Jj Insertions | `symbolInsertions` | `+` |
| Git Deletions, Jj Deletions | `symbolDeletions` | `-` |
| Git Changes, Jj Changes | both | `+` `-` |
| Git Clean Status | `symbolClean`, `symbolDirty` | `✓` `✗` |
| Jj Revision | `character` | `` |

No workaround existed for any of them. The insertions, deletions and changes
widgets return `false` from `supportsRawValue`, so the sign was unconditional.
Git Clean Status has raw mode but emits `clean`/`dirty` as words. Jj Revision's
raw mode drops the revision prefix along with the glyph.

Jj Revision uses `character` and `formatSymbolPrefix` rather than a named slot,
matching Jj Bookmarks and Git Branch: one space-separated prefix. That path also
drops the trailing space when the override is empty, which a named slot would
have left behind.

Git Clean Status mirrors Git Conflicts, which already pairs a symbol with a
clean-state symbol.

Defaults are unchanged, so existing configs render identically.

Tests extend the two tables in `SymbolOverride.test.ts` rather than adding a
suite: Jj Revision joins the `character` cases, the other seven join a new
`slotCases` table covering default, override, empty override, and the `g`
keybind plus editor. Reverting Git Changes and Git Clean Status turns 6 red.

`bun run lint` clean, `bun test` 2223 pass.
