### PR TITLE
perf: keep the TUI off the status line render path

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "start": "bun run src/ccstatusline.ts",
-    "build": "rm -rf dist/* ; bun build src/ccstatusline.ts --target=node --outfile=dist/ccstatusline.js --target-version=14",
+    "build": "rm -rf dist/* ; bun build src/ccstatusline.ts --target=node --splitting --format=esm --outdir=dist --target-version=14",
     "postbuild": "bun run scripts/replace-version.ts",
     "example": "cat scripts/payload.example.json | bun start",
     "video:studio": "remotion studio remotion/index.ts",

--- a/scripts/replace-version.ts
+++ b/scripts/replace-version.ts
@@ -2,6 +2,7 @@
 
 import {
     readFileSync,
+    readdirSync,
     writeFileSync
 } from 'fs';
 import { join } from 'path';
@@ -15,14 +16,25 @@ interface PackageJson {
 const packageJson = JSON.parse(readFileSync('package.json', 'utf-8')) as PackageJson;
 const version = packageJson.version;
 
-// Read the bundled file
-const bundledFilePath = join('dist', 'ccstatusline.js');
-let bundledContent = readFileSync(bundledFilePath, 'utf-8');
+// The build emits the entry plus code-split chunks, and the placeholder can
+// land in any of them, so patch every emitted script rather than just the entry.
+let patched = 0;
+for (const file of readdirSync('dist')) {
+    if (!file.endsWith('.js')) {
+        continue;
+    }
+    const path = join('dist', file);
+    const content = readFileSync(path, 'utf-8');
+    if (!content.includes('__PACKAGE_VERSION__')) {
+        continue;
+    }
+    writeFileSync(path, content.replace(/__PACKAGE_VERSION__/g, version));
+    patched++;
+}
 
-// Replace the placeholder with the actual version
-bundledContent = bundledContent.replace(/__PACKAGE_VERSION__/g, version);
+if (patched === 0) {
+    console.error('✗ No __PACKAGE_VERSION__ placeholder found in dist/');
+    process.exit(1);
+}
 
-// Write back the modified content
-writeFileSync(bundledFilePath, bundledContent);
-
-console.log(`✓ Replaced version placeholder with ${version}`);
+console.log(`✓ Replaced version placeholder with ${version} in ${patched} file(s)`);

--- a/src/ccstatusline.ts
+++ b/src/ccstatusline.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import chalk from 'chalk';
 
-import { runTUI } from './tui';
 import type { SkillsMetrics } from './types';
 import type { RenderContext } from './types/RenderContext';
 import type { StatusJSON } from './types/StatusJSON';
@@ -351,6 +350,11 @@ async function main() {
             void updatemessage;
             await saveSettings(newSettings);
         }
+        // Imported lazily: the TUI pulls in ink/React/yoga-layout, which the
+        // status line render path never touches. Claude Code re-runs this
+        // binary every couple of seconds, so keeping that graph off the
+        // render path is worth the dynamic import here.
+        const { runTUI } = await import('./tui');
         runTUI();
     }
 }


### PR DESCRIPTION
## Problem

Claude Code re-runs the status line command every couple of seconds for as long as a session is open, so this binary's module load time is paid continuously rather than once at startup.

`src/ccstatusline.ts` imports `runTUI` statically:

```ts
import { runTUI } from './tui';
```

That pulls `ink`, React and `yoga-layout` into the render path even though rendering never touches any of them — they are only needed for the interactive config editor.

## What I tried first, and why it wasn't enough

Making the import dynamic on its own changes nothing measurable: `bun build --outfile` cannot code-split, so the whole graph still ends up in one file and still gets parsed on every render. I measured 255 ms vs 250 ms, i.e. noise.

The win only appears when the build actually splits. `--splitting --format=esm --outdir=dist` moves the TUI into its own chunk and shrinks the entry from **3.34 MB to 21 KB**.

## Result

M-series Mac, 20 runs per data point, a real Claude Code payload piped to stdin:

| | ms/render |
|---|---|
| before | 238, 237, 238 |
| after | 226, 222, 220 |

About **7%**. Modest, but it is paid on every render for the whole session, and the rendered output is byte-identical (`diff` on the ANSI output).

## Verification

- `bun run lint` (tsc + eslint) clean.
- Rendered output byte-identical before/after.
- Interactive TUI smoke-tested under a pty: same first frame, no module resolution errors.
- Built output runs under `node` as well as `bun`.

## The non-obvious part

`scripts/replace-version.ts` had to change too. With splitting, the `__PACKAGE_VERSION__` placeholder lands in a chunk rather than in `dist/ccstatusline.js`, so patching only the entry would have silently shipped an unreplaced placeholder. It now patches every emitted script and exits non-zero if it finds none, so this cannot regress quietly.

Packaging is unaffected: `files` is already `dist/`, and `bin`/`main`/`exports` keep pointing at `dist/ccstatusline.js`.

https://claude.ai/code/session_01Jy7HKv8er6ZiodbjFeped2
